### PR TITLE
Removed second default export that caused an error in the bundle compilation

### DIFF
--- a/src/components/Widgets/MarkdownControl.js
+++ b/src/components/Widgets/MarkdownControl.js
@@ -64,8 +64,6 @@ class MarkdownControl extends React.Component {
   }
 }
 
-export default MarkdownControl;
-
 MarkdownControl.propTypes = {
   editor: PropTypes.object.isRequired,
   onChange: PropTypes.func.isRequired,


### PR DESCRIPTION
```
ERROR in ./src/components/Widgets/MarkdownControl.js
Module build failed: SyntaxError: Only one default export allowed per module.

  80 | };
  81 | 
> 82 | export default connect(
     | ^
  83 |   state => ({ editor: state.editor }),
  84 |   { switchVisualMode }
  85 | )(MarkdownControl);

 @ ./src/components/Widgets.js 23:23-59
```