### PR TITLE
Show error if config fails to parse

### DIFF
--- a/src/actions/config.js
+++ b/src/actions/config.js
@@ -73,20 +73,20 @@ export function loadConfig() {
   return (dispatch) => {
     dispatch(configLoading());
 
-    fetch("config.yml", { credentials: 'same-origin' }).then((response) => {
+    fetch("config.yml", { credentials: 'same-origin' })
+    .then((response) => {
       if (response.status !== 200) {
         throw new Error(`Failed to load config.yml (${ response.status })`);
       }
-
-      response
-        .text()
-        .then(parseConfig)
-        .then(applyDefaults)
-        .then((config) => {
-          dispatch(configDidLoad(config));
-          dispatch(authenticateUser());
-        });
-    }).catch((err) => {
+      return response.text();
+    })
+    .then(parseConfig)
+    .then(applyDefaults)
+    .then((config) => {
+      dispatch(configDidLoad(config));
+      dispatch(authenticateUser());
+    })
+    .catch((err) => {
       dispatch(configFailed(err));
     });
   };


### PR DESCRIPTION
**- Summary**

Fixes #357 - shows an error when there is an issue parsing the config file.

**- Test plan**

Changed the `test-repo/config.yml` to:

```yaml
backend:
  name test-repo
  delay: 0.1
``` 

Execute `npm start`:

![screen shot 2017-04-14 at 17 15 34](https://cloud.githubusercontent.com/assets/2513147/25048781/1a0d7bae-2136-11e7-9706-8bf71a9dc2fc.png)

**- Description for the changelog**

Change the promise structure so all happens in a single pipeline and all errors are caught by the catch.