### PR TITLE
hide hidden widget in object and list controls

### DIFF
--- a/example/config.yml
+++ b/example/config.yml
@@ -72,6 +72,7 @@ collections: # A list of collections the CMS should be able to edit
       - {label: "Image", name: "image", widget: "image"}
       - {label: "File", name: "file", widget: "file"}
       - {label: "Select", name: "select", widget: "select", options: ["a", "b", "c"]}
+      - {label: "Hidden", name: "hidden", widget: "hidden", default: "hidden"}
       - label: "Object"
         name: "object"
         widget: "object"
@@ -128,6 +129,7 @@ collections: # A list of collections the CMS should be able to edit
                   - {label: "Image", name: "image", widget: "image"}
                   - {label: "File", name: "file", widget: "file"}
                   - {label: "Select", name: "select", widget: "select", options: ["a", "b", "c"]}
+                  - {label: "Hidden", name: "hidden", widget: "hidden", default: "hidden"}
                   - label: "Object"
                     name: "object"
                     widget: "object"

--- a/src/components/Widgets/ObjectControl.js
+++ b/src/components/Widgets/ObjectControl.js
@@ -22,6 +22,9 @@ export default class ObjectControl extends Component {
 
   controlFor(field) {
     const { onAddAsset, onRemoveAsset, getAsset, value, onChange } = this.props;
+    if (field.get('widget') === 'hidden') {
+      return null;
+    }
     const widget = resolveWidget(field.get('widget') || 'string');
     const fieldValue = value && Map.isMap(value) ? value.get(field.get('name')) : value;
 


### PR DESCRIPTION
Fixes hidden widgets not being hidden when nested (instead outputs something like "No control widget for 'hidden'").

Change only needed to be applied to object control since the list control uses the object control.