### PR TITLE
Prevent giant images in editor

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -32,6 +32,10 @@ h1 {
   font-size: 25px;
 }
 
+img {
+  max-width: 100%;
+}
+
 :global {
 
   & .react-autosuggest__container {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines;
https://github.com/netlify/netlify-cms/blob/master/CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first three fields are mandatory:
-->

**- Summary**

<!--
Explain the **motivation** for making this change.
What existing problem does the pull request solve?
-->
Discovered that large images inserted in the markdown editor expand beyond the borders of the editor, making them a hassle to scroll past.

I added the common global default `img { max-width: 100%; }` to prevent this and other similar layout bugs that may come up in the future.

**- Test plan**

<!--
Demonstrate the code is solid.
Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.
-->
Quick-and-dirty testing with the web inspector showed the problem solved and no other layout bugs as a result.

**- Description for the changelog**

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Prevent images from overflowing their containers

**- A picture of a cute animal (not mandatory but encouraged)**

(my pups, Monty and Petunia) 😄 
![Monty and Petunia, shibas extraordinaire](https://cloud.githubusercontent.com/assets/6111186/22569397/3bd02aba-e94c-11e6-8b0c-dadaa86b6c3d.jpg)

