### PR TITLE
boolean widget & some documentation

### DIFF
--- a/docs/widgets.md
+++ b/docs/widgets.md
@@ -7,6 +7,7 @@ Widgets define the data type and interface for entry fields. Netlify CMS comes w
 Widget | UI | Data Type
 --- | --- | ---
 `string` | text input | string
+`boolean` | select input | switch for true and false
 `text` | text area input | plain text, multiline input
 `number` | text input with `+` and `-` buttons | number
 `markdown` | rich text editor with raw option | markdown-formatted string
@@ -14,5 +15,8 @@ Widget | UI | Data Type
 `image` | file picker widget with drag-and-drop | file path saved as string, image uploaded to media folder
 `hidden` | No UI | Hidden element, typically only useful with a `default` attribute
 `list` | text input | strings separated by commas
+`file` | file input | input file upload
+`select` | select input | dropdown filled with `options` from the config
+`object` | custom | `fields` as a list defined in the config
 
 We’re always adding new widgets, and you can also [create your own](/docs/extending).

--- a/src/components/Widgets.js
+++ b/src/components/Widgets.js
@@ -25,6 +25,7 @@ import ObjectControl from './Widgets/ObjectControl';
 import ObjectPreview from './Widgets/ObjectPreview';
 import RelationControl from './Widgets/RelationControl';
 import RelationPreview from './Widgets/RelationPreview';
+import BooleanControl from './Widgets/BooleanControl';
 
 
 registry.registerWidget('string', StringControl, StringPreview);
@@ -39,6 +40,7 @@ registry.registerWidget('datetime', DateTimeControl, DateTimePreview);
 registry.registerWidget('select', SelectControl, SelectPreview);
 registry.registerWidget('object', ObjectControl, ObjectPreview);
 registry.registerWidget('relation', RelationControl, RelationPreview);
+registry.registerWidget('boolean', BooleanControl);
 registry.registerWidget('unknown', UnknownControl, UnknownPreview);
 
 export function resolveWidget(name) { // eslint-disable-line

--- a/src/components/Widgets/BooleanControl.js
+++ b/src/components/Widgets/BooleanControl.js
@@ -1,0 +1,27 @@
+import React, { PropTypes } from 'react';
+import ImmutablePropTypes from "react-immutable-proptypes";
+import Switch from 'react-toolbox/lib/switch';
+
+export default class BooleanControl extends React.Component {
+
+  handleChange = (e) => {
+    this.props.onChange(e);
+  };
+
+  render() {
+    const finalValue = (this.props.value !== undefined) ? this.props.value : this.props.field.get('defaultValue', false);
+
+    return (<Switch
+      id={this.props.forID}
+      checked={finalValue}
+      onChange={this.handleChange}
+    />);
+  }
+}
+
+BooleanControl.propTypes = {
+  field: ImmutablePropTypes.map.isRequired,
+  onChange: PropTypes.func.isRequired,
+  forID: PropTypes.string.isRequired,
+  value: PropTypes.bool,
+};

--- a/src/components/Widgets/BooleanControl.js
+++ b/src/components/Widgets/BooleanControl.js
@@ -3,19 +3,15 @@ import ImmutablePropTypes from "react-immutable-proptypes";
 import Switch from 'react-toolbox/lib/switch';
 
 export default class BooleanControl extends React.Component {
-
-  handleChange = (e) => {
-    this.props.onChange(e);
-  };
-
   render() {
-    const finalValue = (this.props.value !== undefined) ? this.props.value : this.props.field.get('defaultValue', false);
-
-    return (<Switch
-      id={this.props.forID}
-      checked={finalValue}
-      onChange={this.handleChange}
-    />);
+    const { value, field, forId, onChange } = this.props;
+    return (
+      <Switch
+        id={forId}
+        checked={value === undefined ? field.get('defaultValue', false) : value}
+        onChange={onChange}
+      />
+    );
   }
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -7749,6 +7749,12 @@ slide@^1.1.5:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/slide/-/slide-1.1.6.tgz#56eb027d65b4d2dce6cb2e2d32c4d4afc9e1d707"
 
+slug@^0.9.1:
+  version "0.9.1"
+  resolved "https://registry.yarnpkg.com/slug/-/slug-0.9.1.tgz#af08f608a7c11516b61778aa800dce84c518cfda"
+  dependencies:
+    unicode ">= 0.3.1"
+
 sntp@1.x.x:
   version "1.0.9"
   resolved "https://registry.yarnpkg.com/sntp/-/sntp-1.0.9.tgz#6541184cc90aeea6c6e7b35e2659082443c66198"
@@ -8539,6 +8545,10 @@ uid@0.0.2:
 unc-path-regex@^0.1.0:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/unc-path-regex/-/unc-path-regex-0.1.2.tgz#e73dd3d7b0d7c5ed86fbac6b0ae7d8c6a69d50fa"
+
+"unicode@>= 0.3.1":
+  version "9.0.1"
+  resolved "https://registry.yarnpkg.com/unicode/-/unicode-9.0.1.tgz#104706272c6464c574801be1b086f7245cf25158"
 
 uniq@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
**- Summary**

While working on the file-system backend, I was working with `hugo`. `hugo` uses a draft attribute to let you mark content as draft so it's not included in the output. I found there was no `boolean` widget, so here it is.

The MR passes `npm run lint:staged` but I have issues the the pre-commit hooks:
```
.git/hooks/pre-commit: line 2: ./node_modules/pre-commit/hook: No such file or directory
```

**- Test plan**

There's no test for the other widget, so I did not really know where to start here. Let me know if you want one.

<img width="833" alt="screen shot 2017-05-01 at 21 41 41" src="https://cloud.githubusercontent.com/assets/5230460/25601150/df19821a-2eb7-11e7-97fb-590f5f4d070c.png">

**- Description for the changelog**
Widget for `boolean` fields
