### PR TITLE
Add cache buster to all GitHub API calls

### DIFF
--- a/src/backends/github/API.js
+++ b/src/backends/github/API.js
@@ -44,7 +44,8 @@ export default class API {
   }
 
   urlFor(path, options) {
-    const params = [];
+    const cacheBuster = new Date().getTime();
+    const params = [`ts=${cacheBuster}`];
     if (options.params) {
       for (const key in options.params) {
         params.push(`${ key }=${ encodeURIComponent(options.params[key]) }`);


### PR DESCRIPTION
This should solve issues like #308 and the issues with cached
API responses after deleting an entry

**- Summary**

GitHub's API does fairly aggressive caching for GET requests, at this causes problems in several cases. Especially when creating commit trees where a stale response from the GitHub API can make us try to base the changes on a wrong SHA and lead to issues like #308 

This also caused problem for the work on deleting entries, since we would get a stale folder list right after entry deletion.

This PR takes the brute force approach of adding a cache buster timestamp as a query parameter to all GitHub API requests.

**- Test plan**

Warning - I haven't tested this yet. The old Ember prototype had a similar cache buster approach (though only on some requests) so I'm fairly confident in the solution. An alternative approach would be to only set the cache buster parameter for get requests that MUST be uncached.

**- Description for the changelog**

Fix stale reads from GitHub's API

**- A picture of a cute animal (not mandatory but encouraged)**

![img_20170502_141429312](https://user-images.githubusercontent.com/6515/27005096-058e3782-4dcc-11e7-866b-2640486e637c.jpg)
