### PR TITLE
Remove deprecated card setting from example config.yml

### DIFF
--- a/example/config.yml
+++ b/example/config.yml
@@ -17,7 +17,6 @@ collections: # A list of collections the CMS should be able to edit
       - {label: "Body", name: "body", widget: "markdown"}
     meta:
       - {label: "SEO Description", name: "description", widget: "text"}
-    card: {type: "image", image: "image", text: "title"}
 
   - name: "faq" # Used in routes, ie.: /admin/collections/:slug/edit
     label: "FAQ" # Used in the UI, ie.: "New Post"
@@ -26,7 +25,6 @@ collections: # A list of collections the CMS should be able to edit
     fields: # The fields each document in this collection have
       - {label: "Question", name: "title", widget: "string", tagname: "h1"}
       - {label: "Answer", name: "body", widget: "markdown"}
-    card: {type: "alltype", text: "title"}
 
   - name: "settings"
     label: "Settings"


### PR DESCRIPTION
**- Summary**

The `card` setting in the example config.yml was used in the first iteration of the card UI.
The code was later changed to infer the fields that appear in the card, instead of having to configure them (see [commit 2a2497072dd2c538735a92a1f6e93de6af7c796d](https://github.com/netlify/netlify-cms/commit/2a2497072dd2c538735a92a1f6e93de6af7c796d)).
The old card settings, however, were left in the example configuration file, which leads to confusion.

**- Test plan**

Run the CMS locally and note the UI is not affected by this setting.

**- Description for the changelog**

Remove deprecated setting from example config.yml

**- A picture of a cute animal (not mandatory but encouraged)**

_this should be animated!_
![red_panda](https://cloud.githubusercontent.com/assets/83225/25935608/ca31e73e-35d8-11e7-811e-a862490440e8.jpg)
