### PR TITLE
Add backend config for site ID

### DIFF
--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -54,7 +54,7 @@ The first file, `admin/index.html`, is the entry point for the Netlify CMS admin
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Content Manager</title>
-  
+
   <link rel="stylesheet" href="https://unpkg.com/netlify-cms@^0.3/dist/cms.css" />
 
 </head>
@@ -77,6 +77,7 @@ backend:
   name: github
   repo: owner-name/repo-name # Path to your Github repository
   branch: master # Branch to update
+  site_domain: site-name.netlify.com # Your Netlify site address if different from host
 ```
 
 This names GitHub as the authentication provider, points to the repo location on github.com, and declares the branch where you want to merge changes. If you leave out the `branch` declaration, it will default to `master`.
@@ -109,7 +110,7 @@ This configuration adds a new setting, `public_folder`. While `media_folder` spe
 >If `public_folder` is not set, Netlify CMS will default to the same value as `media_folder`, adding an opening `/` if one is not included.
 
 ### Collections
-Collections define the structure for the different content types on your static site. Since every site is different, the `collections` settings will be very different from one site to the next. Let's say your site has a blog, with the posts stored in `_posts/blog`, and files saved in a date-title format, like `1999-12-31-lets-party.md`. Each post 
+Collections define the structure for the different content types on your static site. Since every site is different, the `collections` settings will be very different from one site to the next. Let's say your site has a blog, with the posts stored in `_posts/blog`, and files saved in a date-title format, like `1999-12-31-lets-party.md`. Each post
 begins with settings in yaml-formatted front matter, like so:
 
 ``` yaml
@@ -198,4 +199,3 @@ Based on this example, you can go through the post types in your site and add th
 With your configuration complete, it's time to try it out! Go to `yoursite.com/admin` and complete the login prompt to access the admin interface. To add users, simply add them as collaborators on the GitHub repo.
 
 Happy posting!
-

--- a/src/backends/github/AuthenticationPage.js
+++ b/src/backends/github/AuthenticationPage.js
@@ -17,7 +17,7 @@ export default class AuthenticationPage extends React.Component {
     if (document.location.host.split(':')[0] === 'localhost') {
       auth = new Authenticator({ site_id: 'cms.netlify.com' });
     } else {
-      auth = new Authenticator();
+      auth = new Authenticator({ site_id: this.props.siteId });
     }
 
     auth.authenticate({ provider: 'github', scope: 'repo' }, (err, data) => {

--- a/src/containers/App.js
+++ b/src/containers/App.js
@@ -51,6 +51,7 @@ class App extends React.Component {
     runCommand: PropTypes.func.isRequired,
     isFetching: PropTypes.bool.isRequired,
     publishMode: PropTypes.oneOf([SIMPLE, EDITORIAL_WORKFLOW]),
+    siteId: PropTypes.string,
   };
 
   static configError(config) {
@@ -87,6 +88,7 @@ class App extends React.Component {
             onLogin: this.handleLogin.bind(this),
             error: auth && auth.get('error'),
             isFetching: auth && auth.get('isFetching'),
+            siteId: this.props.config.getIn(["backend", "site_domain"]),
           })
         }
       </div>


### PR DESCRIPTION
**- Summary**

We have our main site served by nginx and load the netlify site via proxy_pass for specified paths. Attempting to load the admin CMS page breaks since the host is different than our Netlify custom domain. Making the `site_id` configurable addresses this. 

https://github.com/netlify/netlify-cms/issues/37

**- Test plan**
To test this I ran the server locally with `npm run start`, updated my Netlify site config to include the new `site_id:` and pointed the CMS CSS /JS my local copy of my middleman site to the local CMS server.

```haml
= stylesheet_link_tag "http://localhost:8080/cms.css"
= javascript_include_tag "http://localhost:8080/cms.js"
```

I added the following to `src/backends/github/AuthenticationPage.js`

```js
console.log('siteId is 'this.props.siteId);
auth = new Authenticator({ site_id: this.props.siteId });
```
I watched the console in my browser as I authenticated.

**- Description for the changelog**

Users can now specify `site_id` in `config.yml` under `backend`. This is useful
when attempting to access the CMS from a different host.

![squirrel](https://media.giphy.com/media/mPJ4VPpXPtYuA/giphy.gif)
