### PR TITLE
Use react-frame-component for preview pane

### DIFF
--- a/package.json
+++ b/package.json
@@ -135,6 +135,7 @@
     "react-autosuggest": "^7.0.1",
     "react-datetime": "^2.6.0",
     "react-dom": "^15.1.0",
+    "react-frame-component": "^1.0.3",
     "react-hot-loader": "^3.0.0-beta.2",
     "react-immutable-proptypes": "^2.1.0",
     "react-lazy-load": "^3.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6934,6 +6934,10 @@ react-dom@^15.1.0:
     object-assign "^4.1.0"
     prop-types "~15.5.7"
 
+react-frame-component@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/react-frame-component/-/react-frame-component-1.0.3.tgz#00a5deea81671927ea973954a0d8eb19ecc339de"
+
 react-fuzzy@^0.2.3:
   version "0.2.3"
   resolved "https://registry.yarnpkg.com/react-fuzzy/-/react-fuzzy-0.2.3.tgz#4fa08729524cd491e2b589509e8d2de7e3adfb9e"


### PR DESCRIPTION
Fixes #307

<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines;
https://github.com/netlify/netlify-cms/blob/master/CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first three fields are mandatory:
-->

**- Summary**

Uses `react-frame-component` for preview pane instead of custom iframe code. Fixes #307.

<!--
Explain the **motivation** for making this change.
What existing problem does the pull request solve?
-->

**- Test plan**

Existing tests pass; manually tested that previewing and scrolling work correctly in both Firefox and Chrome.

<!--
Demonstrate the code is solid.
Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.
-->

**- Description for the changelog**

Use react-frame-component for preview pane

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->