### PR TITLE
Fixes #292 Display version number

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -11,6 +11,9 @@ if (process.env.NODE_ENV !== 'production') {
   require('./utils.css'); // eslint-disable-line
 }
 
+// Log the version number
+console.log(`Netlify CMS version ${NETLIFY_CMS_VERSION}`);
+
 // Create mount element dynamically
 const el = document.createElement('div');
 el.id = 'root';

--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -45,6 +45,9 @@ module.exports = merge.smart(require('./webpack.base.js'), {
         NODE_ENV: JSON.stringify('development'),
       },
     }),
+    new webpack.DefinePlugin({
+      NETLIFY_CMS_VERSION: JSON.stringify(require("./package.json").version + "-dev")
+    }),
     new webpack.optimize.OccurenceOrderPlugin(),
     new webpack.HotModuleReplacementPlugin(),
     new webpack.NoErrorsPlugin(),

--- a/webpack.prod.js
+++ b/webpack.prod.js
@@ -30,6 +30,9 @@ module.exports = merge.smart(require('./webpack.base.js'), {
         NODE_ENV: JSON.stringify('production'),
       },
     }),
+    new webpack.DefinePlugin({
+      NETLIFY_CMS_VERSION: JSON.stringify(require("./package.json").version)
+    }),
     new webpack.optimize.OccurenceOrderPlugin(),
 
     // Minify and optimize the JavaScript


### PR DESCRIPTION
**- Summary**

Show the version number in the "settings" dropdown - fixes #292. I also combined the settings menu and user avatar together, which haves the benefit of leaving more space for the search bar on mobile. "-dev" is appending to the version when developing.

**- Test plan**

![screen shot 2017-04-15 at 01 32 24](https://cloud.githubusercontent.com/assets/2513147/25059330/735d60e8-217c-11e7-95e7-27e62bbf208a.png)

![screen shot 2017-04-15 at 01 32 21](https://cloud.githubusercontent.com/assets/2513147/25059314/185f1600-217c-11e7-9d12-bac6a621eead.png)

**- Description for the changelog**

* Inject the version number from `package.json` with Webpack and display it in the settings menu (this could lead to an about page)
* Combine the settings icon and user avatar together

**- A picture of a cute animal (not mandatory but encouraged)**

![Cute duckling](http://www.cutenessoverflow.com/wp-content/uploads/2014/03/cute-animals-awesomely-cute-com-1635.jpg)