### PR TITLE
Disable editor preview

### DIFF
--- a/example/config.yml
+++ b/example/config.yml
@@ -30,6 +30,8 @@ collections: # A list of collections the CMS should be able to edit
 
   - name: "settings"
     label: "Settings"
+    editor:
+      preview: false
     files:
       - name: "general"
         label: "Site Settings"

--- a/src/components/EntryEditor/EntryEditor.js
+++ b/src/components/EntryEditor/EntryEditor.js
@@ -53,9 +53,15 @@ class EntryEditor extends Component {
     const controlClassName = `${ styles.controlPane } ${ this.state.showEventBlocker && styles.blocker }`;
     const previewClassName = `${ styles.previewPane } ${ this.state.showEventBlocker && styles.blocker }`;
 
+    const collectionPreviewEnabled = collection.getIn(['editor', 'preview'], true);
+
+    const togglePreviewButton = (
+      <Button className={styles.previewToggle} onClick={this.handleTogglePreview}>Toggle Preview</Button>
+    );
+
     const editor = (
       <div className={controlClassName}>
-        <Button className={styles.previewToggle} onClick={this.handleTogglePreview}>Toggle Preview</Button>
+        { collectionPreviewEnabled ? togglePreviewButton : null }
         <ControlPane
           collection={collection}
           entry={entry}
@@ -97,7 +103,7 @@ class EntryEditor extends Component {
 
     return (
       <div className={styles.root}>
-        { this.state.previewVisible ? editorWithPreview : editor }
+        { collectionPreviewEnabled && this.state.previewVisible ? editorWithPreview : editor }
         <div className={styles.footer}>
           <Toolbar
             isPersisting={entry.get('isPersisting')}
@@ -124,6 +130,5 @@ EntryEditor.propTypes = {
   onRemoveAsset: PropTypes.func.isRequired,
   onCancelEdit: PropTypes.func.isRequired,
 };
-
 
 export default EntryEditor;


### PR DESCRIPTION
**- Summary**

Fixes #113. Adds ability to disable the editor preview for a collection.

**- Test plan**

Added setting to example `config.yml` for settings collection. Tested with `npm start`.

**- Description for the changelog**

Adds `editor.disable_preview` option to collection. If set to `true`, the editor preview will not be displayed and the button to show the preview will not be displayed.

Not sure it was the best option name so let me know if there's a better one.