### PR TITLE
remove site_domain key from example

### DIFF
--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -77,7 +77,6 @@ backend:
   name: github
   repo: owner-name/repo-name # Path to your Github repository
   branch: master # Branch to update
-  site_domain: site-name.netlify.com # Your Netlify site address if different from host
 ```
 
 This names GitHub as the authentication provider, points to the repo location on github.com, and declares the branch where you want to merge changes. If you leave out the `branch` declaration, it will default to `master`.


### PR DESCRIPTION
The `site_domain` key is for a rare case and should not be used by the vast majority of projects. It breaks auth if used incorrectly. Proper documentation will be handled under #405.