### PR TITLE
Cleanup `resolvePromiseProperties`

### DIFF
--- a/src/lib/promiseHelper.js
+++ b/src/lib/promiseHelper.js
@@ -4,20 +4,17 @@ export const filterPromises = (arr, filter) =>
    Promise.all(arr.map(entry => filter(entry)))
      .then(bits => arr.filter(entry => bits.shift()));
 
-export const resolvePromiseProperties = obj =>
-  (new Promise((resolve, reject) => {
-    // Get the keys which represent promises
-    const promiseKeys = Object.keys(obj).filter(
-      key => obj[key] instanceof Promise);
+export const resolvePromiseProperties = (obj) => {
+  // Get the keys which represent promises
+  const promiseKeys = Object.keys(obj).filter(
+    key => typeof obj[key].then === "function");
 
-    const promises = promiseKeys.map(key => obj[key]);
+  const promises = promiseKeys.map(key => obj[key]);
 
-    // Resolve all promises
-    Promise.all(promises)
-      .then(resolvedPromises => resolve(
-        // Return a copy of obj with promises overwritten by their
-        // resolved values
-        Object.assign(obj, zipObject(promiseKeys, resolvedPromises))))
-      // Pass errors to outer promise chain
-      .catch(err => reject(err));
-  }));
+  // Resolve all promises
+  return Promise.all(promises)
+  .then(resolvedPromises =>
+    // Return a copy of obj with promises overwritten by their
+    // resolved values
+    Object.assign({}, obj, zipObject(promiseKeys, resolvedPromises)));
+};


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines;
https://github.com/netlify/netlify-cms/blob/master/CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first three fields are mandatory:
-->

**- Summary**

There were a couple issues with the original version of
`resolvePromiseProperties`:

- The wrapper promise was unnecessary, since we can just return the
  `Promise.all`. Fixing this allows us to remove a wrapping function,
  reduce indentation, remove the `resolve` and `reject` calls, and
  remove the now unnecessary `.catch` line.

- There was inadvertent mutation in the `Object.assign` call - the
  first parameter to `Object.assign` is mutated, so to call it without
  mutating existing objects the first parameter should be a literal
  `{}`. This is now fixed.

<!--
Explain the **motivation** for making this change.
What existing problem does the pull request solve?
-->

**- Test plan**

All existing tests pass and the functionality works as expected.

<!--
Demonstrate the code is solid.
Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.
-->

**- Description for the changelog**

- Cleanup `resolvePromiseProperties`

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->