### PR TITLE
Enable sourcemaps

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Netlify CMS lets content editors work on structured content stored in git",
   "main": "dist/cms.js",
   "scripts": {
-    "start": "webpack-dev-server --config webpack.dev.js",
+    "start": "webpack-dev-server -d --config webpack.dev.js",
     "test": "jest",
     "test:watch": "jest --watch",
     "build": "NODE_ENV=production webpack --config webpack.prod.js",


### PR DESCRIPTION
**- Summary**
It'd be nice to have sourcemaps switched on by default for development

**- Description for the changelog**
- turned on `-d` debug mode for webpack-dev-server cli client

![image](https://cloud.githubusercontent.com/assets/1188186/24634021/95b82806-18c3-11e7-83f1-5b1ad74b1a59.png)

