### PR TITLE
Confirm navigation when it would discard unsaved changes

### DIFF
--- a/src/containers/EntryPage.js
+++ b/src/containers/EntryPage.js
@@ -1,6 +1,7 @@
 import React, { PropTypes } from 'react';
 import ImmutablePropTypes from 'react-immutable-proptypes';
 import { connect } from 'react-redux';
+import history from '../routing/history';
 import {
   loadEntry,
   createDraftFromEntry,
@@ -49,6 +50,13 @@ class EntryPage extends React.Component {
     } else {
       loadEntry(collection, slug);
     }
+
+    this.unlisten = history.listenBefore((location) => {
+      if (this.props.entryDraft.get('hasChanged')) {
+        return "Are you sure you want to leave this page?";
+      }
+      return true;
+    });
   }
 
   componentWillReceiveProps(nextProps) {
@@ -63,6 +71,7 @@ class EntryPage extends React.Component {
 
   componentWillUnmount() {
     this.props.discardDraft();
+    this.unlisten();
   }
 
   createDraft = (entry) => {

--- a/src/reducers/__tests__/entryDraft.spec.js
+++ b/src/reducers/__tests__/entryDraft.spec.js
@@ -2,7 +2,13 @@ import { Map, List, fromJS } from 'immutable';
 import * as actions from '../../actions/entries';
 import reducer from '../entryDraft';
 
-let initialState = Map({ entry: Map(), mediaFiles: List(), fieldsMetaData: Map(), fieldsErrors: Map() });
+let initialState = Map({
+  entry: Map(),
+  mediaFiles: List(),
+  fieldsMetaData: Map(),
+  fieldsErrors: Map(),
+  hasChanged: false,
+});
 
 const entry = {
   collection: 'posts',
@@ -31,6 +37,7 @@ describe('entryDraft reducer', () => {
           mediaFiles: [],
           fieldsMetaData: Map(),
           fieldsErrors: Map(),
+          hasChanged: false,
         })
       );
     });
@@ -52,6 +59,7 @@ describe('entryDraft reducer', () => {
           mediaFiles: [],
           fieldsMetaData: Map(),
           fieldsErrors: Map(),
+          hasChanged: false,
         })
       );
     });
@@ -77,6 +85,7 @@ describe('entryDraft reducer', () => {
             raw: 'updated',
           },
           mediaFiles: [],
+          hasChanged: true,
         }));
     });
   });

--- a/src/reducers/entryDraft.js
+++ b/src/reducers/entryDraft.js
@@ -19,7 +19,13 @@ import {
   REMOVE_ASSET,
 } from '../actions/media';
 
-const initialState = Map({ entry: Map(), mediaFiles: List(), fieldsMetaData: Map(), fieldsErrors: Map() });
+const initialState = Map({
+  entry: Map(),
+  mediaFiles: List(),
+  fieldsMetaData: Map(),
+  fieldsErrors: Map(),
+  hasChanged: false,
+});
 
 const entryDraftReducer = (state = Map(), action) => {
   switch (action.type) {
@@ -47,6 +53,7 @@ const entryDraftReducer = (state = Map(), action) => {
       return state.withMutations((state) => {
         state.setIn(['entry', 'data', action.payload.field], action.payload.value);
         state.mergeIn(['fieldsMetaData'], fromJS(action.payload.metadata));
+        state.set('hasChanged', true);
       });
     
     case DRAFT_VALIDATION_ERRORS:


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines;
https://github.com/netlify/netlify-cms/blob/master/CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first three fields are mandatory:
-->

**- Summary**

- New state field: `state.entryDraft.hasChanged`, initialized to `false`.

- `state.entryDraft.hasChanged` set to `true` in `entryDraft` reducer for `DRAFT_CHANGE_FIELD`.

- `EntryPage` adds a `listenBefore` listener to `history` on `componentDidMount` that checks `this.props.entryDraft.hasChanged` and, if that is true, asks the user to confirm the navigation.

- `EntryPage` removes its listener on `componentWillUnmount`.

Closes #249.

<!--
Explain the **motivation** for making this change.
What existing problem does the pull request solve?
-->

**- Test plan**

Tested manually and added `hasChanged` attribute to relevant tests in `src/reducers/__tests__/entryDraft.spec.js`

<!--
Demonstrate the code is solid.
Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.
-->

**- Description for the changelog**

- **Confirm navigation when it would discard unsaved changes**

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

**- A picture of a cute animal (not mandatory but encouraged)**

![image](https://cloud.githubusercontent.com/assets/1425133/23971597/d32e56ac-098b-11e7-9fe0-20f2e2602861.png)
