### PR TITLE
#222 - Encode branch name on requests to avoid errors with special chars

### DIFF
--- a/src/backends/github/API.js
+++ b/src/backends/github/API.js
@@ -331,20 +331,20 @@ export default class API {
   }
 
   patchRef(type, name, sha) {
-    return this.request(`${ this.repoURL }/git/refs/${ type }/${ name }`, {
+    return this.request(`${ this.repoURL }/git/refs/${ type }/${ encodeURIComponent(name) }`, {
       method: "PATCH",
       body: JSON.stringify({ sha }),
     });
   }
 
   deleteRef(type, name, sha) {
-    return this.request(`${ this.repoURL }/git/refs/${ type }/${ name }`, {
+    return this.request(`${ this.repoURL }/git/refs/${ type }/${ encodeURIComponent(name) }`, {
       method: "DELETE",
     });
   }
 
   getBranch(branch = this.branch) {
-    return this.request(`${ this.repoURL }/branches/${ branch }`);
+    return this.request(`${ this.repoURL }/branches/${ encodeURIComponent(branch) }`);
   }
 
   createBranch(branchName, sha) {


### PR DESCRIPTION
**- Summary**
Closes #222 

**- Test plan**
* Steps/workflow mentioned in #222 were tested manually. 
* Basic tests passed (`npm run test`) but I don't think there are any test for the backends.
* Pre-commit hook was skipped because `eslint` complains of code that is already in master.

**- Additional info**
* `encodeURIComponent` was already being used [here](https://github.com/marzeelabs/netlify-cms/blob/471b26a9d553ca5c92bdf53fd60b3b0512ec520c/src/backends/github/API.js#L49) but it only encodes parameters like the branch name when they're passed in the `options.params` object, not when strings such as the branch name are passed on the URL for the request directly (such as in the lines that change in this diff). For now this will fix it but a refactoring should be considered to pass all dynamic parts of the URL in an object so they can be escaped in [urlFor](https://github.com/marzeelabs/netlify-cms/blob/471b26a9d553ca5c92bdf53fd60b3b0512ec520c/src/backends/github/API.js#L45) as well.

**- Description for the changelog**
* **Encode branch name on Github requests to avoid errors with special chars**

**- A picture of a cute animal (not mandatory but encouraged)**
![Computer says no...](http://www.cm-porto.pt/assets/misc/img/Animais/348bb.jpg)