### PR TITLE
Fix #458 by ending case sensitivity of names of fields used in slug construction

### DIFF
--- a/src/backends/backend.js
+++ b/src/backends/backend.js
@@ -28,18 +28,18 @@ const slugFormatter = (template = "{{slug}}", entryData) => {
   const date = new Date();
 
   const getIdentifier = (entryData) => {
-	  const validIdentifierFields = ["title", "path"];
-	  const identifiers = validIdentifierFields.map((field) =>
-	  	entryData.find((_, key) => key.toLowerCase() === field)
-	  );
+    const validIdentifierFields = ["title", "path"];
+    const identifiers = validIdentifierFields.map((field) =>
+      entryData.find((_, key) => key.toLowerCase() === field)
+    );
 
-	  const identifier = identifiers.find(ident => ident !== undefined);
+    const identifier = identifiers.find(ident => ident !== undefined);
 
-	  if (identifier === undefined) {
-	      throw new Error("Collection must have a field name that is a valid entry identifier"); 
-	  }
-	  
-	  return identifier;
+    if (identifier === undefined) {
+      throw new Error("Collection must have a field name that is a valid entry identifier"); 
+    }
+
+    return identifier;
   };
   
   return template.replace(/\{\{([^\}]+)\}\}/g, (_, field) => {

--- a/src/backends/backend.js
+++ b/src/backends/backend.js
@@ -29,19 +29,17 @@ const slugFormatter = (template = "{{slug}}", entryData) => {
 
   const getIdentifier = (entryData) => {
 	  const validIdentifierFields = ["title", "path"];
-	  const identifiers = validIdentifierFields.map((field) => {
-	  	return entryData.find((_, key) => {
-	  		return key.toLowerCase() === field;
-	  	});
-	  });
-	  
-	  const identifier = identifiers.find(i => typeof i !== 'undefined');
+	  const identifiers = validIdentifierFields.map((field) =>
+	  	entryData.find((_, key) => key.toLowerCase() === field)
+	  );
 
-	  if (typeof identifier === 'undefined') {
+	  const identifier = identifiers.find(ident => ident !== undefined);
+
+	  if (identifier === undefined) {
 	      throw new Error("Collection must have a field name that is a valid entry identifier"); 
-	  } else {
-	  	return identifier;
 	  }
+	  
+	  return identifier;
   };
   
   return template.replace(/\{\{([^\}]+)\}\}/g, (_, field) => {

--- a/src/backends/backend.js
+++ b/src/backends/backend.js
@@ -26,7 +26,24 @@ class LocalStorageAuthStore {
 
 const slugFormatter = (template = "{{slug}}", entryData) => {
   const date = new Date();
-  const identifier = entryData.get("title", entryData.get("path"));
+
+  const getIdentifier = (entryData) => {
+	  const validIdentifierFields = ["title", "path"];
+	  const identifiers = validIdentifierFields.map((field) => {
+	  	return entryData.find((_, key) => {
+	  		return key.toLowerCase() === field;
+	  	});
+	  });
+	  
+	  const identifier = identifiers.find(i => typeof i !== 'undefined');
+
+	  if (typeof identifier === 'undefined') {
+	      throw new Error("Collection must have a field name that is a valid entry identifier"); 
+	  } else {
+	  	return identifier;
+	  }
+  };
+  
   return template.replace(/\{\{([^\}]+)\}\}/g, (_, field) => {
     switch (field) {
       case "year":
@@ -36,7 +53,7 @@ const slugFormatter = (template = "{{slug}}", entryData) => {
       case "day":
         return (`0${ date.getDate() }`).slice(-2);
       case "slug":
-        return slug(identifier.trim(), {lower: true});
+        return slug(getIdentifier(entryData).trim(), {lower: true});
       default:
         return slug(entryData.get(field, "").trim(), {lower: true});
     }

--- a/src/backends/backend.js
+++ b/src/backends/backend.js
@@ -30,7 +30,7 @@ const slugFormatter = (template = "{{slug}}", entryData) => {
   const getIdentifier = (entryData) => {
     const validIdentifierFields = ["title", "path"];
     const identifiers = validIdentifierFields.map((field) =>
-      entryData.find((_, key) => key.toLowerCase() === field)
+      entryData.find((_, key) => key.toLowerCase().trim() === field)
     );
 
     const identifier = identifiers.find(ident => ident !== undefined);


### PR DESCRIPTION
**- Summary**

`identifier` is used to build slug when slug field is `{{slug}}` and was retrieved using nested `.get()` methods on `entryData` which did not fail gracefully and was sensitive to the case of the field name declaration in `config.yml` This change makes the assignment of `identifier` more robust by making it effectively case-insensitive, by throwing a meaningful error when no usable entry identifier can be found, and by moving the   assignment of `identifier` inside the `case "slug"` so that it is only assigned when required.

**- Test plan**

Tested using steps to repro in #458 on Chromium using test-repo backend. 

All jest tests passing.

**- Description for the changelog**

Names of entry fields used in slug construction as entry identifiers are no longer case-sensitive

**- A picture of a cute animal (not mandatory but encouraged)**

![image](https://user-images.githubusercontent.com/4513526/27436116-22ef2258-5756-11e7-9de1-dc13ec145d1d.png)

