### PR TITLE
added support for listing files in nested directories

### DIFF
--- a/src/containers/EntryPage.js
+++ b/src/containers/EntryPage.js
@@ -132,7 +132,7 @@ class EntryPage extends React.Component {
 
 function mapStateToProps(state, ownProps) {
   const { collections, entryDraft } = state;
-  const slug = ownProps.params.slug;
+  const slug = ownProps.params.slug + ownProps.params.splat; // we append splat for the case we're dealing with a nested folder
   const collection = collections.get(ownProps.params.name);
   const newEntry = ownProps.route && ownProps.route.newRecord === true;
   const fields = selectFields(collection, slug);

--- a/src/reducers/collections.js
+++ b/src/reducers/collections.js
@@ -46,7 +46,7 @@ const selectors = {
       return `${ collection.get('folder') }/${ slug }.${ this.entryExtension(collection) }`;
     },
     entrySlug(collection, path) {
-      return path.split('/').pop().replace(/\.[^\.]+$/, '');
+      return path.replace(collection.get('folder'), "").replace(/\.[^.]+$/, '').replace(/^\//, '');
     },
     listMethod() {
       return 'entriesByFolder';
@@ -117,7 +117,7 @@ export const selectInferedField = (collection, fieldName) => {
   if (inferableField.showError) {
     consoleError(
       `The Field ${ fieldName } is missing for the collection “${ collection.get('name') }”`,
-      `Netlify CMS tries to infer the entry ${ fieldName } automatically, but one couldn\'t be found for entries of the collection “${ collection.get('name') }”. Please check your site configuration.`
+      `Netlify CMS tries to infer the entry ${ fieldName } automatically, but one couldn't be found for entries of the collection “${ collection.get('name') }”. Please check your site configuration.`
     );
   }
 

--- a/src/routing/routes.js
+++ b/src/routing/routes.js
@@ -20,7 +20,7 @@ export default (
       newRecord
     />
     <Route
-      path="/collections/:name/entries/:slug"
+      path="/collections/:name/entries/:slug*"
       component={EntryPage}
     />
     <Route


### PR DESCRIPTION
*known limitation* 
currently, only allows the listing of collections which have nested files (and stops silent errors occurring as a result of attempting to do so). When trying to edit a nested file, a "file not found" error appears.

Ability to list relates to #313  in that now there is no silent error and the nested files are shown. I don't anticipate that adding the ability to edit those nested files would be too difficult, but don't know when Ill be able to get around to doing so as its not a requirement for our current project.

And - of course - a cute animal inclusion:

![tikki](https://cloud.githubusercontent.com/assets/1424445/24639125/7f357488-18bb-11e7-8b19-1eda9979e897.jpg)
