### PR TITLE
Docs: change unpkg links to pull latest release

### DIFF
--- a/docs/customization.md
+++ b/docs/customization.md
@@ -26,7 +26,7 @@ CMS.registerPreviewStyle(file);
 **Example:**
 ```html
 // index.html
-<script src="https://unpkg.com/netlify-cms/dist/cms.js"></script>
+<script src="https://unpkg.com/netlify-cms@~0.4/dist/cms.js"></script>
 <script>
   CMS.registerPreviewStyle("/example.css");
 </script>
@@ -67,7 +67,7 @@ Registers a template for a collection.
     **Example:**
     
     ```html
-    <script src="https://unpkg.com/netlify-cms/dist/cms.js"></script>
+    <script src="https://unpkg.com/netlify-cms@~0.4/dist/cms.js"></script>
     <script>
     var PostPreview = createClass({
       render: function() {

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -26,7 +26,7 @@ CMS.registerPreviewStyle(file);
 **Example:**
 ```html
 // index.html
-<script src="https://unpkg.com/netlify-cms@^0.x/dist/cms.js"></script>
+<script src="https://unpkg.com/netlify-cms/dist/cms.js"></script>
 <script>
   CMS.registerPreviewStyle("/example.css");
 </script>
@@ -67,7 +67,7 @@ Registers a template for a collection.
     **Example:**
     
     ```html
-    <script src="https://unpkg.com/netlify-cms@^0.x/dist/cms.js"></script>
+    <script src="https://unpkg.com/netlify-cms/dist/cms.js"></script>
     <script>
     var PostPreview = createClass({
       render: function() {

--- a/docs/extending.md
+++ b/docs/extending.md
@@ -30,7 +30,7 @@ CMS.registerWidget(field, control, \[preview\])
 **Example:**
 
 ```html
-<script src="https://unpkg.com/netlify-cms/dist/cms.js"></script>
+<script src="https://unpkg.com/netlify-cms@~0.4/dist/cms.js"></script>
 <script>
 var CategoriesControl = createClass({
   handleChange: function(e) {
@@ -60,7 +60,7 @@ Register a block level component for the Markdown editor
 **Example:**
 
 ```html
-<script src="https://unpkg.com/netlify-cms/dist/cms.js"></script>
+<script src="https://unpkg.com/netlify-cms@~0.4/dist/cms.js"></script>
 <script>
 CMS.registerEditorComponent({
   // Internal id of the component

--- a/docs/extending.md
+++ b/docs/extending.md
@@ -30,7 +30,7 @@ CMS.registerWidget(field, control, \[preview\])
 **Example:**
 
 ```html
-<script src="https://unpkg.com/netlify-cms@^0.x/dist/cms.js"></script>
+<script src="https://unpkg.com/netlify-cms/dist/cms.js"></script>
 <script>
 var CategoriesControl = createClass({
   handleChange: function(e) {
@@ -60,7 +60,7 @@ Register a block level component for the Markdown editor
 **Example:**
 
 ```html
-<script src="https://unpkg.com/netlify-cms@^0.x/dist/cms.js"></script>
+<script src="https://unpkg.com/netlify-cms/dist/cms.js"></script>
 <script>
 CMS.registerEditorComponent({
   // Internal id of the component

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -25,11 +25,11 @@ The admin interface is a single-page app with the entry point stored in a static
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Content Manager</title>
   
-  <link rel="stylesheet" href="https://unpkg.com/netlify-cms@^0.3/dist/cms.css" />
+  <link rel="stylesheet" href="https://unpkg.com/netlify-cms/dist/cms.css" />
   
 </head>
 <body>
-  <script src="https://unpkg.com/netlify-cms@^0.3/dist/cms.js"></script>
+  <script src="https://unpkg.com/netlify-cms/dist/cms.js"></script>
 </body>
 </html>
 ```

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -25,11 +25,11 @@ The admin interface is a single-page app with the entry point stored in a static
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Content Manager</title>
   
-  <link rel="stylesheet" href="https://unpkg.com/netlify-cms/dist/cms.css" />
+  <link rel="stylesheet" href="https://unpkg.com/netlify-cms@~0.4/dist/cms.css" />
   
 </head>
 <body>
-  <script src="https://unpkg.com/netlify-cms/dist/cms.js"></script>
+  <script src="https://unpkg.com/netlify-cms@~0.4/dist/cms.js"></script>
 </body>
 </html>
 ```

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -57,11 +57,11 @@ The first file, `admin/index.html`, is the entry point for the Netlify CMS admin
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Content Manager</title>
 
-  <link rel="stylesheet" href="https://unpkg.com/netlify-cms@^0.3/dist/cms.css" />
+  <link rel="stylesheet" href="https://unpkg.com/netlify-cms/dist/cms.css" />
 
 </head>
 <body>
-  <script src="https://unpkg.com/netlify-cms@^0.3/dist/cms.js"></script>
+  <script src="https://unpkg.com/netlify-cms/dist/cms.js"></script>
 </body>
 </html>
 ```

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -57,11 +57,11 @@ The first file, `admin/index.html`, is the entry point for the Netlify CMS admin
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Content Manager</title>
 
-  <link rel="stylesheet" href="https://unpkg.com/netlify-cms/dist/cms.css" />
+  <link rel="stylesheet" href="https://unpkg.com/netlify-cms@~0.4/dist/cms.css" />
 
 </head>
 <body>
-  <script src="https://unpkg.com/netlify-cms/dist/cms.js"></script>
+  <script src="https://unpkg.com/netlify-cms@~0.4/dist/cms.js"></script>
 </body>
 </html>
 ```


### PR DESCRIPTION
**- Summary**
html snippets in the docs demonstrate loading the CMS via an unpkg.com link that's pinned at v0.3 (or 0.x in a few places). This changes the link to point to the latest release instead.

**- Test plan**
None

**- Description for the changelog**
Docs: update links to unpkg.com to pull the latest release of Netlify CMS.

**- A picture of a cute animal (not mandatory but encouraged)**
http://i.imgur.com/rDiVe2z.gifv (technically not an image, but too cute)