### PR TITLE
Fix date field persist

### DIFF
--- a/example/config.yml
+++ b/example/config.yml
@@ -12,10 +12,10 @@ collections: # A list of collections the CMS should be able to edit
     create: true # Allow users to create new documents in this collection
     fields: # The fields each document in this collection have
       - {label: "Title", name: "title", widget: "string", tagname: "h1"}
+      - {label: "Publish Date", name: "date", widget: "datetime", format: "YYYY-MM-DD hh:mma"}
       - {label: "Cover Image", name: "image", widget: "image", required: false, tagname: ""}
       - {label: "Body", name: "body", widget: "markdown"}
     meta:
-      - {label: "Publish Date", name: "date", widget: "datetime", format: "YYYY-MM-DD hh:mma"}
       - {label: "SEO Description", name: "description", widget: "text"}
     card: {type: "image", image: "image", text: "title"}
 

--- a/src/formats/__tests__/frontmatter.spec.js
+++ b/src/formats/__tests__/frontmatter.spec.js
@@ -1,5 +1,7 @@
 import Frontmatter from '../frontmatter';
 
+jest.mock("../../valueObjects/AssetProxy.js");
+
 const FrontmatterFormatter = new Frontmatter();
 
 describe('Frontmatter', () => {

--- a/src/formats/frontmatter.js
+++ b/src/formats/frontmatter.js
@@ -1,6 +1,7 @@
 import preliminaries from 'preliminaries';
 import yamlParser from 'preliminaries-parser-yaml';
 import tomlParser from 'preliminaries-parser-toml';
+import YAML from './yaml';
 
 // Automatically register parsers
 preliminaries(true);
@@ -25,7 +26,13 @@ export default class Frontmatter {
         meta[key] = data[key];
       }
     });
+
     // always stringify to YAML
-    return preliminaries.stringify(body, meta, { lang: 'yaml', delims: '---' });
+    const parser = {
+      stringify(metadata) {
+        return new YAML().toFile(metadata, sortedKeys);
+      },
+    };
+    return preliminaries.stringify(body, meta, { lang: "yaml", delims: "---", parser });
   }
 }


### PR DESCRIPTION
Switches back to custom frontmatter stringification
until support lands in the preliminaries lib. This is necessary
because we use custom schemas for certain data types,
such as dates and times.

(This is a copy of #384 with history rewritten to use @josephearl's alternate implementation).

<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines;
https://github.com/netlify/netlify-cms/blob/master/CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first three fields are mandatory:
-->

**- Summary**

Date fields can no longer be changed through the CMS. Regression from #348.

<!--
Explain the **motivation** for making this change.
What existing problem does the pull request solve?
-->

**- Test plan**

Moved the Published Date field in the example project out of metadata and into standard fields, so persisting dates can be observed in deploy previews. Tested locally. Existing automated tests pass.

<!--
Demonstrate the code is solid.
Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.
-->

**- Description for the changelog**

Fix date/datetime field persisting

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->