### PR TITLE
fix preview pane height in Safari

### DIFF
--- a/src/components/EntryEditor/EntryEditor.css
+++ b/src/components/EntryEditor/EntryEditor.css
@@ -1,5 +1,10 @@
 @import '../UI/theme';
 
+/* Quick fix for preview pane not fully displaying in Safari */
+:global(.SplitPane .Pane) {
+  height: 100%;
+}
+
 .controlPane {
   height: calc(100% - 55px);
   overflow: auto;


### PR DESCRIPTION
Fixes #304