### PR TITLE
Use proper loaders for external module's CSS

### DIFF
--- a/webpack.base.js
+++ b/webpack.base.js
@@ -7,25 +7,37 @@ module.exports = {
   module: {
     loaders: [
       {
+        loader: 'babel',
+        test: /\.js?$/,
+        exclude: /node_modules/,
+      },
+      {
+        /* CSS loader for npm modules that are shipped with CSS.
+           List all of theme in the array
+        */
+        test: /\.css$/,
+        include: [/redux-notifications/],
+        loader: ExtractTextPlugin.extract('style', 'css'),
+      },
+      {
+        /* React-toolbox still relies on SCSS and css-modules */
+        test: /\.scss$/,
+        include: [/react-toolbox/],
+        loader: ExtractTextPlugin.extract('style', 'css?modules!sass'),
+      },
+      {
+        /* We use CSS-modules and PostCSS for CMS styles */
+        test: /\.css$/,
+        exclude: /node_modules/,
+        loader: ExtractTextPlugin.extract('style', 'css?modules&importLoaders=1&&localIdentName=cms__[name]__[local]!postcss'),
+      },
+      {
         test: /\.(png|eot|woff|woff2|ttf|svg|gif)(\?v=\d+\.\d+\.\d+)?$/,
         loader: 'url-loader?limit=10000',
       },
       {
         test: /\.json$/,
         loader: 'json-loader',
-      },
-      {
-        test: /\.scss$/,
-        loader: ExtractTextPlugin.extract('style', 'css?modules!sass'),
-      },
-      {
-        test: /\.css$/,
-        loader: ExtractTextPlugin.extract('style', 'css?modules&importLoaders=1&&localIdentName=cms__[name]__[local]!postcss'),
-      },
-      {
-        loader: 'babel',
-        test: /\.js?$/,
-        exclude: /node_modules/,
       },
     ],
   },


### PR DESCRIPTION
- react-toolbox requires its own setup with sass-loader for now
- redux-notifications doen's need to use css-modules
- exclude `node_modules` from our own CSS pipeline

Realted to bcca98b1951d03e0850b353e9c16fd8b1db2291f