### PR TITLE
Disallow full stops in entry slugs

### DIFF
--- a/src/backends/backend.js
+++ b/src/backends/backend.js
@@ -34,7 +34,7 @@ const slugFormatter = (template = "{{slug}}", entryData) => {
       case "day":
         return (`0${ date.getDate() }`).slice(-2);
       case "slug":
-        return identifier.trim().toLowerCase().replace(/[^a-z0-9\.\-_]+/gi, "-");
+        return identifier.trim().toLowerCase().replace(/[^a-z0-9\-_]+/gi, "-");
       default:
         return entryData.get(field, "").trim().toLowerCase().replace(/[^a-z0-9\.\-_]+/gi, "-");
     }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines;
https://github.com/netlify/netlify-cms/blob/master/CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first three fields are mandatory:
-->

**- Summary**

Full stops in slugs were preventing branch creation for unpublished
entries when using the editorial workflow, as `.` is not an allowed
character in branch names. This commit changes slug generation so
periods are replaced with `-` the same way other "non-sluggable"
characters are.

Closes #275.

<!--
Explain the **motivation** for making this change.
What existing problem does the pull request solve?
-->

**- Test plan**

Tested manually (no current automated test setup exists for the editorial workflow, due to its dependence on the GitHub API)

**- Description for the changelog**

- **Disallow full stops in entry slugs**

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

![image](https://cloud.githubusercontent.com/assets/1425133/23921672/bc76c220-08bc-11e7-896a-b95ffc5eb342.png)
