### PR TITLE
Adding close preview feature

### DIFF
--- a/src/components/EntryEditor/EntryEditor.css
+++ b/src/components/EntryEditor/EntryEditor.css
@@ -5,10 +5,17 @@
   height: 100%;
 }
 
+.previewToggle {
+  position: absolute;
+  top: 0;
+  right: 40px;
+  z-index: 1000;
+}
+
 .controlPane {
   height: calc(100% - 55px);
   overflow: auto;
-  padding: 0 20px;
+  padding: 20px 20px 0;
   border-right: 1px solid var(--defaultColorLight);
   background-color: color(#f2f5f4 lightness(90%));
 }

--- a/src/components/EntryEditor/EntryEditor.js
+++ b/src/components/EntryEditor/EntryEditor.js
@@ -8,12 +8,12 @@ import PreviewPane from '../PreviewPane/PreviewPane';
 import Toolbar from './EntryEditorToolbar';
 import styles from './EntryEditor.css';
 
-const PREVIEW_HIDE = 'cms.preview-state';
+const PREVIEW_VISIBLE = 'cms.preview-visible';
 
 class EntryEditor extends Component {
   state = {
     showEventBlocker: false,
-    previewOpen: localStorage.getItem(PREVIEW_HIDE) === "false",
+    previewVisible: localStorage.getItem(PREVIEW_VISIBLE) !== "false",
   };
 
   handleSplitPaneDragStart = () => {
@@ -30,12 +30,9 @@ class EntryEditor extends Component {
   };
 
   handleTogglePreview = () => {
-    const { previewOpen } = this.state;
-    const newPreviewState = !previewOpen ? "false" : "true";
-    this.setState(
-      { previewOpen: !previewOpen },
-      localStorage.setItem(PREVIEW_HIDE, newPreviewState)
-    );
+    const newPreviewVisible = !this.state.previewVisible;
+    this.setState({ previewVisible: newPreviewVisible });
+    localStorage.setItem(PREVIEW_VISIBLE, newPreviewVisible);
   };
 
   render() {
@@ -53,13 +50,12 @@ class EntryEditor extends Component {
         onCancelEdit,
     } = this.props;
 
-    const { previewOpen } = this.state;
     const controlClassName = `${ styles.controlPane } ${ this.state.showEventBlocker && styles.blocker }`;
     const previewClassName = `${ styles.previewPane } ${ this.state.showEventBlocker && styles.blocker }`;
 
     const editor = (
       <div className={controlClassName}>
-        <Button onClick={this.handleTogglePreview}>TOGGLE PREVIEW</Button>
+        <Button className={styles.previewToggle} onClick={this.handleTogglePreview}>Toggle Preview</Button>
         <ControlPane
           collection={collection}
           entry={entry}
@@ -84,9 +80,7 @@ class EntryEditor extends Component {
             onDragStarted={this.handleSplitPaneDragStart}
             onDragFinished={this.handleSplitPaneDragFinished}
           >
-            <ScrollSyncPane>
-              {editor}
-            </ScrollSyncPane>
+            <ScrollSyncPane>{editor}</ScrollSyncPane>
             <div className={previewClassName}>
               <PreviewPane
                 collection={collection}
@@ -100,9 +94,10 @@ class EntryEditor extends Component {
         </div>
       </ScrollSync>
     );
+
     return (
       <div className={styles.root}>
-        {previewOpen === true ? editorWithPreview : editor}
+        { this.state.previewVisible ? editorWithPreview : editor }
         <div className={styles.footer}>
           <Toolbar
             isPersisting={entry.get('isPersisting')}

--- a/src/components/EntryEditor/EntryEditor.js
+++ b/src/components/EntryEditor/EntryEditor.js
@@ -8,12 +8,12 @@ import PreviewPane from '../PreviewPane/PreviewPane';
 import Toolbar from './EntryEditorToolbar';
 import styles from './EntryEditor.css';
 
-const PREVIEW_STATE = 'cms.preview-state';
+const PREVIEW_HIDE = 'cms.preview-state';
 
 class EntryEditor extends Component {
   state = {
     showEventBlocker: false,
-    previewOpen: localStorage.getItem(PREVIEW_STATE) === "open",
+    previewOpen: localStorage.getItem(PREVIEW_HIDE) === "false",
   };
 
   handleSplitPaneDragStart = () => {
@@ -31,10 +31,10 @@ class EntryEditor extends Component {
 
   handleTogglePreview = () => {
     const { previewOpen } = this.state;
-    const newPreviewState = !previewOpen ? "open" : "closed";
+    const newPreviewState = !previewOpen ? "false" : "true";
     this.setState(
       { previewOpen: !previewOpen },
-      localStorage.setItem(PREVIEW_STATE, newPreviewState)
+      localStorage.setItem(PREVIEW_HIDE, newPreviewState)
     );
   };
 
@@ -59,7 +59,7 @@ class EntryEditor extends Component {
 
     const editor = (
       <div className={controlClassName}>
-        <Button onClick={this.handleTogglePreview}> TOGGLE PREVIEW </Button>
+        <Button onClick={this.handleTogglePreview}>TOGGLE PREVIEW</Button>
         <ControlPane
           collection={collection}
           entry={entry}
@@ -76,7 +76,7 @@ class EntryEditor extends Component {
       </div>
     );
 
-    const editorWithPreivew = (
+    const editorWithPreview = (
       <ScrollSync>
         <div className={styles.container}>
           <SplitPane
@@ -102,7 +102,7 @@ class EntryEditor extends Component {
     );
     return (
       <div className={styles.root}>
-        {previewOpen === true ? editorWithPreivew : editor}
+        {previewOpen === true ? editorWithPreview : editor}
         <div className={styles.footer}>
           <Toolbar
             isPersisting={entry.get('isPersisting')}


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines;
https://github.com/netlify/netlify-cms/blob/master/CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first three fields are mandatory:
-->

**- Summary**

Added the basic functionality (via a button) to hide/show the preview panel in the Entry Editor.  It mirrors the request publish functionality. This was created to address issue #113. (*Note that it deals with the second level of integration @calavera mentioned in his most recent comment on the issue.*)
<!--
Explain the **motivation** for making this change.
What existing problem does the pull request solve?
-->

**- Test plan**

Tested code using the local "example" page. Added button(s) which call a function which toggles the state (*added to code as 'previewOpen'*). Added a showOnlyEditor, which displays the editor fullscreen without the preview. Depending on the status of this.state.previewOpen (*boolean*) the main render function displays either the original JSX or calls the showOnlyEditor. Attached gif below demonstrates its functionality: 

![close_preview_pane](https://cloud.githubusercontent.com/assets/16258690/24077541/cdc2a694-0c26-11e7-9f9d-d6b6df471ae9.gif)

(*Note: Different styling maybe needed but css is not my strong-suit, and I was having some issues using the linked styles file. Would appreciate further direction or having someone with artistic ability step in on this part.*)
<!--
Demonstrate the code is solid.
Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.
-->

**- Description for the changelog**

Adds a Button allowing the preview pane to be toggled opened & closed. 
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

**- A picture of a cute animal (not mandatory but encouraged)**
*Same dog as last PR, different headgear.*
![17191209_10101370520941889_309415902569031369_n](https://cloud.githubusercontent.com/assets/16258690/24077561/7e176e9e-0c27-11e7-9e45-79f1f6172f04.jpg)

