### PR TITLE
Add widgetsFor helper - fixes #236

### DIFF
--- a/docs/extending.md
+++ b/docs/extending.md
@@ -37,9 +37,10 @@ Registers a template for a collection.
 **React Component Props:**
 
 * collection: The name of the collection which this preview component will be used for.
-* react_component: A React component that renders the collection data. Three props will be passed to your component during render:
+* react_component: A React component that renders the collection data. Four props will be passed to your component during render:
   * entry: Immutable collection containing the entry data.
   * widgetFor: Returns the appropriate widget preview component for a given field.
+  * [widgetsFor](#lists-and-objects): Returns an array of objects with widgets and associated field data. For use with list and object type entries.
   * getAsset: Returns the correct filePath or in-memory preview for uploaded images.
 
 **Example:**
@@ -60,6 +61,95 @@ var PostPreview = createClass({
 });
 
 CMS.registerPreviewTemplate("posts", PostPreview);
+</script>
+```
+
+### Lists and Objects
+The API for accessing the individual fields of list and object type entries is similar to the API
+for accessing fields in standard entries, but there are a few key differences. Access to these
+nested fields is facilitated through the `widgetsFor` function, which is passed to the preview
+template component during render.
+
+**Note**: as is often the case with the Netlify CMS API, arrays and objects are created with
+Immutable.js. If some of the methods that we use are unfamiliar, such as `getIn`, check out
+[their docs](https://facebook.github.io/immutable-js/docs/#/) to get a better understanding.
+
+**List Example:**
+
+```html
+<script>
+var AuthorsPreview = createClass({
+  // For list fields, the widgetFor function returns an array of objects
+  // which you can map over in your template. If our field is a list of
+  // authors containing two entries, with fields `name` and `description`,
+  // the return value of `widgetsFor` would look like this:
+  //
+  // [{
+  //   data: { name: 'Mathias', description: 'Co-Founder'},
+  //   widgets: { name: (<WidgetComponent>), description: (WidgetComponent>)}
+  // },
+  // {
+  //   data: { name: 'Chris', description: 'Co-Founder'},
+  //   widgets: { name: (<WidgetComponent>), description: (WidgetComponent>)}
+  // }]
+  //
+  // Templating would look something like this:
+
+  render: function() {
+    return h('div', {},
+
+      // This is a static header that would only be rendered once for the entire list
+      h('h1', {}, 'Authors'),
+
+      // Here we provide a simple mapping function that will be applied to each
+      // object in the array of authors
+      this.props.widgetsFor('authors').map(function(author, index) {
+        return h('div', {key: index},
+          h('hr', {}),
+          h('strong', {}, author.getIn(['data', 'name'])),
+          author.getIn(['widgets', 'description'])
+        );
+      })
+    );
+  }
+});
+
+CMS.registerPreviewTemplate("authors", AuthorsPreview);
+</script>
+```
+
+**Object Example:**
+
+```html
+<script>
+var GeneralPreview = createClass({
+  // Object fields are simpler than lists - instead of `widgetsFor` returning
+  // an array of objects, it returns a single object. Accessing the shape of
+  // that object is the same as the shape of objects returned for list fields:
+  //
+  // {
+  //   data: { front_limit: 0, author: 'Chris' },
+  //   widgets: { front_limit: (<WidgetComponent>), author: (WidgetComponent>)}
+  // }
+  render: function() {
+    var entry = this.props.entry;
+    var title = entry.getIn(['data', 'site_title']);
+    var posts = entry.getIn(['data', 'posts']);
+
+    return h('div', {},
+      h('h1', {}, title),
+      h('dl', {},
+        h('dt', {}, 'Posts on Frontpage'),
+        h('dd', {}, this.props.widgetsFor('posts').getIn(['widgets', 'front_limit']) || 0),
+
+        h('dt', {}, 'Default Author'),
+        h('dd', {}, this.props.widgetsFor('posts').getIn(['data', 'author']) || 'None'),
+      )
+    );
+  }
+});
+
+CMS.registerPreviewTemplate("general", GeneralPreview);
 </script>
 ```
 

--- a/example/index.html
+++ b/example/index.html
@@ -98,10 +98,10 @@
           h('h1', {}, title),
           h('dl', {},
             h('dt', {}, 'Posts on Frontpage'),
-            h('dd', {}, posts && posts.get('front_limit') || '0'),
+            h('dd', {}, this.props.widgetsFor('posts').getIn(['widgets', 'front_limit']) || 0),
 
             h('dt', {}, 'Default Author'),
-            h('dd', {}, posts && posts.get('author') || 'None'),
+            h('dd', {}, this.props.widgetsFor('posts').getIn(['data', 'front_limit']) || 'None'),
 
             h('dt', {}, 'Default Thumbnail'),
             h('dd', {}, thumb && h('img', {src: this.props.getAsset(thumb).toString()}))

--- a/example/index.html
+++ b/example/index.html
@@ -101,7 +101,7 @@
             h('dd', {}, this.props.widgetsFor('posts').getIn(['widgets', 'front_limit']) || 0),
 
             h('dt', {}, 'Default Author'),
-            h('dd', {}, this.props.widgetsFor('posts').getIn(['data', 'front_limit']) || 'None'),
+            h('dd', {}, this.props.widgetsFor('posts').getIn(['data', 'author']) || 'None'),
 
             h('dt', {}, 'Default Thumbnail'),
             h('dd', {}, thumb && h('img', {src: this.props.getAsset(thumb).toString()}))

--- a/example/index.html
+++ b/example/index.html
@@ -110,8 +110,24 @@
       }
     });
 
+    var AuthorsPreview = createClass({
+      render: function() {
+        return h('div', {},
+          h('h1', {}, 'Authors'),
+          this.props.widgetsFor('authors').map(function(author, index) {
+            return h('div', {key: index},
+              h('hr', {}),
+              h('strong', {}, author.getIn(['data', 'name'])),
+              author.getIn(['widgets', 'description'])
+            );
+          })
+        );
+      }
+    });
+
     CMS.registerPreviewTemplate("posts", PostPreview);
     CMS.registerPreviewTemplate("general", GeneralPreview);
+    CMS.registerPreviewTemplate("authors", AuthorsPreview);
     CMS.registerPreviewStyle("/example.css");
     CMS.registerEditorComponent({
       id: "youtube",

--- a/src/components/PreviewPane/PreviewPane.js
+++ b/src/components/PreviewPane/PreviewPane.js
@@ -16,6 +16,18 @@ export default class PreviewPane extends React.Component {
     this.renderPreview();
   }
 
+  getWidget = (field, value, props) => {
+    const { fieldsMetaData, getAsset } = props;
+    const widget = resolveWidget(field.get('widget'));
+    return React.createElement(widget.preview, {
+      field,
+      key: field.get('name'),
+      value: value && Map.isMap(value) ? value.get(field.get('name')) : value,
+      metadata: fieldsMetaData && fieldsMetaData.get(field.get('name')),
+      getAsset,
+    });
+  };
+
   inferedFields = {};
 
   inferFields() {
@@ -29,18 +41,6 @@ export default class PreviewPane extends React.Component {
     if (authorField) this.inferedFields[authorField] = INFERABLE_FIELDS.author;
   }
 
-  _getWidget = (field, value, props) => {
-    const { fieldsMetaData, getAsset } = props;
-    const widget = resolveWidget(field.get('widget'));
-    return React.createElement(widget.preview, {
-      field,
-      key: field.get('name'),
-      value: value && Map.isMap(value) ? value.get(field.get('name')) : value,
-      metadata: fieldsMetaData && fieldsMetaData.get(field.get('name')),
-      getAsset,
-    });
-  };
-
   widgetFor = (name) => {
     const { fields, entry } = this.props;
     const field = fields.find(f => f.get('name') === name);
@@ -52,7 +52,7 @@ export default class PreviewPane extends React.Component {
       value = <div><strong>{field.get('label')}:</strong> {value}</div>;
     }
 
-    return value ? this._getWidget(field, value, this.props) : null;
+    return value ? this.getWidget(field, value, this.props) : null;
   };
 
   widgetsFor = (name) => {
@@ -63,14 +63,14 @@ export default class PreviewPane extends React.Component {
 
     if (List.isList(value)) {
       return value.map((val, index) => {
-        const widgets = nestedFields && Map(nestedFields.map((f, i) => [f.get('name'), <div key={i}>{this._getWidget(f, val, this.props)}</div>]));
+        const widgets = nestedFields && Map(nestedFields.map((f, i) => [f.get('name'), <div key={i}>{this.getWidget(f, val, this.props)}</div>]));
         return Map({ data: val, widgets });
       });
     }
 
     return Map({
       data: value,
-      widgets: nestedFields && Map(nestedFields.map(f => [f.get('name'), this._getWidget(f, value, this.props)])),
+      widgets: nestedFields && Map(nestedFields.map(f => [f.get('name'), this.getWidget(f, value, this.props)])),
     });
   };
 

--- a/src/components/PreviewPane/PreviewPane.js
+++ b/src/components/PreviewPane/PreviewPane.js
@@ -1,5 +1,6 @@
 import React, { PropTypes } from 'react';
 import ReactDOM from 'react-dom';
+import { Map } from 'immutable';
 import ImmutablePropTypes from 'react-immutable-proptypes';
 import { ScrollSyncPane } from '../ScrollSync';
 import registry from '../../lib/registry';
@@ -50,6 +51,28 @@ export default class PreviewPane extends React.Component {
     });
   };
 
+  widgetsFor = (name) => {
+    const { fields, entry, getAsset } = this.props;
+    const field = fields && fields.find(f => f.get('name') === name);
+    const nestedFields = field && field.get('fields');
+    const values = entry.getIn(['data', field.get('name')]);
+
+    const widgetFor = (field, value) => {
+      const widget = resolveWidget(field.get('widget'));
+      return (<div key={field.get('name')}>{React.createElement(widget.preview, {
+        key: field.get('name'),
+        value: value && value.get(field.get('name')),
+        field,
+        getAsset,
+      })}</div>);
+    };
+
+    return values ? values.map((value, index) => {
+      const widgets = nestedFields && Map(nestedFields.map(f => [f.get('name'), widgetFor(f, value)]));
+      return Map({ data: value, widgets });
+    }) : null;
+  };
+
   handleIframeRef = (ref) => {
     if (ref) {
       registry.getPreviewStyles().forEach((style) => {
@@ -80,7 +103,9 @@ export default class PreviewPane extends React.Component {
     const previewProps = {
       ...this.props,
       widgetFor: this.widgetFor,
+      widgetsFor: this.widgetsFor,
     };
+
     // We need to use this API in order to pass context to the iframe
     ReactDOM.unstable_renderSubtreeIntoContainer(
       this,


### PR DESCRIPTION
**- Summary**

Fixes #236 

Preview templates did not have access to individual nested fields for object and list entries, which limited customization of related preview panes.

**- Test plan**

An `AuthorPreview` template has been added to the example project, and demonstrates this fix in action for a list entry. The existing `GeneralPreview` template has also been updated to utilize the new fix as an example of use with an object entry.

**- Description for the changelog**

Add widgetsFor helper for nested widget access in preview templates

**- A picture of a cute animal (not mandatory but encouraged)**

![baby-turtle-bro](https://cloud.githubusercontent.com/assets/2112202/23624085/77eb84c4-0272-11e7-8967-e587e950d97a.jpg)