### PR TITLE
Add missing history package

### DIFF
--- a/package.json
+++ b/package.json
@@ -98,6 +98,7 @@
     "dateformat": "^1.0.12",
     "deep-equal": "^1.0.1",
     "fuzzy": "^0.1.1",
+    "history": "^4.6.1",
     "immutability-helper": "^2.0.0",
     "immutable": "^3.7.6",
     "jest": "^17.0.0",

--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     "dateformat": "^1.0.12",
     "deep-equal": "^1.0.1",
     "fuzzy": "^0.1.1",
-    "history": "^4.6.1",
+    "history": "^2.1.2",
     "immutability-helper": "^2.0.0",
     "immutable": "^3.7.6",
     "jest": "^17.0.0",


### PR DESCRIPTION
**- Summary**

With a fresh clone of master `npm run build` gives me the error:

```
ERROR in ./routing/history.js
Module not found: Error: Cannot resolve module 'history' in /Users/Joseph/Workspace/netlify-cms/src/routing
 @ ./routing/history.js 8:15-33
```

**- Test plan**

Before: builds with error.
After: no error when building.

**- Description for the changelog**

Added missing [history](https://www.npmjs.com/package/history) package for `createHashHistory` in `history.js`.