### PR TITLE
delete button working

### DIFF
--- a/example/config.yml
+++ b/example/config.yml
@@ -2,7 +2,6 @@ backend:
   name: test-repo
   delay: 0.1
 
-
 media_folder: "assets/uploads"
 
 collections: # A list of collections the CMS should be able to edit

--- a/example/config.yml
+++ b/example/config.yml
@@ -2,7 +2,6 @@ backend:
   name: test-repo
   delay: 0.1
 
-publish_mode: editorial_workflow
 
 media_folder: "assets/uploads"
 

--- a/example/config.yml
+++ b/example/config.yml
@@ -2,6 +2,8 @@ backend:
   name: test-repo
   delay: 0.1
 
+publish_mode: editorial_workflow
+
 media_folder: "assets/uploads"
 
 collections: # A list of collections the CMS should be able to edit

--- a/src/actions/editorialWorkflow.js
+++ b/src/actions/editorialWorkflow.js
@@ -50,7 +50,7 @@ function unpublishedEntryLoading(collection, slug) {
 function unpublishedEntryLoaded(collection, entry) {
   return {
     type: UNPUBLISHED_ENTRY_SUCCESS,
-    payload: {
+    payload: { 
       collection: collection.get('name'),
       entry,
     },
@@ -60,7 +60,7 @@ function unpublishedEntryLoaded(collection, entry) {
 function unpublishedEntryRedirected(collection, slug) {
   return {
     type: UNPUBLISHED_ENTRY_REDIRECT,
-    payload: {
+    payload: { 
       collection: collection.get('name'),
       slug,
     },

--- a/src/actions/editorialWorkflow.js
+++ b/src/actions/editorialWorkflow.js
@@ -270,17 +270,16 @@ export function updateUnpublishedEntryStatus(collection, slug, oldStatus, newSta
     });
   };
 }
-// create deleteUnpublishedEntry
+
 export function deleteUnpublishedEntry(collection, slug) {
   return (dispatch, getState) => {
     const state = getState();
     const backend = currentBackend(state.config);
     const transactionID = uuid.v4();
-    dispatch(unpublishedEntryPublishRequest(collection, slug, transactionID)); //need change?
+    dispatch(unpublishedEntryPublishRequest(collection, slug, transactionID)); 
     backend.deleteUnpublishedEntry(collection, slug)
-    .then((res) => {
-      console.log("Deleted!", res);
-      dispatch(unpublishedEntryPublished(collection, slug, transactionID)); // rename??? - removes card
+    .then(() => {
+      dispatch(unpublishedEntryPublished(collection, slug, transactionID)); 
     })
     .catch((error) => {
       dispatch(notifSend({
@@ -288,7 +287,7 @@ export function deleteUnpublishedEntry(collection, slug) {
         kind: 'danger',
         dismissAfter: 8000,
       }));
-      dispatch(unpublishedEntryPublishError(collection, slug, transactionID)); // rename / do we need this?
+      dispatch(unpublishedEntryPublishError(collection, slug, transactionID)); 
     });
   };
 }
@@ -301,7 +300,7 @@ export function publishUnpublishedEntry(collection, slug) {
     dispatch(unpublishedEntryPublishRequest(collection, slug, transactionID));
     backend.publishUnpublishedEntry(collection, slug)
     .then(() => {
-      dispatch(unpublishedEntryPublished(collection, slug, transactionID)); // remove card
+      dispatch(unpublishedEntryPublished(collection, slug, transactionID)); 
     })
     .catch((error) => {
       dispatch(notifSend({

--- a/src/actions/editorialWorkflow.js
+++ b/src/actions/editorialWorkflow.js
@@ -300,7 +300,7 @@ export function publishUnpublishedEntry(collection, slug) {
     dispatch(unpublishedEntryPublishRequest(collection, slug, transactionID));
     backend.publishUnpublishedEntry(collection, slug)
     .then(() => {
-      dispatch(unpublishedEntryPublished(collection, slug, transactionID)); 
+      dispatch(unpublishedEntryPublished(collection, slug, transactionID));
     })
     .catch((error) => {
       dispatch(notifSend({

--- a/src/actions/editorialWorkflow.js
+++ b/src/actions/editorialWorkflow.js
@@ -106,7 +106,7 @@ function unpublishedEntryPersisting(collection, entry, transactionID) {
 function unpublishedEntryPersisted(collection, entry, transactionID) {
   return {
     type: UNPUBLISHED_ENTRY_PERSIST_SUCCESS,
-    payload: {
+    payload: { 
       collection: collection.get('name'),
       entry,
     },
@@ -125,7 +125,7 @@ function unpublishedEntryPersistedFail(error, transactionID) {
 function unpublishedEntryStatusChangeRequest(collection, slug, oldStatus, newStatus, transactionID) {
   return {
     type: UNPUBLISHED_ENTRY_STATUS_CHANGE_REQUEST,
-    payload: {
+    payload: { 
       collection,
       slug,
       oldStatus,
@@ -138,7 +138,7 @@ function unpublishedEntryStatusChangeRequest(collection, slug, oldStatus, newSta
 function unpublishedEntryStatusChangePersisted(collection, slug, oldStatus, newStatus, transactionID) {
   return {
     type: UNPUBLISHED_ENTRY_STATUS_CHANGE_SUCCESS,
-    payload: {
+    payload: { 
       collection,
       slug,
       oldStatus,
@@ -279,7 +279,7 @@ export function deleteUnpublishedEntry(collection, slug) {
     dispatch(unpublishedEntryPublishRequest(collection, slug, transactionID)); 
     backend.deleteUnpublishedEntry(collection, slug)
     .then(() => {
-      dispatch(unpublishedEntryPublished(collection, slug, transactionID)); 
+      dispatch(unpublishedEntryPublished(collection, slug, transactionID));
     })
     .catch((error) => {
       dispatch(notifSend({

--- a/src/actions/editorialWorkflow.js
+++ b/src/actions/editorialWorkflow.js
@@ -50,7 +50,7 @@ function unpublishedEntryLoading(collection, slug) {
 function unpublishedEntryLoaded(collection, entry) {
   return {
     type: UNPUBLISHED_ENTRY_SUCCESS,
-    payload: { 
+    payload: {
       collection: collection.get('name'),
       entry,
     },
@@ -60,7 +60,7 @@ function unpublishedEntryLoaded(collection, entry) {
 function unpublishedEntryRedirected(collection, slug) {
   return {
     type: UNPUBLISHED_ENTRY_REDIRECT,
-    payload: { 
+    payload: {
       collection: collection.get('name'),
       slug,
     },
@@ -106,7 +106,7 @@ function unpublishedEntryPersisting(collection, entry, transactionID) {
 function unpublishedEntryPersisted(collection, entry, transactionID) {
   return {
     type: UNPUBLISHED_ENTRY_PERSIST_SUCCESS,
-    payload: { 
+    payload: {
       collection: collection.get('name'),
       entry,
     },
@@ -125,7 +125,7 @@ function unpublishedEntryPersistedFail(error, transactionID) {
 function unpublishedEntryStatusChangeRequest(collection, slug, oldStatus, newStatus, transactionID) {
   return {
     type: UNPUBLISHED_ENTRY_STATUS_CHANGE_REQUEST,
-    payload: { 
+    payload: {
       collection,
       slug,
       oldStatus,
@@ -138,7 +138,7 @@ function unpublishedEntryStatusChangeRequest(collection, slug, oldStatus, newSta
 function unpublishedEntryStatusChangePersisted(collection, slug, oldStatus, newStatus, transactionID) {
   return {
     type: UNPUBLISHED_ENTRY_STATUS_CHANGE_SUCCESS,
-    payload: { 
+    payload: {
       collection,
       slug,
       oldStatus,
@@ -270,6 +270,28 @@ export function updateUnpublishedEntryStatus(collection, slug, oldStatus, newSta
     });
   };
 }
+// create deleteUnpublishedEntry
+export function deleteUnpublishedEntry(collection, slug) {
+  return (dispatch, getState) => {
+    const state = getState();
+    const backend = currentBackend(state.config);
+    const transactionID = uuid.v4();
+    dispatch(unpublishedEntryPublishRequest(collection, slug, transactionID)); //need change?
+    backend.deleteUnpublishedEntry(collection, slug)
+    .then((res) => {
+      console.log("Deleted!", res);
+      dispatch(unpublishedEntryPublished(collection, slug, transactionID)); // rename??? - removes card
+    })
+    .catch((error) => {
+      dispatch(notifSend({
+        message: `Failed to close PR: ${ error }`,
+        kind: 'danger',
+        dismissAfter: 8000,
+      }));
+      dispatch(unpublishedEntryPublishError(collection, slug, transactionID)); // rename / do we need this?
+    });
+  };
+}
 
 export function publishUnpublishedEntry(collection, slug) {
   return (dispatch, getState) => {
@@ -279,7 +301,7 @@ export function publishUnpublishedEntry(collection, slug) {
     dispatch(unpublishedEntryPublishRequest(collection, slug, transactionID));
     backend.publishUnpublishedEntry(collection, slug)
     .then(() => {
-      dispatch(unpublishedEntryPublished(collection, slug, transactionID));
+      dispatch(unpublishedEntryPublished(collection, slug, transactionID)); // remove card
     })
     .catch((error) => {
       dispatch(notifSend({

--- a/src/backends/backend.js
+++ b/src/backends/backend.js
@@ -200,6 +200,9 @@ class Backend {
     return this.implementation.publishUnpublishedEntry(collection, slug);
   }
 
+  deleteUnpublishedEntry(collection, slug) {
+    return this.implementation.deleteUnpublishedEntry(collection, slug);
+  }
 
   entryToRaw(collection, entry) {
     const format = resolveFormat(collection, entry.toJS());

--- a/src/backends/github/API.js
+++ b/src/backends/github/API.js
@@ -209,7 +209,7 @@ export default class API {
   persistFiles(entry, mediaFiles, options) {
     const uploadPromises = [];
     const files = mediaFiles.concat(entry);
-    
+
 
     files.forEach((file) => {
       if (file.uploaded) { return; }
@@ -314,6 +314,14 @@ export default class API {
     .then(updatedMetadata => this.storeMetadata(contentKey, updatedMetadata));
   }
 
+  deleteUnpublishedEntry(collection, slug) {
+    const contentKey = slug;
+    let prNumber; // do we need this?
+    return this.retrieveMetadata(contentKey)
+    .then(metadata => this.closePR(metadata.pr, metadata.objects))
+    .then(() => this.deleteBranch(`cms/${ contentKey }`));
+  }
+
   publishUnpublishedEntry(collection, slug) {
     const contentKey = slug;
     let prNumber;
@@ -364,6 +372,21 @@ export default class API {
     return this.request(`${ this.repoURL }/pulls`, {
       method: "POST",
       body: JSON.stringify({ title, body, head, base }),
+    });
+  }
+
+  closePR(pullrequest, objects) {
+    const headSha = pullrequest.head;
+    const prNumber = pullrequest.number;
+    console.log("%c Deleting PR", "line-height: 30px;text-align: center;font-weight: bold"); // eslint-disable-line
+    return this.request(`${ this.repoURL }/pulls/${ prNumber }`, {
+      method: "PATCH",
+      body: JSON.stringify({
+        state: closed,
+      }),
+    })
+    .catch((error) => {
+      throw error;
     });
   }
 

--- a/src/backends/github/API.js
+++ b/src/backends/github/API.js
@@ -316,7 +316,7 @@ export default class API {
 
   deleteUnpublishedEntry(collection, slug) {
     const contentKey = slug;
-    let prNumber; // do we need this?
+    let prNumber; 
     return this.retrieveMetadata(contentKey)
     .then(metadata => this.closePR(metadata.pr, metadata.objects))
     .then(() => this.deleteBranch(`cms/${ contentKey }`));

--- a/src/backends/github/API.js
+++ b/src/backends/github/API.js
@@ -210,7 +210,6 @@ export default class API {
     const uploadPromises = [];
     const files = mediaFiles.concat(entry);
 
-
     files.forEach((file) => {
       if (file.uploaded) { return; }
       uploadPromises.push(this.uploadBlob(file));

--- a/src/backends/github/API.js
+++ b/src/backends/github/API.js
@@ -384,9 +384,6 @@ export default class API {
       body: JSON.stringify({
         state: closed,
       }),
-    })
-    .catch((error) => {
-      throw error;
     });
   }
 

--- a/src/backends/github/API.js
+++ b/src/backends/github/API.js
@@ -209,7 +209,6 @@ export default class API {
   persistFiles(entry, mediaFiles, options) {
     const uploadPromises = [];
     const files = mediaFiles.concat(entry);
-
     files.forEach((file) => {
       if (file.uploaded) { return; }
       uploadPromises.push(this.uploadBlob(file));

--- a/src/backends/github/API.js
+++ b/src/backends/github/API.js
@@ -209,6 +209,8 @@ export default class API {
   persistFiles(entry, mediaFiles, options) {
     const uploadPromises = [];
     const files = mediaFiles.concat(entry);
+    
+
     files.forEach((file) => {
       if (file.uploaded) { return; }
       uploadPromises.push(this.uploadBlob(file));

--- a/src/backends/github/implementation.js
+++ b/src/backends/github/implementation.js
@@ -135,6 +135,9 @@ export default class GitHub {
     return this.api.updateUnpublishedEntryStatus(collection, slug, newStatus);
   }
 
+  deleteUnpublishedEntry(collection, slug) {
+    return this.api.deleteUnpublishedEntry(collection, slug);
+  }
   publishUnpublishedEntry(collection, slug) {
     return this.api.publishUnpublishedEntry(collection, slug);
   }

--- a/src/components/UnpublishedListing/UnpublishedListing.js
+++ b/src/components/UnpublishedListing/UnpublishedListing.js
@@ -22,6 +22,7 @@ class UnpublishedListing extends React.Component {
     const oldStatus = dragProps.ownStatus;
     this.props.handleChangeStatus(collection, slug, oldStatus, newStatus);
   };
+
   requestDelete = (collection, slug, ownStatus) => {
     if (window.confirm('Are you sure you want to delete this entry?')) {
       this.props.handleDelete(collection, slug, ownStatus);

--- a/src/components/UnpublishedListing/UnpublishedListing.js
+++ b/src/components/UnpublishedListing/UnpublishedListing.js
@@ -13,6 +13,7 @@ class UnpublishedListing extends React.Component {
     entries: ImmutablePropTypes.orderedMap,
     handleChangeStatus: PropTypes.func.isRequired,
     handlePublish: PropTypes.func.isRequired,
+    handleDelete: PropTypes.func.isRequired,
   };
 
   handleChangeStatus = (newStatus, dragProps) => {
@@ -21,7 +22,11 @@ class UnpublishedListing extends React.Component {
     const oldStatus = dragProps.ownStatus;
     this.props.handleChangeStatus(collection, slug, oldStatus, newStatus);
   };
-
+  requestDelete = (collection, slug, ownStatus) => {
+    if (window.confirm('Are you sure you want to delete this entry?')) {
+      this.props.handleDelete(collection, slug, ownStatus);
+    }
+  };
   requestPublish = (collection, slug, ownStatus) => {
     if (ownStatus !== status.last()) return;
     if (window.confirm('Are you sure you want to publish this entry?')) {
@@ -82,6 +87,10 @@ class UnpublishedListing extends React.Component {
                       <Link to={link}>
                         <Button>Edit</Button>
                       </Link>
+                      <Button
+                      onClick={this.requestDelete.bind(this, collection, slug, ownStatus)}>
+                        Delete
+                      </Button>
                       {
                         (ownStatus === status.last() && !entry.get('isPersisting', false)) &&
                         <Button

--- a/src/containers/editorialWorkflow/UnpublishedEntriesPanel.js
+++ b/src/containers/editorialWorkflow/UnpublishedEntriesPanel.js
@@ -2,7 +2,12 @@ import React, { Component, PropTypes } from 'react';
 import ImmutablePropTypes from 'react-immutable-proptypes';
 import { OrderedMap } from 'immutable';
 import { connect } from 'react-redux';
-import { loadUnpublishedEntries, updateUnpublishedEntryStatus, publishUnpublishedEntry, deleteUnpublishedEntry } from '../../actions/editorialWorkflow';
+import { 
+  loadUnpublishedEntries,
+  updateUnpublishedEntryStatus,
+  publishUnpublishedEntry,
+  deleteUnpublishedEntry 
+} from '../../actions/editorialWorkflow';
 import { selectUnpublishedEntriesByStatus } from '../../reducers';
 import { EDITORIAL_WORKFLOW, status } from '../../constants/publishModes';
 import UnpublishedListing from '../../components/UnpublishedListing/UnpublishedListing';

--- a/src/containers/editorialWorkflow/UnpublishedEntriesPanel.js
+++ b/src/containers/editorialWorkflow/UnpublishedEntriesPanel.js
@@ -32,7 +32,6 @@ class unpublishedEntriesPanel extends Component {
   }
 
   render() {
-    console.log(this.props);
     const { isEditorialWorkflow, isFetching, unpublishedEntries, updateUnpublishedEntryStatus, publishUnpublishedEntry, deleteUnpublishedEntry } = this.props;
     if (!isEditorialWorkflow) return null;
     if (isFetching) return <Loader active>Loading Editorial Workflow Entries</Loader>;

--- a/src/containers/editorialWorkflow/UnpublishedEntriesPanel.js
+++ b/src/containers/editorialWorkflow/UnpublishedEntriesPanel.js
@@ -31,7 +31,7 @@ class unpublishedEntriesPanel extends Component {
     const { isEditorialWorkflow, isFetching, unpublishedEntries, updateUnpublishedEntryStatus, publishUnpublishedEntry, deleteUnpublishedEntry } = this.props;
     if (!isEditorialWorkflow) return null;
     if (isFetching) return <Loader active>Loading Editorial Workflow Entries</Loader>;
-    // adding function prop here
+   
     return (
       <UnpublishedListing
         entries={unpublishedEntries}

--- a/src/containers/editorialWorkflow/UnpublishedEntriesPanel.js
+++ b/src/containers/editorialWorkflow/UnpublishedEntriesPanel.js
@@ -2,7 +2,7 @@ import React, { Component, PropTypes } from 'react';
 import ImmutablePropTypes from 'react-immutable-proptypes';
 import { OrderedMap } from 'immutable';
 import { connect } from 'react-redux';
-import { loadUnpublishedEntries, updateUnpublishedEntryStatus, publishUnpublishedEntry } from '../../actions/editorialWorkflow';
+import { loadUnpublishedEntries, updateUnpublishedEntryStatus, publishUnpublishedEntry, deleteUnpublishedEntry } from '../../actions/editorialWorkflow';
 import { selectUnpublishedEntriesByStatus } from '../../reducers';
 import { EDITORIAL_WORKFLOW, status } from '../../constants/publishModes';
 import UnpublishedListing from '../../components/UnpublishedListing/UnpublishedListing';
@@ -16,6 +16,7 @@ class unpublishedEntriesPanel extends Component {
     loadUnpublishedEntries: PropTypes.func.isRequired,
     updateUnpublishedEntryStatus: PropTypes.func.isRequired,
     publishUnpublishedEntry: PropTypes.func.isRequired,
+    deleteUnpublishedEntry: PropTypes.func.isRequired,
   };
 
   componentDidMount() {
@@ -26,14 +27,17 @@ class unpublishedEntriesPanel extends Component {
   }
 
   render() {
-    const { isEditorialWorkflow, isFetching, unpublishedEntries, updateUnpublishedEntryStatus, publishUnpublishedEntry } = this.props;
+    console.log(this.props);
+    const { isEditorialWorkflow, isFetching, unpublishedEntries, updateUnpublishedEntryStatus, publishUnpublishedEntry, deleteUnpublishedEntry } = this.props;
     if (!isEditorialWorkflow) return null;
     if (isFetching) return <Loader active>Loading Editorial Workflow Entries</Loader>;
+    // adding function prop here
     return (
       <UnpublishedListing
         entries={unpublishedEntries}
         handleChangeStatus={updateUnpublishedEntryStatus}
         handlePublish={publishUnpublishedEntry}
+        handleDelete={deleteUnpublishedEntry}
       />
     );
   }
@@ -62,4 +66,5 @@ export default connect(mapStateToProps, {
   loadUnpublishedEntries,
   updateUnpublishedEntryStatus,
   publishUnpublishedEntry,
+  deleteUnpublishedEntry,
 })(unpublishedEntriesPanel);


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines;
https://github.com/netlify/netlify-cms/blob/master/CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first three fields are mandatory:
-->

**- Summary**

Added the basic functionality (via a button) to delete a card from the editorial workflow. It also closes the related PR via GitHub API. It mirrors the request publish functionality. This was created to address issue #252.
<!--
Explain the **motivation** for making this change.
What existing problem does the pull request solve?
-->

**- Test plan**

Added cms to an existing statically generated site. Deleted(which closed related PRs) cards using the new button in all columns of the editorial workflow. (Note this could not be tested in the local example as discussed in issue #264.) Also checked that the cards remained deletable without error if the corresponding PR had been closed independently on github prior to use of the delete button. Attached gifs below: 

First gif demonstrates deleting cards from all rows and resulting PRs closed: 

![delete_button_works](https://cloud.githubusercontent.com/assets/16258690/23813163/8e769666-05ab-11e7-97ad-d92176a46a47.gif)

Second gif demonstrates a previously closed PR in which the card still deletes without error: 

![card_deletes_when_pr_closed](https://cloud.githubusercontent.com/assets/16258690/23813167/940326c6-05ab-11e7-8ca3-2150b345c714.gif)

<!--
Demonstrate the code is solid.
Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.
-->

**- Description for the changelog**

Adds a delete button to the editorial workflow. 
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

**- A picture of a cute animal (not mandatory but encouraged)**

*My dog wearing antlers for xmas* 

![15590495_10101285005680159_7556777379988619321_n](https://cloud.githubusercontent.com/assets/16258690/23813217/ca2ecf7a-05ab-11e7-9deb-71bd915c5af4.jpg)
