### PR TITLE
Fixes #298 Basic validation for config

### DIFF
--- a/src/actions/__tests__/config.spec.js
+++ b/src/actions/__tests__/config.spec.js
@@ -1,15 +1,9 @@
-import * as config from '../config';
+import { applyDefaults, validateConfig } from '../config';
 
 describe('config', () => {
   describe('applyDefaults', () => {
-    it('should throw if media_folder is not defined in config', () => {
-      expect(() => {
-        config.applyDefaults({ foo: 'bar' });
-      }).toThrowError('Error in configuration file: A `media_folder` wasn\'t found. Check your config.yml file.');
-    });
-
     it('should set publish_mode if not set', () => {
-      expect(config.applyDefaults({
+      expect(applyDefaults({
         foo: 'bar',
         media_folder: 'path/to/media',
       })).toEqual({
@@ -21,7 +15,7 @@ describe('config', () => {
     });
 
     it('should set publish_mode from config', () => {
-      expect(config.applyDefaults({
+      expect(applyDefaults({
         foo: 'bar',
         publish_mode: 'complex',
         media_folder: 'path/to/media',
@@ -34,7 +28,7 @@ describe('config', () => {
     });
 
     it('should set public_folder based on media_folder if not set', () => {
-      expect(config.applyDefaults({
+      expect(applyDefaults({
         foo: 'bar',
         media_folder: 'path/to/media',
       })).toEqual({
@@ -46,7 +40,7 @@ describe('config', () => {
     });
 
     it('should not overwrite public_folder if set', () => {
-      expect(config.applyDefaults({
+      expect(applyDefaults({
         foo: 'bar',
         media_folder: 'path/to/media',
         public_folder: '/publib/path',
@@ -56,6 +50,69 @@ describe('config', () => {
         media_folder: 'path/to/media',
         public_folder: '/publib/path',
       });
+    });
+  });
+
+  describe('validateConfig', () => {
+    it('should return the config if no errors', () => {
+      const config = { foo: 'bar', backend: { name: 'bar' }, media_folder: 'baz', collections: [{}] };
+      expect(
+        validateConfig(config)
+      ).toEqual(config);
+    });
+
+    it('should throw if backend is not defined in config', () => {
+      expect(() => {
+        validateConfig({ foo: 'bar' });
+      }).toThrowError('Error in configuration file: A `backend` wasn\'t found. Check your config.yml file.');
+    });
+
+    it('should throw if backend name is not defined in config', () => {
+      expect(() => {
+        validateConfig({ foo: 'bar', backend: {} });
+      }).toThrowError('Error in configuration file: A `backend.name` wasn\'t found. Check your config.yml file.');
+    });
+
+    it('should throw if backend name is not a string in config', () => {
+      expect(() => {
+        validateConfig({ foo: 'bar', backend: { name: { } } });
+      }).toThrowError('Error in configuration file: Your `backend.name` must be a string. Check your config.yml file.');
+    });
+
+    it('should throw if media_folder is not defined in config', () => {
+      expect(() => {
+        validateConfig({ foo: 'bar', backend: { name: 'bar' } });
+      }).toThrowError('Error in configuration file: A `media_folder` wasn\'t found. Check your config.yml file.');
+    });
+
+    it('should throw if media_folder is not a string in config', () => {
+      expect(() => {
+        validateConfig({ foo: 'bar', backend: { name: 'bar' }, media_folder: {} });
+      }).toThrowError('Error in configuration file: Your `media_folder` must be a string. Check your config.yml file.');
+    });
+
+    it('should throw if collections is not defined in config', () => {
+      expect(() => {
+        validateConfig({ foo: 'bar', backend: { name: 'bar' }, media_folder: 'baz' });
+      }).toThrowError('Error in configuration file: A `collections` wasn\'t found. Check your config.yml file.');
+    });
+
+    it('should throw if collections not an array in config', () => {
+      expect(() => {
+        validateConfig({ foo: 'bar', backend: { name: 'bar' }, media_folder: 'baz', collections: {} });
+      }).toThrowError('Error in configuration file: Your `collections` must be an array with at least one element. Check your config.yml file.');
+    });
+
+    it('should throw if collections is an empty array in config', () => {
+      expect(() => {
+        validateConfig({ foo: 'bar', backend: { name: 'bar' }, media_folder: 'baz', collections: [] });
+      }).toThrowError('Error in configuration file: Your `collections` must be an array with at least one element. Check your config.yml file.');
+    });
+
+    it('should throw if collections is an array with a single null element in config', () => {
+      expect(() => {
+        validateConfig({ foo: 'bar', backend: { name: 'bar' }, media_folder: 'baz', collections: [null] });
+      }).toThrowError('Error in configuration file: Your `collections` must be an array with at least one element. Check your config.yml file.');
     });
   });
 });

--- a/src/reducers/collections.js
+++ b/src/reducers/collections.js
@@ -1,10 +1,9 @@
 import { OrderedMap, fromJS } from 'immutable';
+import { has } from 'lodash';
 import consoleError from '../lib/consoleError';
 import { CONFIG_SUCCESS } from '../actions/config';
 import { FILES, FOLDER } from '../constants/collectionTypes';
 import { INFERABLE_FIELDS } from '../constants/fieldInference';
-
-const hasProperty = (config, property) => ({}.hasOwnProperty.call(config, property));
 
 const collections = (state = null, action) => {
   const configCollections = action.payload && action.payload.collections;
@@ -12,9 +11,9 @@ const collections = (state = null, action) => {
     case CONFIG_SUCCESS:
       return OrderedMap().withMutations((map) => {
         (configCollections || []).forEach((configCollection) => {
-          if (hasProperty(configCollection, 'folder')) {
+          if (has(configCollection, 'folder')) {
             configCollection.type = FOLDER; // eslint-disable-line no-param-reassign
-          } else if (hasProperty(configCollection, 'files')) {
+          } else if (has(configCollection, 'files')) {
             configCollection.type = FILES; // eslint-disable-line no-param-reassign
           } else {
             throw new Error('Unknown collection type. Collections can be either Folder based or File based. Please verify your site configuration');


### PR DESCRIPTION
**- Summary**

Fixes #298 - adds some basic validation for the config.

**- Test plan**

Added some unit tests for config validations.

![screen shot 2017-04-14 at 22 34 42](https://cloud.githubusercontent.com/assets/2513147/25056777/09a12202-2163-11e7-8b61-d410267a07b7.png)
![screen shot 2017-04-14 at 22 34 17](https://cloud.githubusercontent.com/assets/2513147/25056784/121f80fe-2163-11e7-8098-0833d0507e27.png)
![screen shot 2017-04-14 at 22 34 28](https://cloud.githubusercontent.com/assets/2513147/25056779/0e5025c8-2163-11e7-8ed1-c7aa4b0ea4d5.png)

**- Description for the changelog**

Add a `validateConfig` to provide basic validation of configuration.

**- A picture of a cute animal (not mandatory but encouraged)**

![Cute polar bear on it's back](http://static.boredpanda.com/blog/wp-content/uploads/2016/02/cute-baby-polar-bear-day-photography-14__880.jpg)