### PR TITLE
make doc page a h1

### DIFF
--- a/docs/customization.md
+++ b/docs/customization.md
@@ -1,4 +1,4 @@
-## Customizing the Preview Pane
+# Customizing the Preview Pane
 
 The NetlifyCMS exposes an `window.CMS` global object that you can use to register custom widgets, previews and editor plugins. The available customization methods are:
 

--- a/docs/extending.md
+++ b/docs/extending.md
@@ -1,4 +1,4 @@
-## Extending With Widgets
+# Extending With Widgets
 
 The NetlifyCMS exposes an `window.CMS` global object that you can use to register custom widgets, previews and editor plugins. The available widger extension methods are:
 


### PR DESCRIPTION
# What is this?
I notice I created two new doc pages using h2 markdown headers and they should of been h1

This 

<img width="622" alt="screenshot 2017-04-12 16 28 38" src="https://cloud.githubusercontent.com/assets/5713670/24983628/2e283100-1f9d-11e7-8d47-0b022e3e42b8.png">

should look like this:
<img width="612" alt="screenshot 2017-04-12 16 28 44" src="https://cloud.githubusercontent.com/assets/5713670/24983629/324eda5e-1f9d-11e7-8265-3b2d5acaefe0.png">


