### PR TITLE
Fixes 358 Save bar stuck

### DIFF
--- a/src/components/EntryEditor/EntryEditor.css
+++ b/src/components/EntryEditor/EntryEditor.css
@@ -40,3 +40,10 @@
   background: var(--backgroundColor);
   text-align: right;
 }
+
+.noPreviewEditorContainer {
+  position: absolute;
+  left: 0;
+  right: 0;
+  height: 100%;
+}

--- a/src/components/EntryEditor/EntryEditor.js
+++ b/src/components/EntryEditor/EntryEditor.js
@@ -101,9 +101,15 @@ class EntryEditor extends Component {
       </ScrollSync>
     );
 
+    const editorWithoutPreview = (
+      <div className={styles.noPreviewEditorContainer}>
+        {editor}
+      </div>
+    );
+
     return (
       <div className={styles.root}>
-        { collectionPreviewEnabled && this.state.previewVisible ? editorWithPreview : editor }
+        { collectionPreviewEnabled && this.state.previewVisible ? editorWithPreview : editorWithoutPreview }
         <div className={styles.footer}>
           <Toolbar
             isPersisting={entry.get('isPersisting')}


### PR DESCRIPTION
**- Summary**

Fixes #358 - Save bar stuck in middle of screen.

Feedback welcome on class names or if there's an existing style I should be using, or if I should make a component.

**- Test plan**

Tested by toggling off the preview editor using test backend, using Safari.

**- Description for the changelog**

Put the editor inside an absolutely positioned div container, to match the `ScrollSync` container when editor is visible).

**- A picture of a cute animal (not mandatory but encouraged)**

![Cat in a hat](https://s-media-cache-ak0.pinimg.com/originals/b1/ec/46/b1ec46e6e6c482a380f0b7f649d52e84.jpg)