### PR TITLE
Tests remaing field value in card view for null

### DIFF
--- a/example/config.yml
+++ b/example/config.yml
@@ -15,7 +15,6 @@ collections: # A list of collections the CMS should be able to edit
       - {label: "Publish Date", name: "date", widget: "datetime", format: "YYYY-MM-DD hh:mma"}
       - {label: "Cover Image", name: "image", widget: "image", required: false, tagname: ""}
       - {label: "Body", name: "body", widget: "markdown"}
-      - {label: "Some Field", name: "somefield", widget: "string", required: false} # Testing empty field
     meta:
       - {label: "SEO Description", name: "description", widget: "text"}
 

--- a/example/config.yml
+++ b/example/config.yml
@@ -15,6 +15,7 @@ collections: # A list of collections the CMS should be able to edit
       - {label: "Publish Date", name: "date", widget: "datetime", format: "YYYY-MM-DD hh:mma"}
       - {label: "Cover Image", name: "image", widget: "image", required: false, tagname: ""}
       - {label: "Body", name: "body", widget: "markdown"}
+      - {label: "Some Field", name: "somefield", widget: "string", required: false} # Testing empty field
     meta:
       - {label: "SEO Description", name: "description", widget: "text"}
 

--- a/example/index.html
+++ b/example/index.html
@@ -14,7 +14,7 @@
         content: "---\ntitle: This is a YAML front matter post\nimage: /nf-logo.png\ndate: 2015-02-14T00:00:00.000Z\n---\n\n# I Am a Title in Markdown\n\nHello, world\n\n* One Thing\n* Another Thing\n* A Third Thing\n"
       },
 	  "2015-02-14-this-is-test-post.md": {
-        content: "---\ntitle: This is a test post\nimage: /Photo 1-lobby_FS.jpg\ndate: 2015-02-14T00:00:00.000Z\n---\n\n# I Am a Title in Markdown\n\nHello, world\n\n* One Thing\n* Another Thing\n* A Third Thing\n"
+        content: "---\ntitle: This is a test post\nimage: /Photo 1-lobby_FS.jpg\ndate: 2015-02-14T00:00:00.000Z\nsomefield: null\n---\n\n# I Am a Title in Markdown\n\nHello, world\n\n* One Thing\n* Another Thing\n* A Third Thing\n"
       },
       "2015-02-15-this-is-a-json-frontmatter-post.md": {
         content: "{\n\"title\": \"This is a JSON front matter post\",\n\"image\": \"/nf-logo.png\",\n\"date\": \"2015-02-15T00:00:00.000Z\"\n}\n\n# I Am a Title in Markdown\n\nHello, world\n\n* One Thing\n* Another Thing\n* A Third Thing\n"

--- a/example/index.html
+++ b/example/index.html
@@ -13,9 +13,6 @@
       "2015-02-14-this-is-a-post.md": {
         content: "---\ntitle: This is a YAML front matter post\nimage: /nf-logo.png\ndate: 2015-02-14T00:00:00.000Z\n---\n\n# I Am a Title in Markdown\n\nHello, world\n\n* One Thing\n* Another Thing\n* A Third Thing\n"
       },
-	  "2015-02-14-this-is-test-post.md": {
-        content: "---\ntitle: This is a test post\nimage: /Photo 1-lobby_FS.jpg\ndate: 2015-02-14T00:00:00.000Z\nsomefield: null\n---\n\n# I Am a Title in Markdown\n\nHello, world\n\n* One Thing\n* Another Thing\n* A Third Thing\n"
-      },
       "2015-02-15-this-is-a-json-frontmatter-post.md": {
         content: "{\n\"title\": \"This is a JSON front matter post\",\n\"image\": \"/nf-logo.png\",\n\"date\": \"2015-02-15T00:00:00.000Z\"\n}\n\n# I Am a Title in Markdown\n\nHello, world\n\n* One Thing\n* Another Thing\n* A Third Thing\n"
       },

--- a/src/components/EntryListing/EntryListing.js
+++ b/src/components/EntryListing/EntryListing.js
@@ -57,7 +57,7 @@ export default class EntryListing extends React.Component {
           : inferedFields.remainingFields && inferedFields.remainingFields.map(f => (
             <p key={f.get('name')} className={styles.cardList}>
               <span className={styles.cardListLabel}>{f.get('label')}:</span>{' '}
-              { entry.getIn(['data', f.get('name')], '').toString() }
+              { entry.getIn(['data', f.get('name')], '')?entry.getIn(['data', f.get('name')], '').toString():'' }
             </p>
           ))
         }

--- a/src/components/EntryListing/EntryListing.js
+++ b/src/components/EntryListing/EntryListing.js
@@ -57,7 +57,7 @@ export default class EntryListing extends React.Component {
           : inferedFields.remainingFields && inferedFields.remainingFields.map(f => (
             <p key={f.get('name')} className={styles.cardList}>
               <span className={styles.cardListLabel}>{f.get('label')}:</span>{' '}
-              { entry.getIn(['data', f.get('name')], '')?entry.getIn(['data', f.get('name')], '').toString():'' }
+              { (entry.getIn(['data', f.get('name')]) || '').toString() }
             </p>
           ))
         }


### PR DESCRIPTION

**- Summary**

In the current behavior, the CMS encounters a problem, while displaying "remaining fields" in a card, as it encounters a field with a value of "null" explicitly set in the front matter... blank works, but not null. The console errors with "Cannot read property 'toString' of null at EntryListing.js:60" and the CMS app will no longer respond until refreshed.

A null value occurs whenever a non-required field is skipped during post entry. This might not be intended behavior for persisting a post, but regardless, it should be handled.

The offending line originally read:

```
{ entry.getIn(['data', f.get('name')], '').toString() }
```

but now is changed to:

```
{ entry.getIn(['data', f.get('name')], '')?entry.getIn(['data', f.get('name')], '').toString():'' }
```

**- Test plan**

A post in the local content (index:1) was given a field of somefield: null and a corresponding field in the config was added to match it... and it was set required: false.

The app no longer crashes and all tests pass.

**- Description for the changelog**

Card remaining fields now are checked for null values.

**- A picture of a cute animal (not mandatory but encouraged)**

![cute-animal-10](https://cloud.githubusercontent.com/assets/3292160/26030160/709bca2c-3818-11e7-96d7-ef00105fa665.png)
