### PR TITLE
Fix filtering by file extension

### DIFF
--- a/src/backends/github/implementation.js
+++ b/src/backends/github/implementation.js
@@ -42,7 +42,7 @@ export default class GitHub {
 
   entriesByFolder(collection, extension) {
     return this.api.listFiles(collection.get("folder"))
-    .then(files => files.filter(fileExtension(file.name) === extension))
+    .then(files => files.filter(file => fileExtension(file.name) === extension))
     .then(this.fetchFiles);
   }
 


### PR DESCRIPTION
**- Summary**

The extension filter was not running properly since `file` was not passed in.

**- Test plan**

Run server locally and watch posts not load and then load with the change

**- Description for the changelog**

Fix extension filter filtering out all files

**- A picture of a cute animal (not mandatory but encouraged)**
![squirrel](https://media.giphy.com/media/BiQPmevsqQyxW/giphy.gif)