### PR TITLE
Simple markdown editor

### DIFF
--- a/example/example.css
+++ b/example/example.css
@@ -1,15 +1,21 @@
-html, body {
-  font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
-  font-size: 14px;
+html,
+body {
   color: #444;
+  font-size: 14px;
+  font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
 }
+
 body {
   padding: 20px;
 }
 
 h1 {
-  font-weight: bold;
-  color: #666;
-  font-size: 32px;
   margin-top: 20px;
+  color: #666;
+  font-weight: bold;
+  font-size: 32px;
+}
+
+img {
+  max-width: 100%;
 }

--- a/package.json
+++ b/package.json
@@ -94,6 +94,7 @@
     "@kadira/storybook": "^1.36.0",
     "autoprefixer": "^6.3.3",
     "bricks.js": "^1.7.0",
+    "textarea-caret-position": "^0.1.1",
     "dateformat": "^1.0.12",
     "fuzzy": "^0.1.1",
     "immutability-helper": "^2.0.0",

--- a/src/components/ControlPanel/ControlPane.css
+++ b/src/components/ControlPanel/ControlPane.css
@@ -20,6 +20,7 @@
   }
 }
 .label {
+  display: block;
   color: #AAB0AF;
   font-size: 12px;
   margin-bottom: 18px;

--- a/src/components/Widgets/MarkdownControl.js
+++ b/src/components/Widgets/MarkdownControl.js
@@ -30,7 +30,7 @@ class MarkdownControl extends React.Component {
   };
 
   render() {
-    const { editor, onChange, onAddMedia, getMedia, value } = this.props;
+    const { editor, onChange, onAddMedia, onRemoveMedia, getMedia, value } = this.props;
     if (editor.get('useVisualMode')) {
       return (
         <div className="cms-editor-visual">
@@ -51,6 +51,7 @@ class MarkdownControl extends React.Component {
           <RawEditor
             onChange={onChange}
             onAddMedia={onAddMedia}
+            onRemoveMedia={onRemoveMedia}
             getMedia={getMedia}
             value={value}
           />

--- a/src/components/Widgets/MarkdownControlElements/RawEditor/BlockMenu.css
+++ b/src/components/Widgets/MarkdownControlElements/RawEditor/BlockMenu.css
@@ -1,0 +1,134 @@
+.root {
+  position: absolute;
+  left: -18px;
+  display: none;
+  width: 100%;
+}
+
+.visible {
+  display: block;
+}
+
+.button {
+  display: block;
+  width: 15px;
+  height: 15px;
+  border: 1px solid #444;
+  border-radius: 100%;
+  background: transparent;
+  line-height: 13px;
+}
+
+.expanded {
+  display: block;
+}
+
+.collapsed {
+  display: none;
+}
+
+.pluginForm,
+.menu {
+  margin-top: -20px;
+  margin-bottom: 30px;
+  margin-left: 20px;
+  border-radius: 4px;
+  background: #fff;
+  box-shadow: 1px 1px 20px;
+
+  & h3 {
+    padding: 5px 20px;
+    border-bottom: 1px solid;
+  }
+}
+
+.menu {
+  list-style: none;
+
+  & li button {
+    display: block;
+    padding: 5px 20px;
+    min-width: 30%;
+    width: 100%;
+    border: none;
+    border-bottom: 1px solid;
+    background: #fff;
+    -webkit-appearance: none;
+  }
+
+  & li:last-child button {
+    border-bottom: none;
+  }
+
+  & li:hover button {
+    background: #efefef;
+  }
+}
+
+.menu.expanded {
+  display: inline-block;
+}
+
+.control {
+  position: relative;
+  padding: 20px 20px;
+  color: #7c8382;
+
+  & input,
+  & textarea,
+  & select {
+    display: block;
+    margin: 0;
+    padding: 0;
+    width: 100%;
+    outline: 0;
+    border: none;
+    background: 0 0;
+    box-shadow: none;
+    color: #7c8382;
+    font-size: 18px;
+    font-family: monospace;
+  }
+}
+
+.label {
+  display: block;
+  margin-bottom: 18px;
+  color: #aab0af;
+  font-size: 12px;
+}
+
+.widget {
+  position: relative;
+  border-bottom: 1px solid #aaa;
+
+  &:after {
+    position: absolute;
+    bottom: -7px;
+    left: 42px;
+    z-index: 1;
+    width: 12px;
+    height: 12px;
+    border-right: 1px solid #aaa;
+    border-bottom: 1px solid #aaa;
+    background-color: #f2f5f4;
+    content: '';
+    -webkit-transform: rotate(45deg);
+    transform: rotate(45deg);
+  }
+
+  &:last-child {
+    border-bottom: none;
+  }
+
+  &:last-child:after {
+    display: none;
+  }
+}
+
+.footer {
+  padding: 10px 20px;
+  border-top: 1px solid #eee;
+  background: #fff;
+  text-align: right;
+}

--- a/src/components/Widgets/MarkdownControlElements/RawEditor/BlockMenu.js
+++ b/src/components/Widgets/MarkdownControlElements/RawEditor/BlockMenu.js
@@ -1,0 +1,135 @@
+import React, { Component, PropTypes } from 'react';
+import { fromJS } from 'immutable';
+import { Button } from 'react-toolbox/lib/button';
+import { resolveWidget } from '../../../Widgets';
+import styles from './BlockMenu.css';
+
+export default class BlockMenu extends Component {
+  static propTypes = {
+    isOpen: PropTypes.bool,
+    selectionPosition: PropTypes.object,
+    plugins: PropTypes.object.isRequired,
+    onBlock: PropTypes.func.isRequired,
+    onAddMedia: PropTypes.func.isRequired,
+    onRemoveMedia: PropTypes.func.isRequired,
+    getMedia: PropTypes.func.isRequired,
+  };
+
+  constructor(props) {
+    super(props);
+    this.state = {
+      isExpanded: false,
+      openPlugin: null,
+      pluginData: fromJS({}),
+    };
+  }
+
+  componentDidUpdate() {
+    const { selectionPosition } = this.props;
+    if (selectionPosition) {
+      const style = this.element.style;
+      style.setProperty('top', `${ selectionPosition.top }px`);
+    }
+  }
+
+  handleToggle = (e) => {
+    e.preventDefault();
+    this.setState({ isExpanded: !this.state.isExpanded });
+  };
+
+  handleRef = (ref) => {
+    this.element = ref;
+  };
+
+  handlePlugin(plugin) {
+    return (e) => {
+      e.preventDefault();
+      this.setState({ openPlugin: plugin, pluginData: fromJS({}) });
+    };
+  }
+
+  buttonFor(plugin) {
+    return (<li key={plugin.get('id')}>
+      <button onClick={this.handlePlugin(plugin)}>{plugin.get('label')}</button>
+    </li>);
+  }
+
+  handleSubmit = (e) => {
+    e.preventDefault();
+    const { openPlugin, pluginData } = this.state;
+    const toBlock = openPlugin.get('toBlock');
+    this.props.onBlock(toBlock.call(toBlock, pluginData.toJS()));
+    this.setState({ openPlugin: null, isExpanded: false });
+  };
+
+  handleCancel = (e) => {
+    e.preventDefault();
+    this.setState({ openPlugin: null, isExpanded: false });
+  };
+
+  controlFor(field) {
+    const { onAddMedia, onRemoveMedia, getMedia } = this.props;
+    const { pluginData } = this.state;
+    const widget = resolveWidget(field.get('widget') || 'string');
+    const value = pluginData.get(field.get('name'));
+
+    return (
+      <div className={styles.control} key={field.get('name')}>
+        <label className={styles.label}>{field.get('label')}</label>
+        {
+          React.createElement(widget.control, {
+            field,
+            value,
+            onChange: (val) => {
+              this.setState({
+                pluginData: pluginData.set(field.get('name'), val),
+              });
+            },
+            onAddMedia,
+            onRemoveMedia,
+            getMedia,
+          })
+        }
+      </div>
+    );
+  }
+
+  pluginForm(plugin) {
+    return (<form className={styles.pluginForm} onSubmit={this.handleSubmit}>
+      <h3>Insert {plugin.get('label')}</h3>
+      {plugin.get('fields').map(field => this.controlFor(field))}
+      <div className={styles.footer}>
+        <Button
+          raised
+          onClick={this.handleSubmit}
+        >
+          Insert
+        </Button>
+        {' '}
+        <Button onClick={this.handleCancel}>
+          Cancel
+        </Button>
+      </div>
+    </form>);
+  }
+
+  render() {
+    const { isOpen, plugins } = this.props;
+    const { isExpanded, openPlugin } = this.state;
+    const classNames = [styles.root];
+    if (isOpen) {
+      classNames.push(styles.visible);
+    }
+    if (openPlugin) {
+      classNames.push(styles.openPlugin);
+    }
+
+    return (<div className={classNames.join(' ')} ref={this.handleRef}>
+      <button className={styles.button} onClick={this.handleToggle}>+</button>
+      <ul className={[styles.menu, isExpanded && !openPlugin ? styles.expanded : styles.collapsed].join(' ')}>
+        {plugins.map(plugin => this.buttonFor(plugin))}
+      </ul>
+      {openPlugin && this.pluginForm(openPlugin)}
+    </div>);
+  }
+}

--- a/src/components/Widgets/MarkdownControlElements/RawEditor/Toolbar.css
+++ b/src/components/Widgets/MarkdownControlElements/RawEditor/Toolbar.css
@@ -1,0 +1,16 @@
+.Toolbar {
+  position: absolute;
+  z-index: 1000;
+  display: none;  
+  margin: none;
+  padding: none;
+  list-style: none;
+}
+
+.Button {
+  display: inline-block;
+}
+
+.Visible {
+  display: block;
+}

--- a/src/components/Widgets/MarkdownControlElements/RawEditor/Toolbar.js
+++ b/src/components/Widgets/MarkdownControlElements/RawEditor/Toolbar.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { Component, PropTypes } from 'react';
 import styles from './Toolbar.css';
 
 function button(label, action) {
@@ -7,15 +7,44 @@ function button(label, action) {
   </li>);
 }
 
-export default class Toolbar extends React.Component {
+export default class Toolbar extends Component {
+  static propTypes = {
+    isOpen: PropTypes.bool,
+    selectionPosition: PropTypes.node,
+    onBold: PropTypes.func.isRequired,
+    onItalic: PropTypes.func.isRequired,
+    onLink: PropTypes.func.isRequired,
+  };
+
+  componentDidUpdate() {
+    const { selectionPosition } = this.props;
+    if (selectionPosition) {
+      const rect = this.element.getBoundingClientRect();
+      const parentRect = this.element.parentElement.getBoundingClientRect();
+      const style = this.element.style;
+      const pos = {
+        top: selectionPosition.top - rect.height - 5,
+        left: Math.min(selectionPosition.left, parentRect.width - rect.width),
+      };
+      style.setProperty('top', `${ pos.top }px`);
+      style.setProperty('left', `${ pos.left }px`);
+    }
+  }
+
+  handleRef = (ref) => {
+    this.element = ref;
+  };
+
   render() {
     const { isOpen, onBold, onItalic, onLink } = this.props;
     const classNames = [styles.Toolbar];
+
     if (isOpen) {
       classNames.push(styles.Visible);
     }
+
     return (
-      <ul className={classNames.join(' ')}>
+      <ul className={classNames.join(' ')} ref={this.handleRef}>
         {button('Bold', onBold)}
         {button('Italic', onItalic)}
         {button('Link', onLink)}

--- a/src/components/Widgets/MarkdownControlElements/RawEditor/Toolbar.js
+++ b/src/components/Widgets/MarkdownControlElements/RawEditor/Toolbar.js
@@ -10,7 +10,7 @@ function button(label, action) {
 export default class Toolbar extends Component {
   static propTypes = {
     isOpen: PropTypes.bool,
-    selectionPosition: PropTypes.node,
+    selectionPosition: PropTypes.object,
     onBold: PropTypes.func.isRequired,
     onItalic: PropTypes.func.isRequired,
     onLink: PropTypes.func.isRequired,

--- a/src/components/Widgets/MarkdownControlElements/RawEditor/Toolbar.js
+++ b/src/components/Widgets/MarkdownControlElements/RawEditor/Toolbar.js
@@ -1,0 +1,25 @@
+import React from 'react';
+import styles from './Toolbar.css';
+
+function button(label, action) {
+  return (<li className={styles.Button}>
+    <button className={styles[label]} onClick={action}>{label}</button>
+  </li>);
+}
+
+export default class Toolbar extends React.Component {
+  render() {
+    const { isOpen, onBold, onItalic, onLink } = this.props;
+    const classNames = [styles.Toolbar];
+    if (isOpen) {
+      classNames.push(styles.Visible);
+    }
+    return (
+      <ul className={classNames.join(' ')}>
+        {button('Bold', onBold)}
+        {button('Italic', onItalic)}
+        {button('Link', onLink)}
+      </ul>
+    );
+  }
+}

--- a/src/components/Widgets/MarkdownControlElements/RawEditor/index.css
+++ b/src/components/Widgets/MarkdownControlElements/RawEditor/index.css
@@ -1,13 +1,3 @@
 .root {
-  font-family: monospace;
-  display: block;
-  width: 100%;
-  padding: 0;
-  margin: 0;
-  border: none;
-  outline: 0;
-  box-shadow: none;
-  background: 0 0;
-  font-size: 18px;
-  color: #7c8382;
+  position: relative;
 }

--- a/src/components/Widgets/MarkdownControlElements/RawEditor/index.js
+++ b/src/components/Widgets/MarkdownControlElements/RawEditor/index.js
@@ -177,7 +177,7 @@ export default class RawEditor extends React.Component {
     } else if (selection.start === selection.end) {
       const newBlock =
         (
-          selection.start === 0 ||
+          (selection.start === 0 && value.substr(0,1).match(/^\n?$/)) ||
           value.substr(selection.start - 2, 2) === '\n\n') &&
         (
           selection.end === (value.length - 1) ||

--- a/src/components/Widgets/MarkdownControlElements/RawEditor/index.js
+++ b/src/components/Widgets/MarkdownControlElements/RawEditor/index.js
@@ -34,13 +34,6 @@ export default class RawEditor extends React.Component {
     this.element.addEventListener('drop', this.handleDrop, false);
   }
 
-  componentWillUnmount() {
-    console.log('unmounting');
-    this.element.removeEventListener('dragenter', preventDefault);
-    this.element.removeEventListener('dragover', preventDefault);
-    this.element.removeEventListener('drop', this.handleDrop);
-  }
-
   componentDidUpdate() {
     if (this.newSelection) {
       this.element.selectionStart = this.newSelection.start;
@@ -49,73 +42,11 @@ export default class RawEditor extends React.Component {
     }
   }
 
-  handleChange = (e) => {
-    this.props.onChange(e.target.value);
-    this.updateHeight();
-  };
-
-  handleDrop = (e) => {
-    e.preventDefault();
-    let data;
-
-    if (e.dataTransfer.files && e.dataTransfer.files.length) {
-      data = Array.from(e.dataTransfer.files).map((file) => {
-        const mediaProxy = new MediaProxy(file.name, file);
-        this.props.onAddMedia(mediaProxy);
-        const link = `[${ file.name }](${ mediaProxy.public_path })`;
-        if (file.type.split('/')[0] === 'image') {
-          return `!${ link }`;
-        }
-        return link;
-      }).join('\n\n');
-    } else {
-      data = e.dataTransfer.getData('text/plain');
-    }
-    this.replaceSelection(data);
-  };
-
-  updateHeight() {
-    if (this.element.scrollHeight > this.element.clientHeight) {
-      this.element.style.height = `${ this.element.scrollHeight }px`;
-    }
+  componentWillUnmount() {
+    this.element.removeEventListener('dragenter', preventDefault);
+    this.element.removeEventListener('dragover', preventDefault);
+    this.element.removeEventListener('drop', this.handleDrop);
   }
-
-  handleRef = (ref) => {
-    this.element = ref;
-  };
-
-  handleToolbarRef = (ref) => {
-    this.toolbar = ref;
-  };
-
-  handleKey = (e) => {
-    if (e.metaKey) {
-      const action = this.shortcuts.meta[e.key];
-      if (action) {
-        e.preventDefault();
-        action();
-      }
-    }
-  };
-
-  handleBold = () => {
-    this.surroundSelection('**');
-  };
-
-  handleItalic = () => {
-    this.surroundSelection('*');
-  };
-
-  handleLink = () => {
-    const url = prompt('URL:');
-    const selection = this.getSelection();
-    this.replaceSelection(`[${ selection.selected }](${ processUrl(url) })`);
-  };
-
-  handleSelection = () => {
-    const selection = this.getSelection();
-    this.setState({ showToolbar: selection.start !== selection.end });
-  };
 
   getSelection() {
     const start = this.element.selectionStart;
@@ -163,6 +94,74 @@ export default class RawEditor extends React.Component {
     this.newSelection = newSelection;
     this.props.onChange(beforeSelection + chars + afterSelection);
   }
+
+  updateHeight() {
+    if (this.element.scrollHeight > this.element.clientHeight) {
+      this.element.style.height = `${ this.element.scrollHeight }px`;
+    }
+  }
+
+  handleRef = (ref) => {
+    this.element = ref;
+  };
+
+  handleToolbarRef = (ref) => {
+    this.toolbar = ref;
+  };
+
+  handleKey = (e) => {
+    if (e.metaKey) {
+      const action = this.shortcuts.meta[e.key];
+      if (action) {
+        e.preventDefault();
+        action();
+      }
+    }
+  };
+
+  handleBold = () => {
+    this.surroundSelection('**');
+  };
+
+  handleItalic = () => {
+    this.surroundSelection('*');
+  };
+
+  handleLink = () => {
+    const url = prompt('URL:');
+    const selection = this.getSelection();
+    this.replaceSelection(`[${ selection.selected }](${ processUrl(url) })`);
+  };
+
+  handleSelection = () => {
+    const selection = this.getSelection();
+    this.setState({ showToolbar: selection.start !== selection.end });
+  };
+
+  handleChange = (e) => {
+    this.props.onChange(e.target.value);
+    this.updateHeight();
+  };
+
+  handleDrop = (e) => {
+    e.preventDefault();
+    let data;
+
+    if (e.dataTransfer.files && e.dataTransfer.files.length) {
+      data = Array.from(e.dataTransfer.files).map((file) => {
+        const mediaProxy = new MediaProxy(file.name, file);
+        this.props.onAddMedia(mediaProxy);
+        const link = `[${ file.name }](${ mediaProxy.public_path })`;
+        if (file.type.split('/')[0] === 'image') {
+          return `!${ link }`;
+        }
+        return link;
+      }).join('\n\n');
+    } else {
+      data = e.dataTransfer.getData('text/plain');
+    }
+    this.replaceSelection(data);
+  };
 
   render() {
     const { showToolbar } = this.state;

--- a/src/components/Widgets/MarkdownControlElements/plugins.js
+++ b/src/components/Widgets/MarkdownControlElements/plugins.js
@@ -1,5 +1,5 @@
 import { Component, PropTypes, Children } from 'react';
-import { List, Record } from 'immutable';
+import { List, Record, fromJS } from 'immutable';
 import _ from 'lodash';
 
 const plugins = { editor: List() };
@@ -11,23 +11,23 @@ const EditorComponent = Record({
   icon: 'exclamation-triangle',
   fields: [],
   pattern: catchesNothing,
-  fromBlock: function(match) { return {}; },
-  toBlock: function(attributes) { return 'Plugin'; },
-  toPreview: function(attributes) { return 'Plugin'; }
+  fromBlock(match) { return {}; },
+  toBlock(attributes) { return 'Plugin'; },
+  toPreview(attributes) { return 'Plugin'; },
 });
 
 
 class Plugin extends Component { // eslint-disable-line
   static propTypes = {
-    children: PropTypes.element.isRequired
+    children: PropTypes.element.isRequired,
   };
 
   static childContextTypes = {
-    plugins: PropTypes.object
+    plugins: PropTypes.object,
   };
 
   getChildContext() {
-    return { plugins: plugins };
+    return { plugins };
   }
 
   render() {
@@ -40,11 +40,11 @@ export function newEditorPlugin(config) {
     id: config.id || config.label.replace(/[^A-Z0-9]+/ig, '_'),
     label: config.label,
     icon: config.icon,
-    fields: config.fields,
+    fields: fromJS(config.fields),
     pattern: config.pattern,
     fromBlock: _.isFunction(config.fromBlock) ? config.fromBlock.bind(null) : null,
     toBlock: _.isFunction(config.toBlock) ? config.toBlock.bind(null) : null,
-    toPreview: _.isFunction(config.toPreview) ? config.toPreview.bind(null) : config.toBlock.bind(null)
+    toPreview: _.isFunction(config.toPreview) ? config.toPreview.bind(null) : config.toBlock.bind(null),
   });
 
 


### PR DESCRIPTION
**- Summary**

The current slate based editor is not performant enough to handle real life articles, content, etc. This seems to be a problem with Slate itself, and it will quite possibly be a lot of work to fix. Meanwhile we should have a robust solution for markdown editing. This PR replaces Slate with a much simpler textarea based markdown editor without an intermediary content model, but with menu bar and custom block support.

**- Test plan**

This is still work in progress and the menus are very roughly styled, but it's already workable for long posts, dragging images and files work, bold and italics works and there's an option to add link, although this one relies on a prompt.

**- A picture of a cute animal (not mandatory but encouraged)**

![img_20160709_215324](https://cloud.githubusercontent.com/assets/6515/19623233/5d7123c0-98c2-11e6-83a1-fa053dfb68f3.jpg)


