### PR TITLE
#359 - Handle metadata for all children of a list field

### DIFF
--- a/src/components/Widgets/ListControl.js
+++ b/src/components/Widgets/ListControl.js
@@ -102,7 +102,7 @@ export default class ListControl extends Component {
     return (e) => {
       e.preventDefault();
       const { value, metadata, onChange, forID } = this.props;
-      const parsedMetadata = { [forID]: metadata.remove(metadata.keySeq().get(0)) };
+      const parsedMetadata = { [forID]: metadata.removeIn(value.get(index).valueSeq()) };
       onChange(value.remove(index), parsedMetadata);
     };
   }

--- a/src/components/Widgets/ListControl.js
+++ b/src/components/Widgets/ListControl.js
@@ -197,7 +197,3 @@ export default class ListControl extends Component {
     />);
   }
 }
-
-
-// WEBPACK FOOTER //
-// ./components/Widgets/ListControl.js

--- a/src/components/Widgets/ListControl.js
+++ b/src/components/Widgets/ListControl.js
@@ -89,17 +89,21 @@ export default class ListControl extends Component {
 
   handleChangeFor(index) {
     return (newValue, newMetadata) => {
-      const { value, onChange } = this.props;
+      const { value, metadata, onChange, forID } = this.props;
       const parsedValue = (this.valueType === valueTypes.SINGLE) ? newValue.first() : newValue;
-      onChange(value.set(index, parsedValue), newMetadata);
+      const parsedMetadata = {
+        [forID]: Object.assign(metadata ? metadata.toJS() : {}, newMetadata ? newMetadata[forID] : {}),
+      };
+      onChange(value.set(index, parsedValue), parsedMetadata);
     };
   }
 
   handleRemove(index) {
     return (e) => {
       e.preventDefault();
-      const { value, onChange } = this.props;
-      onChange(value.remove(index));
+      const { value, metadata, onChange, forID } = this.props;
+      const parsedMetadata = { [forID]: metadata.remove(metadata.keySeq().get(0)) };
+      onChange(value.remove(index), parsedMetadata);
     };
   }
 
@@ -193,3 +197,7 @@ export default class ListControl extends Component {
     />);
   }
 }
+
+
+// WEBPACK FOOTER //
+// ./components/Widgets/ListControl.js


### PR DESCRIPTION
**- Summary**
* Closes #359 

**- Test plan**
* I know, no excuses for not writing any tests but I ended up having to test it all manually anyway in my use case. Adding, removing and updating any child of the `list` works, there are no incompatibilities with the current version, nothing needs to be changed in the docs (they don't go very deep into the `relation` widget anyway - room for improvement in another contribution), now works as expected. If you did the setup to confirm the bug exists (see #359), just adding, editing and removing entries in the list field should be enough to confirm that the metadata now comes as expected.

**- Description for the changelog**
* Handle metadata for all children of a list field

**- A picture of a cute animal (not mandatory but encouraged)**
![wiki](https://cloud.githubusercontent.com/assets/8883545/25001058/893f75aa-203b-11e7-9603-5203d58e00e2.gif)
