### PR TITLE
Fix development warnings

### DIFF
--- a/src/components/ControlPanel/ControlPane.js
+++ b/src/components/ControlPanel/ControlPane.js
@@ -67,11 +67,11 @@ export default class ControlPane extends Component {
     return (
       <div>
         {
-          fields.map((field) => {
+          fields.map((field, i) => {
             if (isHidden(field)) {
               return null;
             }
-            return <div key={field.get('name')} className={styles.widget}>{this.controlFor(field)}</div>;
+            return <div key={i} className={styles.widget}>{this.controlFor(field)}</div>;
           })
         }
       </div>

--- a/src/components/PreviewPane/PreviewPane.js
+++ b/src/components/PreviewPane/PreviewPane.js
@@ -88,10 +88,10 @@ export default class PreviewPane extends React.Component {
     };
 
     const styleEls = registry.getPreviewStyles()
-       .map(style => <link href={style} type="text/css" rel="stylesheet" />);
+       .map((style, i) => <link key={i} href={style} type="text/css" rel="stylesheet" />);
 
     if (!collection) {
-      return <Frame className={styles.frame} head={styleEl} />;
+      return <Frame className={styles.frame} head={styleEls} />;
     }
 
     // We need to create a lightweight component here so that we can

--- a/src/components/Widgets/BooleanControl.js
+++ b/src/components/Widgets/BooleanControl.js
@@ -4,10 +4,10 @@ import Switch from 'react-toolbox/lib/switch';
 
 export default class BooleanControl extends React.Component {
   render() {
-    const { value, field, forId, onChange } = this.props;
+    const { value, field, forID, onChange } = this.props;
     return (
       <Switch
-        id={forId}
+        id={forID}
         checked={value === undefined ? field.get('defaultValue', false) : value}
         onChange={onChange}
       />
@@ -18,6 +18,6 @@ export default class BooleanControl extends React.Component {
 BooleanControl.propTypes = {
   field: ImmutablePropTypes.map.isRequired,
   onChange: PropTypes.func.isRequired,
-  forID: PropTypes.string.isRequired,
+  forID: PropTypes.string,
   value: PropTypes.bool,
 };

--- a/src/components/Widgets/ControlHOC.js
+++ b/src/components/Widgets/ControlHOC.js
@@ -8,7 +8,10 @@ class ControlHOC extends Component {
   static propTypes = {
     controlComponent: PropTypes.func.isRequired,
     field: ImmutablePropTypes.map.isRequired,
-    value: PropTypes.node,
+    value: PropTypes.oneOfType([
+      PropTypes.object,
+      PropTypes.string,
+    ]),
     metadata: ImmutablePropTypes.map,
     onChange: PropTypes.func.isRequired,
     onValidate: PropTypes.func.isRequired,

--- a/src/components/Widgets/DateTimeControl.js
+++ b/src/components/Widgets/DateTimeControl.js
@@ -19,5 +19,8 @@ export default class DateTimeControl extends React.Component {
 
 DateTimeControl.propTypes = {
   onChange: PropTypes.func.isRequired,
-  value: PropTypes.object, // eslint-disable-line
+  value: PropTypes.oneOfType([
+    PropTypes.object,
+    PropTypes.string,
+  ]),
 };

--- a/src/components/Widgets/ListControl.js
+++ b/src/components/Widgets/ListControl.js
@@ -30,7 +30,7 @@ export default class ListControl extends Component {
     onChange: PropTypes.func.isRequired,
     value: PropTypes.node,
     field: PropTypes.node,
-    forID: PropTypes.string.isRequired,
+    forID: PropTypes.string,
     getAsset: PropTypes.func.isRequired,
     onAddAsset: PropTypes.func.isRequired,
     onRemoveAsset: PropTypes.func.isRequired,

--- a/src/components/Widgets/NumberControl.js
+++ b/src/components/Widgets/NumberControl.js
@@ -13,5 +13,5 @@ export default class StringControl extends React.Component {
 StringControl.propTypes = {
   onChange: PropTypes.func.isRequired,
   value: PropTypes.node,
-  forID: PropTypes.string.isRequired,
+  forID: PropTypes.string,
 };

--- a/src/components/Widgets/ObjectControl.js
+++ b/src/components/Widgets/ObjectControl.js
@@ -12,7 +12,7 @@ export default class ObjectControl extends Component {
     getAsset: PropTypes.func.isRequired,
     value: PropTypes.node,
     field: PropTypes.object,
-    forID: PropTypes.string.isRequired,
+    forID: PropTypes.string,
     className: PropTypes.string,
   };
 

--- a/src/components/Widgets/StringControl.js
+++ b/src/components/Widgets/StringControl.js
@@ -12,6 +12,6 @@ export default class StringControl extends React.Component {
 
 StringControl.propTypes = {
   onChange: PropTypes.func.isRequired,
-  forID: PropTypes.string.isRequired,
+  forID: PropTypes.string,
   value: PropTypes.node,
 };

--- a/src/components/Widgets/TextControl.js
+++ b/src/components/Widgets/TextControl.js
@@ -27,6 +27,6 @@ export default class StringControl extends React.Component {
 
 StringControl.propTypes = {
   onChange: PropTypes.func.isRequired,
-  forID: PropTypes.string.isRequired,
+  forID: PropTypes.string,
   value: PropTypes.node,
 };

--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -26,6 +26,7 @@ module.exports = merge.smart(require('./webpack.base.js'), {
   },
   context: path.join(__dirname, 'src'),
   module: {
+    noParse: /localforage\.js/,
     loaders: [
       {
         loader: 'babel',


### PR DESCRIPTION
**- Summary**
First, thanks for your app, it is really usefull !

I wanted to remove warnings that I saw while browsing the example and building my `config.yml`.
Here are the results:
- remove `localforage.js` warning (This seems to be a pre-built javascript file)
- warnings/proptypes: use oneOfType to support object and string
- warnings/widgets: forID is not required (can be undefined) + typo
- warnings/map>key related warnings + typo

**- Test plan**
To test this PR, you can browse the example and look at the console, this PR removes most of warnings

**- Description for the changelog**
fix development warnings (proptypes, keys in map, prebuild javascript + typos
