### PR TITLE
allow test repo to be used without window.testRepo

### DIFF
--- a/src/backends/test-repo/implementation.js
+++ b/src/backends/test-repo/implementation.js
@@ -3,7 +3,7 @@ import { fileExtension } from '../../lib/pathHelper'
 
 function getFile(path) {
   const segments = path.split('/');
-  let obj = window.repoFiles;
+  let obj = window.repoFiles || {};
   while (obj && segments.length) {
     obj = obj[segments.shift()];
   }
@@ -22,9 +22,6 @@ function nameFromEmail(email) {
 export default class TestRepo {
   constructor(config) {
     this.config = config;
-    if (window.repoFiles == null) {
-      throw 'The TestRepo backend needs a "window.repoFiles" object.';
-    }
   }
 
   setUser() {}
@@ -44,8 +41,10 @@ export default class TestRepo {
   entriesByFolder(collection, extension) {
     const entries = [];
     const folder = collection.get('folder');
+    const obj = window.repoFiles;
     if (folder) {
-      for (const path in window.repoFiles[folder]) {
+      obj[folder] = obj[folder] || {};
+      for (const path in obj[folder]) {
         if (fileExtension(path) !== extension) {
           continue;
         }
@@ -54,7 +53,7 @@ export default class TestRepo {
         entries.push(
           {
             file,
-            data: window.repoFiles[folder][path].content,
+            data: obj[folder][path].content,
           }
         );
       }


### PR DESCRIPTION
For example purposes, its helpful to allow users to run the test
backend without creating a repo object with nested objects for
each folder. This fix creates empty objects wherever needed.

<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines;
https://github.com/netlify/netlify-cms/blob/master/CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first three fields are mandatory:
-->

**- Summary**

<!--
Explain the **motivation** for making this change.
What existing problem does the pull request solve?
-->

Using the test repo requires a repo object to be created on the window and a nested object for each folder in the config. For test purposes, and for new users trying it out, the CMS should just
create empty objects where they don't exist for the test backend.

**- Description for the changelog**

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Allow the test backend to be used without mock content
