### PR TITLE
switch to markup-it upstream repo

### DIFF
--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
     "jwt-decode": "^2.1.0",
     "localforage": "^1.4.2",
     "lodash": "^4.13.1",
-    "markup-it": "git+https://github.com/cassiozen/markup-it.git",
+    "markup-it": "^2.0.0",
     "material-design-icons": "^3.0.1",
     "moment": "^2.11.2",
     "netlify-auth-js": "^0.5.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4052,8 +4052,8 @@ is-windows@^0.2.0:
   resolved "https://registry.yarnpkg.com/is-windows/-/is-windows-0.2.0.tgz#de1aa6d63ea29dd248737b69f1ff8b8002d2108c"
 
 is@^3.1.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/is/-/is-3.2.0.tgz#a362e3daf7df3fd8b7114115d624c5b7e1cb90f7"
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/is/-/is-3.2.1.tgz#d0ac2ad55eb7b0bec926a5266f6c662aaa83dca5"
 
 isarray@0.0.1:
   version "0.0.1"
@@ -5379,9 +5379,9 @@ marked@^0.3.6:
   version "0.3.6"
   resolved "https://registry.yarnpkg.com/marked/-/marked-0.3.6.tgz#b2c6c618fccece4ef86c4fc6cb8a7cbf5aeda8d7"
 
-"markup-it@git+https://github.com/cassiozen/markup-it.git":
-  version "2.4.0"
-  resolved "git+https://github.com/cassiozen/markup-it.git#35e17a9ebf23d7f6bffcf8a673a6c1b467b6177d"
+markup-it@^2.0.0:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/markup-it/-/markup-it-2.5.0.tgz#239bb2f445b4c8664af8527168ee3c00bc0d451c"
   dependencies:
     escape-string-regexp "^1.0.5"
     html-entities "^1.2.0"
@@ -7021,7 +7021,7 @@ range-parser@^1.0.3, range-parser@~1.2.0:
 
 range-utils@^1.1.0:
   version "1.1.0"
-  resolved "http://registry.npmjs.org/range-utils/-/range-utils-1.1.0.tgz#b27a9e8669d76eab7f7611f3120b39655b2e9495"
+  resolved "https://registry.yarnpkg.com/range-utils/-/range-utils-1.1.0.tgz#b27a9e8669d76eab7f7611f3120b39655b2e9495"
   dependencies:
     extend "^3.0.0"
     is "^3.1.0"


### PR DESCRIPTION
Current markup-it dep is based on @cassiozen's fork - moving to upstream (his changes were merged in https://github.com/GitbookIO/markup-it/pull/26). Using the latest release in the currently used major release line 2.x.