### PR TITLE
Add a script for auto configurating a collection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 dist/
+bin/
 node_modules/
 npm-debug.log
 .DS_Store

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "test": "jest",
     "test:watch": "jest --watch",
     "build": "NODE_ENV=production webpack --config webpack.prod.js",
+    "build:scripts": "NODE_ENV=production webpack --config webpack.cli.js",
     "prepublish": "npm run build",
     "storybook": "start-storybook -p 9001",
     "storybook-build": "build-storybook -o dist",
@@ -91,7 +92,10 @@
   "dependencies": {
     "@kadira/storybook": "^1.36.0",
     "autoprefixer": "^6.3.3",
+    "babel": "^6.5.2",
+    "babel-cli": "^6.18.0",
     "dateformat": "^1.0.12",
+    "deep-equal": "^1.0.1",
     "fuzzy": "^0.1.1",
     "immutability-helper": "^2.0.0",
     "immutable": "^3.7.6",

--- a/scripts/autoconfigure.collection.js
+++ b/scripts/autoconfigure.collection.js
@@ -1,0 +1,150 @@
+import fs from "fs";
+import path from "path";
+import process from "process";
+import yaml from 'js-yaml';
+import deepEqual from 'deep-equal';
+import { formatByExtension } from "../src/formats/formats";
+
+const looksLikeMarkdown = /(\[.+\]\(.+\)|\n?[#]+ [a-z0-9])/; // eslint-disable-line
+const looksLikeAnImage = /^[^ ]+\.(png|jpg|svg|gif|jpeg)/;
+
+function capitalize(name) {
+  return name.substr(0, 1).toUpperCase() + name.substr(1);
+}
+
+function inferWidget(name, value) {
+  if (value == null) {
+    return { widget: 'string' };
+  }
+  if (value instanceof Date) {
+    return { widget: value.toJSON().match(/T00:00:00\.000Z$/) ? 'date' : 'datetime' };
+  }
+  if (value instanceof Array) {
+    if (typeof value[0] === 'string') {
+      return { widget: 'list' };
+    }
+    return { widget: 'list', fields: inferFields(value) };
+  }
+  if (typeof value === 'object') {
+    return { widget: 'object', fields: inferFields([value]) };
+  }
+  if (value === false || value === true) {
+    return { widget: 'checkbox' };
+  }
+  if (typeof value === 'number') {
+    return { widget: 'number' };
+  }
+  if (name === 'body' || value.match(looksLikeMarkdown)) {
+    return { widget: 'markdown' };
+  }
+  if (value.match(/\n/)) {
+    return { widget: 'text' };
+  }
+  if (value.match(looksLikeAnImage)) {
+    return { widget: 'image' };
+  }
+  return { widget: 'string' };
+}
+
+function inferField(name, value) {
+  return Object.assign({
+    label: capitalize(name.replace(/_-/g, ' ')),
+    name,
+  }, inferWidget(name, value));
+}
+
+function inferFields(entries) {
+  const fields = {};
+  entries.forEach((entry) => {
+    if (entry == null) { return; }
+    Object.keys(entry).forEach((fieldName) => {
+      const field = inferField(fieldName, entry[fieldName]);
+      if (fields[fieldName]) {
+        fields[fieldName] = combineFields(fields[fieldName], field);
+      } else {
+        fields[fieldName] = field;
+      }
+    });
+  });
+  return Object.keys(fields).map(key => fields[key]);
+}
+
+const widgetRank = {
+  markdown: 1,
+  text: 2,
+  string: 3,
+  image: 4,
+  datetime: 4,
+  date: 5,
+  number: 5,
+  object: 7,
+  list: 7,
+};
+
+function compareWidget(a, b) {
+  return widgetRank[a] - widgetRank[b];
+}
+
+function combineFields(a, b) {
+  if (b == null && a) {
+    return a;
+  }
+  if (a == null && b) {
+    return b;
+  }
+  if (deepEqual(a, b)) {
+    return a;
+  }
+  if (a.widget === b.widget) {
+    if (a.fields && b.fields) {
+      const newFields = {};
+      a.fields.forEach((field) => {
+        newFields[field.name] = combineFields(field, b.fields.find(f => f.name === field.name));
+      });
+      b.fields.forEach((field) => {
+        if (!newFields[field.name]) {
+          newFields[field.name] = field;
+        }
+      });
+      return Object.assign({}, a, { fields: Object.keys(newFields).map(k => newFields[k]) });
+    }
+    return a;
+  }
+  return [a, b].sort((fieldA, fieldB) => compareWidget(fieldB.widget, fieldA.widget))[0];
+}
+
+if (process.argv.length !== 3) {
+  console.log("Usage: autoconfigure.collections.js <path-to-my-folder>");
+  process.exit(1);
+}
+
+const folder = process.argv[2].replace(/\/$/, '');
+const files = fs.readdirSync(folder);
+const extensions = {};
+
+files.forEach((file) => {
+  const ext = file.split(".").pop();
+  if (ext) {
+    extensions[ext] = extensions[ext] || 0;
+    extensions[ext] += 1;
+  }
+});
+
+const name = folder.split('/').filter(s => s).pop();
+const extension = Object.keys(extensions).sort((a, b) => extensions[b] - extensions[a])[0];
+const format = formatByExtension(extension);
+const entries = files.filter(name => name.split(".").pop() === extension).slice(0, 100).map(file => (
+  format.fromFile(fs.readFileSync(path.join(folder, file), { encoding: 'utf8' }))
+));
+const fields = inferFields(entries);
+
+
+const collection = {
+  label: capitalize(name),
+  name,
+  folder,
+  extension,
+  fields,
+};
+
+console.log(yaml.safeDump([collection], { flowLevel: 3 }));

--- a/src/formats/formats.js
+++ b/src/formats/formats.js
@@ -12,7 +12,7 @@ function formatByType(type) {
   return YamlFrontmatterFormatter;
 }
 
-function formatByExtension(extension) {
+export function formatByExtension(extension) {
   return {
     yml: yamlFormatter,
     json: jsonFormatter,

--- a/yarn.lock
+++ b/yarn.lock
@@ -334,6 +334,31 @@ aws4@^1.2.1:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.5.0.tgz#0a29ffb79c31c9e712eeb087e8e7a64b4a56d755"
 
+babel:
+  version "6.5.2"
+  resolved "https://registry.yarnpkg.com/babel/-/babel-6.5.2.tgz#59140607438270920047ff56f02b2d8630c2d129"
+
+babel-cli:
+  version "6.18.0"
+  resolved "https://registry.yarnpkg.com/babel-cli/-/babel-cli-6.18.0.tgz#92117f341add9dead90f6fa7d0a97c0cc08ec186"
+  dependencies:
+    babel-core "^6.18.0"
+    babel-polyfill "^6.16.0"
+    babel-register "^6.18.0"
+    babel-runtime "^6.9.0"
+    commander "^2.8.1"
+    convert-source-map "^1.1.0"
+    fs-readdir-recursive "^1.0.0"
+    glob "^5.0.5"
+    lodash "^4.2.0"
+    output-file-sync "^1.1.0"
+    path-is-absolute "^1.0.0"
+    slash "^1.0.0"
+    source-map "^0.5.0"
+    v8flags "^2.0.10"
+  optionalDependencies:
+    chokidar "^1.0.0"
+
 babel-code-frame@^6.16.0, babel-code-frame@^6.20.0:
   version "6.20.0"
   resolved "https://registry.yarnpkg.com/babel-code-frame/-/babel-code-frame-6.20.0.tgz#b968f839090f9a8bc6d41938fb96cb84f7387b26"
@@ -962,7 +987,7 @@ babel-plugin-transform-system-register@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-system-register/-/babel-plugin-transform-system-register-0.0.1.tgz#9dff40390c2763ac518f0b2ad7c5ea4f65a5be25"
 
-babel-polyfill@^6.9.1:
+babel-polyfill@^6.16.0, babel-polyfill@^6.9.1:
   version "6.20.0"
   resolved "https://registry.yarnpkg.com/babel-polyfill/-/babel-polyfill-6.20.0.tgz#de4a371006139e20990aac0be367d398331204e7"
   dependencies:
@@ -1648,7 +1673,7 @@ combined-stream@^1.0.5, combined-stream@~1.0.5:
   dependencies:
     delayed-stream "~1.0.0"
 
-commander@^2.9.0, commander@2.9.x:
+commander@^2.8.1, commander@^2.9.0, commander@2.9.x:
   version "2.9.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.9.0.tgz#9c99094176e12240cb22d6c5146098400fe0f7d4"
   dependencies:
@@ -2087,7 +2112,7 @@ decamelize@^1.0.0, decamelize@^1.1.1, decamelize@^1.1.2:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
 
-deep-equal@^1.0.0, deep-equal@^1.0.1, deep-equal@~1.0.1:
+deep-equal, deep-equal@^1.0.0, deep-equal@^1.0.1, deep-equal@~1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/deep-equal/-/deep-equal-1.0.1.tgz#f5d260292b660e084eff4cdbc9f08ad3247448b5"
 
@@ -3131,6 +3156,10 @@ fs-exists-sync@^0.1.0:
   version "0.1.0"
   resolved "http://registry.npmjs.org/fs-exists-sync/-/fs-exists-sync-0.1.0.tgz#982d6893af918e72d08dec9e8673ff2b5a8d6add"
 
+fs-readdir-recursive@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/fs-readdir-recursive/-/fs-readdir-recursive-1.0.0.tgz#8cd1745c8b4f8a29c8caec392476921ba195f560"
+
 fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
@@ -3283,7 +3312,7 @@ glob-parent@^2.0.0:
   dependencies:
     is-glob "^2.0.0"
 
-glob@^5.0.15, glob@5.0.x, glob@5.x:
+glob@^5.0.15, glob@^5.0.5, glob@5.0.x, glob@5.x:
   version "5.0.15"
   resolved "https://registry.yarnpkg.com/glob/-/glob-5.0.15.tgz#1bc936b9e02f4a603fcc222ecf7633d30b8b93b1"
   dependencies:
@@ -3411,7 +3440,7 @@ got@^5.0.0:
     unzip-response "^1.0.2"
     url-parse-lax "^1.0.0"
 
-graceful-fs@^4.1.2, graceful-fs@^4.1.3, graceful-fs@^4.1.6:
+graceful-fs@^4.1.2, graceful-fs@^4.1.3, graceful-fs@^4.1.4, graceful-fs@^4.1.6:
   version "4.1.11"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.11.tgz#0e8bdfe4d1ddb8854d64e04ea7c00e2a026e5658"
 
@@ -6010,6 +6039,14 @@ osenv@^0.1.0, osenv@0:
   dependencies:
     os-homedir "^1.0.0"
     os-tmpdir "^1.0.0"
+
+output-file-sync@^1.1.0:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/output-file-sync/-/output-file-sync-1.1.2.tgz#d0a33eefe61a205facb90092e826598d5245ce76"
+  dependencies:
+    graceful-fs "^4.1.4"
+    mkdirp "^0.5.1"
+    object-assign "^4.1.0"
 
 package-json@^2.0.0, package-json@^2.0.1:
   version "2.4.0"
@@ -8689,6 +8726,10 @@ url@^0.11.0:
     punycode "1.3.2"
     querystring "0.2.0"
 
+user-home@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/user-home/-/user-home-1.1.1.tgz#2b5be23a32b63a7c9deb8d0f28d485724a3df190"
+
 user-home@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/user-home/-/user-home-2.0.0.tgz#9c70bfd8169bc1dcbf48604e0f04b8b49cde9e9f"
@@ -8716,6 +8757,12 @@ uuid@^2.0.1, uuid@^2.0.2, uuid@^2.0.3:
 uuid@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.0.1.tgz#6544bba2dfda8c1cf17e629a3a305e2bb1fee6c1"
+
+v8flags@^2.0.10:
+  version "2.0.11"
+  resolved "https://registry.yarnpkg.com/v8flags/-/v8flags-2.0.11.tgz#bca8f30f0d6d60612cc2c00641e6962d42ae6881"
+  dependencies:
+    user-home "^1.1.1"
 
 validate-npm-package-license@^3.0.1:
   version "3.0.1"


### PR DESCRIPTION
Eventually this could turn into a bin/netlict-cms commandline tool

Right now this PR will let you build a small cli tool by running:

```
npm run build:cli
```

You can then use `bin/autoconfigure.collection.js <path-to-my-collection-folder>` to
autogenerate a configuration for a collection that you can paste into your `config.yml`.