### PR TITLE
Fix firefox fetch issue in GitHub API

### DIFF
--- a/src/backends/github/API.js
+++ b/src/backends/github/API.js
@@ -142,7 +142,7 @@ export default class API {
       return this.request(`${ this.repoURL }/contents/${ path }`, {
         headers: { Accept: "application/vnd.github.VERSION.raw" },
         params: { ref: branch },
-        cache: false,
+        cache: "no-store",
       }).then((result) => {
         if (sha) {
           LocalForage.setItem(`gh.${ sha }`, result);


### PR DESCRIPTION
Firefox 52 gives an error:

```
Failed to load entry: 'cache' member of RequestInit 'false' is not a valid value for enumeration RequestCache.
```

When calling fetch with `cache: false` as an option.

Change this to `cache: no-store`
