### PR TITLE
Stop showing loader forever when there are no entries

### DIFF
--- a/src/containers/CollectionPage.css
+++ b/src/containers/CollectionPage.css
@@ -1,0 +1,10 @@
+.noEntries {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  margin: 0px;
+  text-align: center;
+  z-index: 1000;
+  transform: translateX(-50%) translateY(-50%);
+  margin-top: 28px;
+}

--- a/src/containers/CollectionPage.js
+++ b/src/containers/CollectionPage.js
@@ -5,6 +5,7 @@ import { loadEntries } from '../actions/entries';
 import { selectEntries } from '../reducers';
 import { Loader } from '../components/UI';
 import EntryListing from '../components/EntryListing/EntryListing';
+import styles from "./CollectionPage.css";
 
 class CollectionPage extends React.Component {
 
@@ -15,6 +16,7 @@ class CollectionPage extends React.Component {
     dispatch: PropTypes.func.isRequired,
     page: PropTypes.number,
     entries: ImmutablePropTypes.list,
+    isFetching: PropTypes.bool.isRequired,
   };
 
   componentDidMount() {
@@ -37,25 +39,28 @@ class CollectionPage extends React.Component {
   };
 
   render() {
-    const { collections, collection, publicFolder, page, entries } = this.props;
+    const { collections, collection, publicFolder, page, entries, isFetching } = this.props;
     if (collections == null) {
       return <h1>No collections defined in your config.yml</h1>;
     }
-    return (<div>
-      {entries ?
-        <EntryListing
-          collections={collection}
-          entries={entries}
-          publicFolder={publicFolder}
-          page={page}
-          onPaginate={this.handleLoadMore}
-        >
-          {collection.get('label')}
-        </EntryListing>
-        :
-        <Loader active>{['Loading Entries', 'Caching Entries', 'This might take several minutes']}</Loader>
-      }
-    </div>);
+
+    const entriesContent = (<EntryListing
+      collections={collection}
+      entries={entries}
+      publicFolder={publicFolder}
+      page={page}
+      onPaginate={this.handleLoadMore}
+    >
+      {collection.get('label')}
+    </EntryListing>);
+
+    const fetchingEntriesContent = (<Loader active>
+        {['Loading Entries', 'Caching Entries', 'This might take several minutes']}
+    </Loader>);
+    const noEntriesContent = <div className={styles.noEntries}>No Entries</div>;
+    const fallbackContent = isFetching ? fetchingEntriesContent : noEntriesContent;
+
+    return (<div>{entries ? entriesContent : fallbackContent}</div>);
   }
 }
 
@@ -68,8 +73,9 @@ function mapStateToProps(state, ownProps) {
   const page = state.entries.getIn(['pages', collection.get('name'), 'page']);
 
   const entries = selectEntries(state, collection.get('name'));
+  const isFetching = state.entries.getIn(['pages', collection.get('name'), 'isFetching'], false);
 
-  return { slug, publicFolder, collection, collections, page, entries };
+  return { slug, publicFolder, collection, collections, page, entries, isFetching };
 }
 
 export default connect(mapStateToProps)(CollectionPage);

--- a/src/reducers/entries.js
+++ b/src/reducers/entries.js
@@ -5,6 +5,7 @@ import {
   ENTRY_FAILURE,
   ENTRIES_REQUEST,
   ENTRIES_SUCCESS,
+  ENTRIES_FAILURE,
 } from '../actions/entries';
 
 import { SEARCH_ENTRIES_SUCCESS } from '../actions/search';
@@ -42,7 +43,10 @@ const entries = (state = Map({ entities: Map(), pages: Map() }), action) => {
           ids: (!page || page === 0) ? ids : map.getIn(['pages', collection, 'ids'], List()).concat(ids),
         }));
       });
-    
+
+    case ENTRIES_FAILURE:
+      return state.setIn(['pages', action.meta.collection, 'isFetching'], false);
+
     case ENTRY_FAILURE:
       return state.withMutations((map) => {
         map.setIn(['entities', `${ action.payload.collection }.${ action.payload.slug }`, 'isFetching'], false);


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines;
https://github.com/netlify/netlify-cms/blob/master/CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first three fields are mandatory:
-->

**- Summary**

Stop showing the loading spinner on the collection page when there are no entries. Closes https://github.com/netlify/netlify-cms/issues/269.

<!--
Explain the **motivation** for making this change.
What existing problem does the pull request solve?
-->

**- Test plan**

Existing test suite passes. Changes are mostly cosmetic.

<!--
Demonstrate the code is solid.
Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.
-->

**- Description for the changelog**

Stop showing the loading spinner on the collection page when there are no entries.

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

**- A picture of a cute animal (not mandatory but encouraged)**

![image](https://cloud.githubusercontent.com/assets/1425133/24680347/6fc935ea-1945-11e7-8c1e-0397861b946c.png)
