### PR TITLE
improve entry editor UI

### DIFF
--- a/src/components/ControlPanel/ControlPane.css
+++ b/src/components/ControlPanel/ControlPane.css
@@ -1,3 +1,5 @@
+@import "../UI/theme";
+
 .control {
   color: #7c8382;
   position: relative;
@@ -9,12 +11,13 @@
     font-family: monospace;
     display: block;
     width: 100%;
-    padding: 12px 0 10px 0;
+    padding: 12px;
     margin: 0;
     border: none;
+    border-radius: var(--borderRadius);
     outline: 0;
     box-shadow: none;
-    background: 0 0;
+    background-color: var(--controlBGColor);
     font-size: 18px;
     color: #7c8382;
   }
@@ -22,8 +25,8 @@
 
 .label {
   display: block;
-  color: #AAB0AF;
-  font-size: 12px;
+  color: var(--controlLabelColor);
+  font-size: 14px;
 }
 
 .labelWithError {
@@ -36,32 +39,4 @@
   font-size: 10px;
   color: #FF706F;
   margin-bottom: 5px;
-}
-
-.widget {
-  border-bottom: 1px solid #e8eae8;
-  position: relative;
-
-  &:after {
-    content: '';
-    position: absolute;
-    left: 42px;
-    bottom: -7px;
-    width: 12px;
-    height: 12px;
-    background-color: #f2f5f4;
-    -webkit-transform: rotate(45deg);
-    transform: rotate(45deg);
-    z-index: 1;
-    border-right: 1px solid #e8eae8;
-    border-bottom: 1px solid #e8eae8;
-  }
-
-  &:last-child {
-    border-bottom: none;
-  }
-
-  &:last-child:after {
-    display: none;
-  }
 }

--- a/src/components/EntryEditor/EntryEditor.css
+++ b/src/components/EntryEditor/EntryEditor.css
@@ -5,6 +5,7 @@
   overflow: auto;
   padding: 0 20px;
   border-right: 1px solid var(--defaultColorLight);
+  background-color: color(#f2f5f4 lightness(90%));
 }
 
 .previewPane {

--- a/src/components/UI/theme.css
+++ b/src/components/UI/theme.css
@@ -14,6 +14,8 @@
   --textFieldBorderColor: #e7e7e7;
   --highlightFGColor: #fff;
   --highlightBGColor: #3ab7a5;
+  --controlLabelColor: #272e30;
+  --controlBGColor: #fff;
 }
 
 .base {

--- a/src/components/Widgets/ListControl.css
+++ b/src/components/Widgets/ListControl.css
@@ -1,55 +1,66 @@
+@import "../UI/theme";
+
 :global(.list-item-dragging) {
   opacity: 0.5;
 }
 
 .addButton {
-  display: block;
+  display: flex;
+  justify-content: center;
+  align-items: center;
   cursor: pointer;
-  margin: 20px 0;
-  border: none;
-  background: transparent;
-  &::before {
-    content: "+";
-    display: inline-block;
-    margin-right: 5px;
-    width: 15px;
-    height: 15px;
-    border: 1px solid #444;
-    border-radius: 100%;
-    background: transparent;
-    line-height: 13px;
-  }
+  margin-top: 20px;
+  padding: 8px;
+  border: 0;
+  border-radius: var(--borderRadius);
+  background-color: var(--controlBGColor);
+}
+
+.addButtonIcon {
+  font-size: 18px;
+}
+
+.addButtonText {
+  margin-left: 4px;
 }
 
 .removeButton {
   position: absolute;
-  top: 5px;
-  right: 5px;
-  display: inline-block;
+  top: 2px;
+  right: 2px;
   cursor: pointer;
-  border: none;
-  background: transparent;
-  width: 15px;
-  height: 15px;
-  border: 1px solid #444;
-  border-radius: 100%;
-  line-height: 13px;
+  display: flex;
+  align-items: center;
+  padding: 0 0 2px 2px;
+  border: 0;
+  background: none;
+  z-index: 1;
 }
 
 .toggleButton {
   position: absolute;
-  top: 5px;
-  left: 5px;
+  top: 0;
+  left: 0;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  height: 28px;
+  border: none;
+  border-radius: var(--borderRadius) 0 0 var(--borderRadius);
+  background: rgba(0,0,0,0.1);
 }
 
 .item {
   position: relative;
-  padding-left: 20px;
+  padding-left: 24px;
   cursor: move;
 }
 
 .objectLabel {
-  border: 1px solid #e8eae8;
+  border: 2px solid rgba(0,0,0,0.1);
+  border-top-width: 28px;
+  border-radius: var(--borderRadius);
+  border-top-left-radius: 0;
   margin-bottom: 20px;
   padding: 20px;
   display: none;
@@ -57,6 +68,8 @@
 
 .objectControl {
   display: block;
+  border-top: 28px solid rgba(0,0,0,0.1);
+  border-top-left-radius: 0;
 }
 
 .expanded {
@@ -69,4 +82,12 @@
   & .objectControl {
     display: none;
   }
+}
+
+.dragIcon {
+  position: absolute;
+  top: 2px;
+  display: block;
+  width: 100%;
+  text-align: center;
 }

--- a/src/components/Widgets/ListControl.js
+++ b/src/components/Widgets/ListControl.js
@@ -1,6 +1,7 @@
 import React, { Component, PropTypes } from 'react';
 import { List, Map, fromJS } from 'immutable';
 import { sortable } from 'react-sortable';
+import FontIcon from 'react-toolbox/lib/font_icon';
 import ObjectControl from './ObjectControl';
 import styles from './ListControl.css';
 
@@ -143,21 +144,23 @@ export default class ListControl extends Component {
       outline="list"
     >
       <div className={classNames.join(' ')}>
-        <div className={styles.objectLabel}>{this.objectLabel(item)}</div>
-        <div className={styles.objectControl}>
-          <ObjectControl
-            value={item}
-            field={field}
-            onChange={this.handleChangeFor(index)}
-            getAsset={getAsset}
-            onAddAsset={onAddAsset}
-            onRemoveAsset={onRemoveAsset}
-          />
-        </div>
         <button className={styles.toggleButton} onClick={this.handleToggle(index)}>
-          {collapsed ? '+' : '-'}
+          <FontIcon value={collapsed ? 'expand_more' : 'expand_less'} />
         </button>
-        <button className={styles.removeButton} onClick={this.handleRemove(index)}>x</button>
+        <FontIcon value="drag_handle" className={styles.dragIcon} />
+        <button className={styles.removeButton} onClick={this.handleRemove(index)}>
+          <FontIcon value="close" />
+        </button>
+        <div className={styles.objectLabel}>{this.objectLabel(item)}</div>
+        <ObjectControl
+          value={item}
+          field={field}
+          className={styles.objectControl}
+          onChange={this.handleChangeFor(index)}
+          getAsset={getAsset}
+          onAddAsset={onAddAsset}
+          onRemoveAsset={onRemoveAsset}
+        />
       </div>
     </SortableListItem>);
   }
@@ -166,7 +169,10 @@ export default class ListControl extends Component {
     const { value, forID } = this.props;
     return (<div id={forID}>
       {value && value.map((item, index) => this.renderItem(item, index))}
-      <div><button className={styles.addButton} onClick={this.handleAdd}>new</button></div>
+      <button className={styles.addButton} onClick={this.handleAdd}>
+        <FontIcon value="add" className={styles.addButtonIcon} />
+        <span className={styles.addButtonText}>new</span>
+      </button>
     </div>);
   }
 

--- a/src/components/Widgets/MarkdownControlElements/VisualEditor/index.css
+++ b/src/components/Widgets/MarkdownControlElements/VisualEditor/index.css
@@ -1,3 +1,5 @@
+@import "../../../UI/theme";
+
 .editor {
   position: relative;
   & h1, & h2, & h3 {
@@ -57,6 +59,9 @@
 :global {
   & .ProseMirror {
     position: relative;
+    background-color: var(--controlBGColor);
+    padding: 12px;
+    border-radius: var(--borderRadius);
   }
 
   & .ProseMirror-content {

--- a/src/components/Widgets/ObjectControl.css
+++ b/src/components/Widgets/ObjectControl.css
@@ -1,6 +1,9 @@
+@import "../UI/theme";
+
 .root {
   position: relative;
-  border: 1px solid #e8eae8;
+  border: 2px solid rgba(0,0,0,0.1);
+  border-radius: var(--borderRadius);
   margin-bottom: 20px;
-  padding: 20px;
+  padding: 0 20px 12px;
 }

--- a/src/components/Widgets/ObjectControl.js
+++ b/src/components/Widgets/ObjectControl.js
@@ -8,10 +8,12 @@ export default class ObjectControl extends Component {
   static propTypes = {
     onChange: PropTypes.func.isRequired,
     onAddAsset: PropTypes.func.isRequired,
+    onRemoveAsset: PropTypes.func.isRequired,
     getAsset: PropTypes.func.isRequired,
     value: PropTypes.node,
     field: PropTypes.object,
     forID: PropTypes.string.isRequired,
+    className: PropTypes.string,
   };
 
   controlFor(field) {
@@ -21,9 +23,10 @@ export default class ObjectControl extends Component {
 
     return (<div className={controlStyles.widget} key={field.get('name')}>
       <div className={controlStyles.control} key={field.get('name')}>
-        <label className={controlStyles.label}>{field.get('label')}</label>
+        <label className={controlStyles.label} htmlFor={field.get('name')}>{field.get('label')}</label>
         {
           React.createElement(widget.control, {
+            id: field.get('name'),
             field,
             value: fieldValue,
             onChange: (val, metadata) => {
@@ -42,10 +45,11 @@ export default class ObjectControl extends Component {
     const { field, forID } = this.props;
     const multiFields = field.get('fields');
     const singleField = field.get('field');
+    const className = this.props.className || '';
 
     if (multiFields) {
-      return (<div id={forID} className={styles.root}>
-        {multiFields.map(field => this.controlFor(field))}
+      return (<div id={forID} className={`${ className } ${ styles.root }`}>
+        {multiFields.map(f => this.controlFor(f))}
       </div>);
     } else if (singleField) {
       return this.controlFor(singleField);


### PR DESCRIPTION
Fixes #257, improves various rough bits in the entry editor UI. Tested with Smashing's setup.

* Improved contrast (no more white against very light gray)
* Replaced text based icons with icon font
* Increased label sizes
* Form controls have white background for clarity
* Provided a visual "drag bar" - even though entire list objects are draggable, this helps make that discoverable and should reduce confusion
* Other basic finishing

<img width="706" alt="screen shot 2017-03-15 at 2 34 11 pm" src="https://cloud.githubusercontent.com/assets/2112202/23965063/29b86732-098d-11e7-8792-01553363ab56.png">
