### PR TITLE
prevent rte scroll, improve code display

### DIFF
--- a/src/components/Widgets/MarkdownControlElements/RawEditor/index.css
+++ b/src/components/Widgets/MarkdownControlElements/RawEditor/index.css
@@ -24,3 +24,8 @@
   display: block;
   pointer-events: none;
 }
+
+.textarea {
+  overflow: hidden;
+  resize: none;
+}

--- a/src/components/Widgets/MarkdownControlElements/RawEditor/index.js
+++ b/src/components/Widgets/MarkdownControlElements/RawEditor/index.js
@@ -339,6 +339,7 @@ export default class RawEditor extends React.Component {
       </Sticky>
       <TextareaAutosize
         inputRef={this.handleRef}
+        className={styles.textarea}
         value={this.props.value || ''}
         onKeyDown={this.handleKey}
         onChange={this.handleChange}

--- a/src/components/Widgets/MarkdownControlElements/VisualEditor/index.css
+++ b/src/components/Widgets/MarkdownControlElements/VisualEditor/index.css
@@ -27,6 +27,7 @@
     font-size: 1.8rem;
   }
   & p {
+    margin-top: 20px;
     margin-bottom: 20px;
   }
   & hr {
@@ -69,10 +70,21 @@
     background-color: var(--controlBGColor);
     padding: 12px;
     border-radius: 0 0 var(--borderRadius) var(--borderRadius);
-    overflow-x: auto;
+    overflow: hidden;
 
-    & ul {
+    & ul,
+    & ol {
       padding-left: 20px;
+    }
+
+    & pre > code {
+      display: block;
+      width: 100%;
+      overflow-y: auto;
+      background-color: #000;
+      color: #ccc;
+      border-radius: var(--borderRadius);
+      padding: 10px;
     }
   }
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines;
https://github.com/netlify/netlify-cms/blob/master/CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first three fields are mandatory:
-->

**- Summary**

<!--
Explain the **motivation** for making this change.
What existing problem does the pull request solve?
-->

The rich text editor is now sized by an autosizing library, and should never have scroll bars. When it does have scroll bars, the scroll events break sticky toolbar positioning. This fix prevents scrollbars from showing within the rich text editor, and also improves code, ordered list, and paragraph display styling (within the rte).

**- Description for the changelog**

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Prevent rich text editor scroll and improve code/code block display