### PR TITLE
Validation

### DIFF
--- a/src/actions/editorialWorkflow.js
+++ b/src/actions/editorialWorkflow.js
@@ -219,9 +219,14 @@ export function loadUnpublishedEntries() {
   };
 }
 
-export function persistUnpublishedEntry(collection, entryDraft, existingUnpublishedEntry) {
+export function persistUnpublishedEntry(collection, existingUnpublishedEntry) {
   return (dispatch, getState) => {
     const state = getState();
+    const entryDraft = state.entryDraft;
+
+    // Early return if draft contains validation errors
+    if (!entryDraft.get('fieldsErrors').isEmpty()) return;
+
     const backend = currentBackend(state.config);
     const assetProxies = entryDraft.get('mediaFiles').map(path => getAsset(state, path));
     const entry = entryDraft.get('entry');

--- a/src/actions/entries.js
+++ b/src/actions/entries.js
@@ -163,10 +163,10 @@ export function changeDraftField(field, value, metadata) {
   };
 }
 
-export function changeDraftValidationErrors(errors) {
+export function changeDraftFieldValidation(field, errors) {
   return {
     type: DRAFT_VALIDATION_ERRORS,
-    payload: { errors },
+    payload: { field, errors },
   };
 }
 
@@ -223,9 +223,14 @@ export function createEmptyDraft(collection) {
   };
 }
 
-export function persistEntry(collection, entryDraft) {
+export function persistEntry(collection) {
   return (dispatch, getState) => {
     const state = getState();
+    const entryDraft = state.entryDraft;
+
+    // Early return if draft contains validation errors
+    if (!entryDraft.get('fieldsErrors').isEmpty()) return;
+    
     const backend = currentBackend(state.config);
     const assetProxies = entryDraft.get('mediaFiles').map(path => getAsset(state, path));
     const entry = entryDraft.get('entry');

--- a/src/actions/entries.js
+++ b/src/actions/entries.js
@@ -24,6 +24,7 @@ export const DRAFT_CREATE_EMPTY = 'DRAFT_CREATE_EMPTY';
 export const DRAFT_DISCARD = 'DRAFT_DISCARD';
 export const DRAFT_CHANGE = 'DRAFT_CHANGE';
 export const DRAFT_CHANGE_FIELD = 'DRAFT_CHANGE_FIELD';
+export const DRAFT_VALIDATION_ERRORS = 'DRAFT_VALIDATION_ERRORS';
 
 export const ENTRY_PERSIST_REQUEST = 'ENTRY_PERSIST_REQUEST';
 export const ENTRY_PERSIST_SUCCESS = 'ENTRY_PERSIST_SUCCESS';
@@ -141,6 +142,7 @@ export function createDraftFromEntry(entry) {
   };
 }
 
+
 export function discardDraft() {
   return {
     type: DRAFT_DISCARD,
@@ -160,6 +162,14 @@ export function changeDraftField(field, value, metadata) {
     payload: { field, value, metadata },
   };
 }
+
+export function changeDraftValidationErrors(errors) {
+  return {
+    type: DRAFT_VALIDATION_ERRORS,
+    payload: { errors },
+  };
+}
+
 
 /*
  * Exported Thunk Action Creators

--- a/src/components/ControlPanel/ControlPane.css
+++ b/src/components/ControlPanel/ControlPane.css
@@ -19,12 +19,26 @@
     color: #7c8382;
   }
 }
+
 .label {
   display: block;
   color: #AAB0AF;
   font-size: 12px;
+  margin-bottom: 8px;
+}
+
+.labelWithError {
+  composes: label;
+  color: #FF706F;
+}
+
+.errors {
+  list-style-type: none;
+  font-size: 10px;
+  color: #FF706F;
   margin-bottom: 18px;
 }
+
 .widget {
   border-bottom: 1px solid #e8eae8;
   position: relative;

--- a/src/components/ControlPanel/ControlPane.js
+++ b/src/components/ControlPanel/ControlPane.js
@@ -10,31 +10,14 @@ function isHidden(field) {
 }
 
 export default class ControlPane extends Component {
-  componentValidation = {};
+  componentValidate = {};
   processControlRef(fieldName, wrappedControl) {
     if (!wrappedControl) return;
-    this.componentValidation[fieldName] = wrappedControl.isValid;
+    this.componentValidate[fieldName] = wrappedControl.validate;
   }
 
-  isValid = () => {
-    const errors = this.props.fields.reduce((acc, field) => {
-      const fieldErrors = this.componentValidation[field.get("name")]();
-      if (fieldErrors.length > 0) {
-        return acc.set(field.get("name"), fromJS(fieldErrors));
-      }
-      return acc;
-    }, Map());
-    this.props.onValidate(errors);
-    return errors.isEmpty();
-  };
-
-  handleAsyncFieldValidation = (field, errors) => {
-    const { fieldsErrors } = this.props;
-    if (errors.length > 0) {
-      this.props.onValidate(fieldsErrors.set(field, fromJS(errors)));
-    } else {
-      this.props.onValidate(fieldsErrors.delete(field));
-    }
+  validate = () => {
+    this.props.fields.forEach(field => this.componentValidate[field.get("name")]());
   };
 
   controlFor(field) {
@@ -62,7 +45,7 @@ export default class ControlPane extends Component {
           value={value}
           metadata={metadata}
           onChange={(newValue, newMetadata) => onChange(fieldName, newValue, newMetadata)}
-          onAsyncValidate={this.handleAsyncFieldValidation.bind(this, fieldName)}
+          onValidate={this.props.onValidate.bind(this, fieldName)}
           onAddAsset={onAddAsset}
           onRemoveAsset={onRemoveAsset}
           getAsset={getAsset}

--- a/src/components/ControlPanel/ControlPane.js
+++ b/src/components/ControlPanel/ControlPane.js
@@ -1,6 +1,7 @@
 import React, { Component, PropTypes } from 'react';
 import ImmutablePropTypes from 'react-immutable-proptypes';
 import { resolveWidget } from '../Widgets';
+import ControlHOC from '../Widgets/ControlHOC';
 import styles from './ControlPane.css';
 
 function isHidden(field) {
@@ -8,6 +9,11 @@ function isHidden(field) {
 }
 
 export default class ControlPane extends Component {
+  isValid = {};
+  processControlRef(fieldName, wrappedControl) {
+    if (!wrappedControl) return;
+    this.isValid[fieldName] = wrappedControl.isValid;
+  }
 
   controlFor(field) {
     const { entry, fieldsMetaData, getAsset, onChange, onAddAsset, onRemoveAsset } = this.props;
@@ -19,17 +25,17 @@ export default class ControlPane extends Component {
     return (
       <div className={styles.control}>
         <label className={styles.label} htmlFor={fieldName}>{field.get('label')}</label>
-        {
-          React.createElement(widget.control, {
-            field,
-            value,
-            metadata,
-            onChange: (newValue, newMetadata) => onChange(fieldName, newValue, newMetadata),
-            onAddAsset,
-            onRemoveAsset,
-            getAsset,
-          })
-        }
+        <ControlHOC 
+          controlComponent={widget.control}
+          field={field}
+          value={value}
+          metadata={metadata}
+          onChange={(newValue, newMetadata) => onChange(fieldName, newValue, newMetadata)}
+          onAddAsset={onAddAsset}
+          onRemoveAsset={onRemoveAsset}
+          getAsset={getAsset}
+          ref={this.processControlRef.bind(this, fieldName)}
+        />
       </div>
     );
   }

--- a/src/components/ControlPanel/ControlPane.js
+++ b/src/components/ControlPanel/ControlPane.js
@@ -24,9 +24,17 @@ export default class ControlPane extends Component {
       }
       return acc;
     }, Map());
-
     this.props.onValidate(errors);
     return errors.isEmpty();
+  };
+
+  handleAsyncFieldValidation = (field, errors) => {
+    const { fieldsErrors } = this.props;
+    if (errors.length > 0) {
+      this.props.onValidate(fieldsErrors.set(field, fromJS(errors)));
+    } else {
+      this.props.onValidate(fieldsErrors.delete(field));
+    }
   };
 
   controlFor(field) {
@@ -54,6 +62,7 @@ export default class ControlPane extends Component {
           value={value}
           metadata={metadata}
           onChange={(newValue, newMetadata) => onChange(fieldName, newValue, newMetadata)}
+          onAsyncValidate={this.handleAsyncFieldValidation.bind(this, fieldName)}
           onAddAsset={onAddAsset}
           onRemoveAsset={onRemoveAsset}
           getAsset={getAsset}

--- a/src/components/ControlPanel/ControlPane.js
+++ b/src/components/ControlPanel/ControlPane.js
@@ -1,4 +1,5 @@
 import React, { Component, PropTypes } from 'react';
+import { Map, fromJS } from 'immutable';
 import ImmutablePropTypes from 'react-immutable-proptypes';
 import { resolveWidget } from '../Widgets';
 import ControlHOC from '../Widgets/ControlHOC';
@@ -15,21 +16,38 @@ export default class ControlPane extends Component {
     this.componentValidation[fieldName] = wrappedControl.isValid;
   }
 
-  isValid = () => this.props.fields.reduce((acc, field) => {
-    const componentIsValid = this.componentValidation[field.get("name")]();
-    return acc && componentIsValid;
-  }, true);
+  isValid = () => {
+    const errors = this.props.fields.reduce((acc, field) => {
+      const fieldErrors = this.componentValidation[field.get("name")]();
+      if (fieldErrors.length > 0) {
+        return acc.set(field.get("name"), fromJS(fieldErrors));
+      }
+      return acc;
+    }, Map());
+
+    this.props.onValidate(errors);
+    return errors.isEmpty();
+  };
 
   controlFor(field) {
-    const { entry, fieldsMetaData, getAsset, onChange, onAddAsset, onRemoveAsset } = this.props;
+    const { entry, fieldsMetaData, fieldsErrors, getAsset, onChange, onAddAsset, onRemoveAsset } = this.props;
     const widget = resolveWidget(field.get('widget'));
     const fieldName = field.get('name');
     const value = entry.getIn(['data', fieldName]);
     const metadata = fieldsMetaData.get(fieldName);
+    const errors = fieldsErrors.get(fieldName);
+    const labelClass = errors ? styles.labelWithError : styles.label;
     if (entry.size === 0 || entry.get('partial') === true) return null;
     return (
       <div className={styles.control}>
-        <label className={styles.label} htmlFor={fieldName}>{field.get('label')}</label>
+        <label className={labelClass} htmlFor={fieldName}>{field.get('label')}</label>
+        <ul className={styles.errors}>
+          {
+            errors && errors.map(error => (
+              typeof error === 'string' && <li key={error.trim().replace(/[^a-z0-9]+/gi, '-')}>{error}</li>
+            ))
+          }
+        </ul>
         <ControlHOC 
           controlComponent={widget.control}
           field={field}
@@ -71,8 +89,10 @@ ControlPane.propTypes = {
   entry: ImmutablePropTypes.map.isRequired,
   fields: ImmutablePropTypes.list.isRequired,
   fieldsMetaData: ImmutablePropTypes.map.isRequired,
+  fieldsErrors: ImmutablePropTypes.map.isRequired,
   getAsset: PropTypes.func.isRequired,
   onAddAsset: PropTypes.func.isRequired,
   onChange: PropTypes.func.isRequired,
+  onValidate: PropTypes.func.isRequired,
   onRemoveAsset: PropTypes.func.isRequired,
 };

--- a/src/components/ControlPanel/ControlPane.js
+++ b/src/components/ControlPanel/ControlPane.js
@@ -9,11 +9,16 @@ function isHidden(field) {
 }
 
 export default class ControlPane extends Component {
-  isValid = {};
+  componentValidation = {};
   processControlRef(fieldName, wrappedControl) {
     if (!wrappedControl) return;
-    this.isValid[fieldName] = wrappedControl.isValid;
+    this.componentValidation[fieldName] = wrappedControl.isValid;
   }
+
+  isValid = () => this.props.fields.reduce((acc, field) => {
+    const componentIsValid = this.componentValidation[field.get("name")]();
+    return acc && componentIsValid;
+  }, true);
 
   controlFor(field) {
     const { entry, fieldsMetaData, getAsset, onChange, onAddAsset, onRemoveAsset } = this.props;

--- a/src/components/EntryEditor/EntryEditor.js
+++ b/src/components/EntryEditor/EntryEditor.js
@@ -21,7 +21,8 @@ class EntryEditor extends Component {
   };
 
   handleOnPersist = () => {
-    if (this.controlPaneRef.isValid()) this.props.onPersist();
+    this.controlPaneRef.validate();
+    this.props.onPersist();
   };
 
   render() {

--- a/src/components/EntryEditor/EntryEditor.js
+++ b/src/components/EntryEditor/EntryEditor.js
@@ -20,6 +20,10 @@ class EntryEditor extends Component {
     this.setState({ showEventBlocker: false });
   };
 
+  handleOnPersist = () => {
+    if (this.controlPaneRef.isValid()) this.props.onPersist();
+  };
+
   render() {
     const {
         collection,
@@ -30,7 +34,6 @@ class EntryEditor extends Component {
         onChange,
         onAddAsset,
         onRemoveAsset,
-        onPersist,
         onCancelEdit,
     } = this.props;
 
@@ -57,6 +60,7 @@ class EntryEditor extends Component {
                     onChange={onChange}
                     onAddAsset={onAddAsset}
                     onRemoveAsset={onRemoveAsset}
+                    ref={c => this.controlPaneRef = c} // eslint-disable-line
                   />
 
                 </div>
@@ -76,7 +80,7 @@ class EntryEditor extends Component {
         <div className={styles.footer}>
           <Toolbar
             isPersisting={entry.get('isPersisting')}
-            onPersist={onPersist}
+            onPersist={this.handleOnPersist}
             onCancelEdit={onCancelEdit}
           />
         </div>

--- a/src/components/EntryEditor/EntryEditor.js
+++ b/src/components/EntryEditor/EntryEditor.js
@@ -30,8 +30,10 @@ class EntryEditor extends Component {
         entry,
         fields,
         fieldsMetaData,
+        fieldsErrors,
         getAsset,
         onChange,
+        onValidate,
         onAddAsset,
         onRemoveAsset,
         onCancelEdit,
@@ -56,8 +58,10 @@ class EntryEditor extends Component {
                     entry={entry}
                     fields={fields}
                     fieldsMetaData={fieldsMetaData}
+                    fieldsErrors={fieldsErrors}
                     getAsset={getAsset}
                     onChange={onChange}
+                    onValidate={onValidate}
                     onAddAsset={onAddAsset}
                     onRemoveAsset={onRemoveAsset}
                     ref={c => this.controlPaneRef = c} // eslint-disable-line
@@ -95,9 +99,11 @@ EntryEditor.propTypes = {
   entry: ImmutablePropTypes.map.isRequired,
   fields: ImmutablePropTypes.list.isRequired,
   fieldsMetaData: ImmutablePropTypes.map.isRequired,
+  fieldsErrors: ImmutablePropTypes.map.isRequired,
   getAsset: PropTypes.func.isRequired,
   onAddAsset: PropTypes.func.isRequired,
   onChange: PropTypes.func.isRequired,
+  onValidate: PropTypes.func.isRequired,
   onPersist: PropTypes.func.isRequired,
   onRemoveAsset: PropTypes.func.isRequired,
   onCancelEdit: PropTypes.func.isRequired,

--- a/src/components/Widgets/ControlHOC.js
+++ b/src/components/Widgets/ControlHOC.js
@@ -14,10 +14,13 @@ class ControlHOC extends Component {
   };
 
   isValid = () => {
-    if (this.props.value && this.props.value.length > 3) {
-      return true;
-    }
-    return false;
+    const { field, value } = this.props;
+    let valid = true;
+    const isRequired = field.get('required', true);
+    const pattern = field.get('pattern', false);
+    if (isRequired) valid = valid && (value !== null && value.length > 0);
+    if (pattern) valid = valid && RegExp(pattern).test(value);
+    return valid;
   };
 
   render() {

--- a/src/components/Widgets/ControlHOC.js
+++ b/src/components/Widgets/ControlHOC.js
@@ -29,21 +29,22 @@ class ControlHOC extends Component {
       const response = func(field, value);
       if (response.error) errors.push(response.error);
     });
-    return errors.length === 0;
+
+    return errors;
   };
 
   validatePresence(field, value) {
     const isRequired = field.get('required', true);
     if (isRequired && (value === null || value.length === 0)) {
-      return { error: `${ field.get('title', field.get('name')) } is required.` };
+      return { error: true };
     }
     return { error: false };  
   }
 
   validatePattern(field, value) {
     const pattern = field.get('pattern', false);
-    if (pattern && !RegExp(pattern).test(value)) {
-      return { error: `${ field.get('title', field.get('name')) } didn't match the pattern: ${ field.get('patternTitle') }` };
+    if (pattern && !RegExp(pattern.first()).test(value)) {
+      return { error: `${ field.get('label', field.get('name')) } didn't match the pattern: ${ pattern.last() }` };
     }
     return { error: false };
   }

--- a/src/components/Widgets/ControlHOC.js
+++ b/src/components/Widgets/ControlHOC.js
@@ -1,0 +1,37 @@
+import React, { Component, PropTypes } from 'react';
+import ImmutablePropTypes from "react-immutable-proptypes";
+
+class ControlHOC extends Component {
+  static propTypes = {
+    controlComponent: PropTypes.func.isRequired,
+    field: ImmutablePropTypes.map.isRequired,
+    value: PropTypes.node,
+    metadata: ImmutablePropTypes.map,
+    onChange: PropTypes.func.isRequired,
+    onAddAsset: PropTypes.func.isRequired,
+    onRemoveAsset: PropTypes.func.isRequired,
+    getAsset: PropTypes.func.isRequired,
+  };
+
+  isValid = () => {
+    if (this.props.value && this.props.value.length > 3) {
+      return true;
+    }
+    return false;
+  };
+
+  render() {
+    const { controlComponent, field, value, metadata, onChange, onAddAsset, onRemoveAsset, getAsset } = this.props;
+    return React.createElement(controlComponent, {
+      field,
+      value,
+      metadata,
+      onChange,
+      onAddAsset,
+      onRemoveAsset,
+      getAsset,
+    });
+  }
+}
+
+export default ControlHOC;

--- a/src/components/Widgets/ControlHOC.js
+++ b/src/components/Widgets/ControlHOC.js
@@ -11,7 +11,7 @@ class ControlHOC extends Component {
     value: PropTypes.node,
     metadata: ImmutablePropTypes.map,
     onChange: PropTypes.func.isRequired,
-    onAsyncValidate: PropTypes.func.isRequired,
+    onValidate: PropTypes.func.isRequired,
     onAddAsset: PropTypes.func.isRequired,
     onRemoveAsset: PropTypes.func.isRequired,
     getAsset: PropTypes.func.isRequired,
@@ -22,7 +22,7 @@ class ControlHOC extends Component {
     this.wrappedControlValid = wrappedControl.isValid || truthy;
   };
 
-  isValid = (skipWrapped = false) => {
+  validate = (skipWrapped = false) => {
     const { field, value } = this.props;
     const errors = [];
     const validations = [this.validatePresence, this.validatePattern];
@@ -36,7 +36,7 @@ class ControlHOC extends Component {
       const wrappedError = this.validateWrappedControl(field);
       if (wrappedError.error) errors.push(wrappedError.error);
     }
-    return errors;
+    this.props.onValidate(errors);
   };
 
   validatePresence(field, value) {
@@ -61,9 +61,9 @@ class ControlHOC extends Component {
       return response;
     } else if (response instanceof Promise) {
       response.then(
-        () => { this.props.onAsyncValidate(this.isValid({ error: false })); },
+        () => { this.validate({ error: false }); },
         (error) => { 
-          this.props.onAsyncValidate(this.isValid({ error: `${ field.get('label', field.get('name')) } - ${ error }.` }));
+          this.validate({ error: `${ field.get('label', field.get('name')) } - ${ error }.` });
         }
       );
       return { error: `${ field.get('label', field.get('name')) } is processing.` };

--- a/src/components/Widgets/ControlHOC.js
+++ b/src/components/Widgets/ControlHOC.js
@@ -1,7 +1,10 @@
 import React, { Component, PropTypes } from 'react';
 import ImmutablePropTypes from "react-immutable-proptypes";
 
+const truthy = () => ({ error: false });
+
 class ControlHOC extends Component {
+
   static propTypes = {
     controlComponent: PropTypes.func.isRequired,
     field: ImmutablePropTypes.map.isRequired,
@@ -13,15 +16,37 @@ class ControlHOC extends Component {
     getAsset: PropTypes.func.isRequired,
   };
 
+  processInnerControlRef = (wrappedControl) => {
+    if (!wrappedControl) return;
+    this.innerControlValid = wrappedControl.isValid || truthy;
+  };
+
   isValid = () => {
     const { field, value } = this.props;
-    let valid = true;
-    const isRequired = field.get('required', true);
-    const pattern = field.get('pattern', false);
-    if (isRequired) valid = valid && (value !== null && value.length > 0);
-    if (pattern) valid = valid && RegExp(pattern).test(value);
-    return valid;
+    const errors = [];
+    const validations = [this.validatePresence, this.validatePattern, this.innerControlValid];
+    validations.forEach((func) => {
+      const response = func(field, value);
+      if (response.error) errors.push(response.error);
+    });
+    return errors.length === 0;
   };
+
+  validatePresence(field, value) {
+    const isRequired = field.get('required', true);
+    if (isRequired && (value === null || value.length === 0)) {
+      return { error: `${ field.get('title', field.get('name')) } is required.` };
+    }
+    return { error: false };  
+  }
+
+  validatePattern(field, value) {
+    const pattern = field.get('pattern', false);
+    if (pattern && !RegExp(pattern).test(value)) {
+      return { error: `${ field.get('title', field.get('name')) } didn't match the pattern: ${ field.get('patternTitle') }` };
+    }
+    return { error: false };
+  }
 
   render() {
     const { controlComponent, field, value, metadata, onChange, onAddAsset, onRemoveAsset, getAsset } = this.props;
@@ -33,6 +58,7 @@ class ControlHOC extends Component {
       onAddAsset,
       onRemoveAsset,
       getAsset,
+      ref: this.processInnerControlRef,
     });
   }
 }

--- a/src/components/Widgets/ControlHOC.js
+++ b/src/components/Widgets/ControlHOC.js
@@ -58,6 +58,9 @@ class ControlHOC extends Component {
   validateWrappedControl = (field) => {
     const response = this.wrappedControlValid();
     if (typeof response === "boolean") {
+      const isValid = response;
+      return { error: (!isValid) };
+    } else if (response.hasOwnProperty('error')) {
       return response;
     } else if (response instanceof Promise) {
       response.then(

--- a/src/components/Widgets/FileControl.js
+++ b/src/components/Widgets/FileControl.js
@@ -10,12 +10,15 @@ export default class FileControl extends React.Component {
     processing: false,
   };
 
+  promise = null;
+
   isValid = () => {
-    if (this.state.processing) {
-      return { error: "Processing File Upload" };
+    if (this.promise) {
+      return this.promise;
     }
     return { error: false };
   };
+
 
   handleFileInputRef = (el) => {
     this._fileInput = el;
@@ -49,7 +52,7 @@ export default class FileControl extends React.Component {
     this.props.onRemoveAsset(this.props.value);
     if (file) {
       this.setState({ processing: true });
-      createAssetProxy(file.name, file, false, this.props.field.get('private', false))
+      this.promise = createAssetProxy(file.name, file, false, this.props.field.get('private', false))
       .then((assetProxy) => {
         this.setState({ processing: false });
         this.props.onAddAsset(assetProxy);

--- a/src/components/Widgets/FileControl.js
+++ b/src/components/Widgets/FileControl.js
@@ -10,6 +10,13 @@ export default class FileControl extends React.Component {
     processing: false,
   };
 
+  isValid = () => {
+    if (this.state.processing) {
+      return { error: "Processing File Upload" };
+    }
+    return { error: false };
+  };
+
   handleFileInputRef = (el) => {
     this._fileInput = el;
   };

--- a/src/components/Widgets/ImageControl.js
+++ b/src/components/Widgets/ImageControl.js
@@ -10,9 +10,11 @@ export default class ImageControl extends React.Component {
     processing: false,
   };
 
+  promise = null;
+
   isValid = () => {
-    if (this.state.processing) {
-      return { error: "Processing Image Upload" };
+    if (this.promise) {
+      return this.promise;
     }
     return { error: false };
   };
@@ -54,7 +56,7 @@ export default class ImageControl extends React.Component {
     this.props.onRemoveAsset(this.props.value);
     if (file) {
       this.setState({ processing: true });
-      createAssetProxy(file.name, file)
+      this.promise = createAssetProxy(file.name, file)
       .then((assetProxy) => {
         this.setState({ processing: false });
         this.props.onAddAsset(assetProxy);

--- a/src/components/Widgets/ImageControl.js
+++ b/src/components/Widgets/ImageControl.js
@@ -10,6 +10,14 @@ export default class ImageControl extends React.Component {
     processing: false,
   };
 
+  isValid = () => {
+    if (this.state.processing) {
+      return { error: "Processing Image Upload" };
+    }
+    return { error: false };
+  };
+
+
   handleFileInputRef = (el) => {
     this._fileInput = el;
   };

--- a/src/containers/EntryPage.js
+++ b/src/containers/EntryPage.js
@@ -7,6 +7,7 @@ import {
   createEmptyDraft,
   discardDraft,
   changeDraftField,
+  changeDraftValidationErrors,
   persistEntry,
 } from '../actions/entries';
 import { closeEntry } from '../actions/editor';
@@ -23,6 +24,7 @@ class EntryPage extends React.Component {
     addAsset: PropTypes.func.isRequired,
     boundGetAsset: PropTypes.func.isRequired,
     changeDraftField: PropTypes.func.isRequired,
+    changeDraftValidationErrors: PropTypes.func.isRequired,
     collection: ImmutablePropTypes.map.isRequired,
     createDraftFromEntry: PropTypes.func.isRequired,
     createEmptyDraft: PropTypes.func.isRequired,
@@ -84,6 +86,7 @@ class EntryPage extends React.Component {
       boundGetAsset,
       collection,
       changeDraftField,
+      changeDraftValidationErrors,
       addAsset,
       removeAsset,
       closeEntry,
@@ -104,7 +107,9 @@ class EntryPage extends React.Component {
         collection={collection}
         fields={fields}
         fieldsMetaData={entryDraft.get('fieldsMetaData')}
+        fieldsErrors={entryDraft.get('fieldsErrors')}
         onChange={changeDraftField}
+        onValidate={changeDraftValidationErrors}
         onAddAsset={addAsset}
         onRemoveAsset={removeAsset}
         onPersist={this.handlePersistEntry}
@@ -138,6 +143,7 @@ export default connect(
   mapStateToProps,
   {
     changeDraftField,
+    changeDraftValidationErrors,
     addAsset,
     removeAsset,
     loadEntry,

--- a/src/containers/EntryPage.js
+++ b/src/containers/EntryPage.js
@@ -7,7 +7,7 @@ import {
   createEmptyDraft,
   discardDraft,
   changeDraftField,
-  changeDraftValidationErrors,
+  changeDraftFieldValidation,
   persistEntry,
 } from '../actions/entries';
 import { closeEntry } from '../actions/editor';
@@ -24,7 +24,7 @@ class EntryPage extends React.Component {
     addAsset: PropTypes.func.isRequired,
     boundGetAsset: PropTypes.func.isRequired,
     changeDraftField: PropTypes.func.isRequired,
-    changeDraftValidationErrors: PropTypes.func.isRequired,
+    changeDraftFieldValidation: PropTypes.func.isRequired,
     collection: ImmutablePropTypes.map.isRequired,
     createDraftFromEntry: PropTypes.func.isRequired,
     createEmptyDraft: PropTypes.func.isRequired,
@@ -74,8 +74,8 @@ class EntryPage extends React.Component {
   };
 
   handlePersistEntry = () => {
-    const { persistEntry, collection, entryDraft } = this.props;
-    persistEntry(collection, entryDraft);
+    const { persistEntry, collection } = this.props;
+    persistEntry(collection);
   };
 
   render() {
@@ -86,7 +86,7 @@ class EntryPage extends React.Component {
       boundGetAsset,
       collection,
       changeDraftField,
-      changeDraftValidationErrors,
+      changeDraftFieldValidation,
       addAsset,
       removeAsset,
       closeEntry,
@@ -109,7 +109,7 @@ class EntryPage extends React.Component {
         fieldsMetaData={entryDraft.get('fieldsMetaData')}
         fieldsErrors={entryDraft.get('fieldsErrors')}
         onChange={changeDraftField}
-        onValidate={changeDraftValidationErrors}
+        onValidate={changeDraftFieldValidation}
         onAddAsset={addAsset}
         onRemoveAsset={removeAsset}
         onPersist={this.handlePersistEntry}
@@ -143,7 +143,7 @@ export default connect(
   mapStateToProps,
   {
     changeDraftField,
-    changeDraftValidationErrors,
+    changeDraftFieldValidation,
     addAsset,
     removeAsset,
     loadEntry,

--- a/src/containers/editorialWorkflow/EntryPageHOC.js
+++ b/src/containers/editorialWorkflow/EntryPageHOC.js
@@ -40,8 +40,8 @@ export default function EntryPageHOC(EntryPage) {
       };
       
       // Overwrite persistEntry to persistUnpublishedEntry
-      returnObj.persistEntry = (collection, entryDraft) => {
-        dispatch(persistUnpublishedEntry(collection, entryDraft, unpublishedEntry));
+      returnObj.persistEntry = (collection) => {
+        dispatch(persistUnpublishedEntry(collection, unpublishedEntry));
       };
     }
 

--- a/src/reducers/__tests__/entryDraft.spec.js
+++ b/src/reducers/__tests__/entryDraft.spec.js
@@ -2,7 +2,7 @@ import { Map, List, fromJS } from 'immutable';
 import * as actions from '../../actions/entries';
 import reducer from '../entryDraft';
 
-let initialState = Map({ entry: Map(), mediaFiles: List(), fieldsMetaData: Map() });
+let initialState = Map({ entry: Map(), mediaFiles: List(), fieldsMetaData: Map(), fieldsErrors: Map() });
 
 const entry = {
   collection: 'posts',
@@ -30,6 +30,7 @@ describe('entryDraft reducer', () => {
           },
           mediaFiles: [],
           fieldsMetaData: Map(),
+          fieldsErrors: Map(),
         })
       );
     });
@@ -50,6 +51,7 @@ describe('entryDraft reducer', () => {
           },
           mediaFiles: [],
           fieldsMetaData: Map(),
+          fieldsErrors: Map(),
         })
       );
     });

--- a/src/reducers/entryDraft.js
+++ b/src/reducers/entryDraft.js
@@ -4,6 +4,7 @@ import {
   DRAFT_CREATE_EMPTY,
   DRAFT_DISCARD,
   DRAFT_CHANGE_FIELD,
+  DRAFT_VALIDATION_ERRORS,
   ENTRY_PERSIST_REQUEST,
   ENTRY_PERSIST_SUCCESS,
   ENTRY_PERSIST_FAILURE,
@@ -24,6 +25,7 @@ const entryDraftReducer = (state = Map(), action) => {
         state.setIn(['entry', 'newRecord'], false);
         state.set('mediaFiles', List());
         state.set('fieldsMetaData', Map());
+        state.set('fieldsErrors', Map());
       });
     case DRAFT_CREATE_EMPTY:
       // New Entry
@@ -32,6 +34,7 @@ const entryDraftReducer = (state = Map(), action) => {
         state.setIn(['entry', 'newRecord'], true);
         state.set('mediaFiles', List());
         state.set('fieldsMetaData', Map());
+        state.set('fieldsErrors', Map());
       });
     case DRAFT_DISCARD:
       return initialState;
@@ -40,6 +43,10 @@ const entryDraftReducer = (state = Map(), action) => {
         state.setIn(['entry', 'data', action.payload.field], action.payload.value);
         state.mergeIn(['fieldsMetaData'], fromJS(action.payload.metadata));
       });
+    
+    case DRAFT_VALIDATION_ERRORS:
+      return state.setIn(['fieldsErrors'], action.payload.errors);
+
     case ENTRY_PERSIST_REQUEST: {
       return state.setIn(['entry', 'isPersisting'], true);
     }

--- a/src/reducers/entryDraft.js
+++ b/src/reducers/entryDraft.js
@@ -45,7 +45,11 @@ const entryDraftReducer = (state = Map(), action) => {
       });
     
     case DRAFT_VALIDATION_ERRORS:
-      return state.setIn(['fieldsErrors'], action.payload.errors);
+      if (action.payload.errors.length === 0) {
+        return state.deleteIn(['fieldsErrors', action.payload.field]);
+      } else {
+        return state.setIn(['fieldsErrors', action.payload.field], action.payload.errors);
+      }
 
     case ENTRY_PERSIST_REQUEST: {
       return state.setIn(['entry', 'isPersisting'], true);

--- a/src/reducers/entryDraft.js
+++ b/src/reducers/entryDraft.js
@@ -14,7 +14,7 @@ import {
   REMOVE_ASSET,
 } from '../actions/media';
 
-const initialState = Map({ entry: Map(), mediaFiles: List(), fieldsMetaData: Map() });
+const initialState = Map({ entry: Map(), mediaFiles: List(), fieldsMetaData: Map(), fieldsErrors: Map() });
 
 const entryDraftReducer = (state = Map(), action) => {
   switch (action.type) {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines;
https://github.com/netlify/netlify-cms/blob/master/CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first three fields are mandatory:
-->

**- Summary**

## Adds validation to widgets. Available validations:

- Presence: By default all widgets are required, unless specified in the config. Example:
`- {label: "Subtitle", name: "subtitle", widget: "string", required: false}`

- Pattern: Field configuration can specify a regex pattern with the appropriate error message. Example:
`- {label: "Title", name: "title", widget: "string", pattern: [".{10,}", "Should have more than 10 characters"] }`

The widget control can optionally implement an `isValid` method to perform custom validations, in addition to presence and pattern. The `isValid` method will be automatically called, and it can return either a boolean value, an object with an error message or a promise. Examples:

**Boolean**
No errors:

```javascript
  isValid = () => {
    // Do internal validation
    return true;
  };
```

Existing error:

```javascript
  isValid = () => {
    // Do internal validation
    return false;
  };
```

**Object with `error` (Useful for returning custom error messages)**
Existing error:

```javascript
  isValid = () => {
    // Do internal validation
    return { error: 'Your error message.' };
  };
```

**Promise**
You can also return a promise from isValid. While the promise is pending, the widget will be marked as in error. When the promise resolves, the error is automatically cleared.

```javascript
  isValid = () => {
    return this.existingPromise;
  };
```

Note: Do not create a promise inside isValid - isValid is called right before trying to persist. This means that even if a previous promise was already resolved, when the user hits 'save', `isValid` will be called again - if it returns a new Promise it will be immediately marked as in error until the new promise resolves.

<!--
Explain the **motivation** for making this change.
What existing problem does the pull request solve?
-->

**- Test plan**

<!--
Demonstrate the code is solid.
Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.
-->

**- Description for the changelog**

Added support for validations.

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

**- A picture of a cute animal (not mandatory but encouraged)**

```
……(\__/)
……(=’.’=)
…☆(”)_(”)☆
```
