### PR TITLE
Prevent long code lines from breaking visual entry editor

### DIFF
--- a/src/components/Widgets/MarkdownControlElements/VisualEditor/index.css
+++ b/src/components/Widgets/MarkdownControlElements/VisualEditor/index.css
@@ -69,6 +69,7 @@
     background-color: var(--controlBGColor);
     padding: 12px;
     border-radius: 0 0 var(--borderRadius) var(--borderRadius);
+    overflow-x: auto;
 
     & ul {
       padding-left: 20px;


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines;
https://github.com/netlify/netlify-cms/blob/master/CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first three fields are mandatory:
-->

**- Summary**

Previously, long lines of preformatted text would cause the lines to run off the side of the ProseMirror edit box and give the entire entry editor a horizontal scrollbar. This commit makes the edit box itself scroll, which looks and feels much less broken.

<!--
Explain the **motivation** for making this change.
What existing problem does the pull request solve?
-->

**- Test plan**

Tested manually (no visual diff testing exists on this project at the moment).

<!--
Demonstrate the code is solid.
Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.
-->

**- Description for the changelog**

Prevent long code lines from breaking visual entry editor.

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->