### PR TITLE
In collection view, fix rendering of falsy field values

### DIFF
--- a/src/components/EntryListing/EntryListing.js
+++ b/src/components/EntryListing/EntryListing.js
@@ -57,7 +57,7 @@ export default class EntryListing extends React.Component {
           : inferedFields.remainingFields && inferedFields.remainingFields.map(f => (
             <p key={f.get('name')} className={styles.cardList}>
               <span className={styles.cardListLabel}>{f.get('label')}:</span>{' '}
-              { (entry.getIn(['data', f.get('name')], '') ).toString() }
+              { entry.getIn(['data', f.get('name')], '').toString() }
             </p>
           ))
         }

--- a/src/components/EntryListing/EntryListing.js
+++ b/src/components/EntryListing/EntryListing.js
@@ -57,7 +57,7 @@ export default class EntryListing extends React.Component {
           : inferedFields.remainingFields && inferedFields.remainingFields.map(f => (
             <p key={f.get('name')} className={styles.cardList}>
               <span className={styles.cardListLabel}>{f.get('label')}:</span>{' '}
-              { (entry.getIn(['data', f.get('name')]) || '').toString() }
+              { (entry.getIn(['data', f.get('name')], '') ).toString() }
             </p>
           ))
         }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines;
https://github.com/netlify/netlify-cms/blob/master/CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first three fields are mandatory:
-->

**- Summary**

Fixes #462. Logical OR was used to provide a fallback value of `''` when field data cannot be found during card rendering in collection view. With boolean widgets, field values can now be falsy and this was trapping the string representation of `false` (and other falsy values). Rewrite to use `Map` API `notSetValue` instead.

**- Test plan**

All jest tests passing. Not covered in test suite. 
Tested in browser using issue steps to repro.

**- Description for the changelog**

Boolean data field values are rendered accurately in collection view.  

**- A picture of a cute animal (not mandatory but encouraged)**