### PR TITLE
Update ember-cli-ic-ajax

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "ember-cli-autoprefixer": "0.4.1",
     "ember-cli-dependency-checker": "^1.0.0",
     "ember-cli-htmlbars": "^0.7.6",
-    "ember-cli-ic-ajax": "0.1.1",
+    "ember-cli-ic-ajax": "^0.2.4",
     "ember-cli-inject-live-reload": "^1.3.1",
     "ember-cli-qunit": "0.3.13",
     "ember-cli-sass": "^4.0.0",


### PR DESCRIPTION
I ran npm start and got this error:
> ENOENT: no such file or directory, lstat 'node_modules/ember-cli-ic-ajax/node_modules'
Error: ENOENT: no such file or directory, lstat 'node_modules/ember-cli-ic-ajax/node_modules'
    at Error (native)
    at Object.fs.lstatSync (fs.js:888:18)
    at symlink (/netlify-cms/node_modules/symlink-or-copy/index.js:60:26)
    at symlinkOrCopySync (/netlify-cms/node_modules/symlink-or-copy/index.js:55:5)
    at /netlify-cms/node_modules/broccoli-plugin/read_compat.js:58:9
    at lib$rsvp$$internal$$tryCatch (/netlify-cms/node_modules/rsvp/dist/rsvp.js:493:16)
    at lib$rsvp$$internal$$invokeCallback (/netlify-cms/node_modules/rsvp/dist/rsvp.js:505:17)
    at lib$rsvp$$internal$$publish (/netlify-cms/node_modules/rsvp/dist/rsvp.js:476:11)
    at lib$rsvp$asap$$flush (/netlify-cms/node_modules/rsvp/dist/rsvp.js:1198:9)
    at nextTickCallbackWith0Args (node.js:433:9)

This is fixed by updating ember-cli-ic-ajax.
See https://github.com/rwjblue/ember-cli-ic-ajax/issues/6