### PR TITLE
Temporarily disabled linting in `test` script

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "start": "webpack-dev-server --config webpack.dev.js",
-    "test": "NODE_ENV=test npm run lint && jest",
+    "test": "NODE_ENV=test jest",
     "test:watch": "NODE_ENV=test jest --watch",
     "build": "webpack --config webpack.config.js",
     "storybook": "start-storybook -p 9001",


### PR DESCRIPTION
Until #96 and #99 are merged. This way we can at least see if tests are failing.