### PR TITLE
adds context to new list item button

### DIFF
--- a/src/components/Widgets/ListControl.css
+++ b/src/components/Widgets/ListControl.css
@@ -22,6 +22,7 @@
 
 .addButtonText {
   margin-left: 4px;
+  text-transform: lowercase;
 }
 
 .removeButton {

--- a/src/components/Widgets/ListControl.js
+++ b/src/components/Widgets/ListControl.js
@@ -170,8 +170,8 @@ export default class ListControl extends Component {
   }
 
   renderListControl() {
-    const { value, forID } = this.props;
-    const listLabel = this.props.field._root.entries[0][1];
+    const { value, forID, field } = this.props;
+    const listLabel = field.get('label');
 
     return (<div id={forID}>
       {value && value.map((item, index) => this.renderItem(item, index))}

--- a/src/components/Widgets/ListControl.js
+++ b/src/components/Widgets/ListControl.js
@@ -171,11 +171,13 @@ export default class ListControl extends Component {
 
   renderListControl() {
     const { value, forID } = this.props;
+    const listLabel = this.props.field._root.entries[0][1];
+
     return (<div id={forID}>
       {value && value.map((item, index) => this.renderItem(item, index))}
       <button className={styles.addButton} onClick={this.handleAdd}>
         <FontIcon value="add" className={styles.addButtonIcon} />
-        <span className={styles.addButtonText}>new</span>
+        <span className={styles.addButtonText}>new {listLabel}</span>
       </button>
     </div>);
   }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines;
https://github.com/netlify/netlify-cms/blob/master/CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first three fields are mandatory:
-->

> Fixes Issue #300 

**- Summary**
This PR adds the list label to the new button which provides users better context (especially with nested lists).



**- Test plan**
All tests continue to pass. I created nested lists 20 levels deep to test & ensure scalability. I ran `npm build test` & `npm run line` in compliance with contributing.md guidelines.
<br/>

#### Example screenshot of the result here: ![Screenshot](https://cldup.com/PJFzqF6ZNS.png)  
<br/>

**- Description for the changelog**

- Adds the specific content type to the list control widget's "new" button.

<br/>

**- A picture of a cute animal (not mandatory but encouraged)**

> ![Basketball Dog :)](https://media.giphy.com/media/HWamJO1FK5dNm/giphy.gif)