### PR TITLE
Reverse change in #415; Image paths encoded before displaying instead

### DIFF
--- a/src/components/EntryListing/EntryListing.js
+++ b/src/components/EntryListing/EntryListing.js
@@ -41,6 +41,9 @@ export default class EntryListing extends React.Component {
     const title = label || entry.getIn(['data', inferedFields.titleField]);
     let image = entry.getIn(['data', inferedFields.imageField]);
     image = resolvePath(image, publicFolder);
+    if(image) {
+      image = encodeURI(image);
+    }
 
     return (
       <Card

--- a/src/lib/pathHelper.js
+++ b/src/lib/pathHelper.js
@@ -1,5 +1,5 @@
 const absolutePath = new RegExp('^(?:[a-z]+:)?//', 'i');
-const normalizePath = path => path.replace(/[\\\/]+/g, '/').replace(/[\s]+/g, '%20');
+const normalizePath = path => path.replace(/[\\\/]+/g, '/');
 
 export function resolvePath(path, basePath) { // eslint-disable-line
   // No path provided, skip


### PR DESCRIPTION


**- Summary**

PR #415 fixed the image path problem, but too deep. The fix created a problem where all images with a space in the image name ended up with "%20" in the actual persisted image name. This was because resolvePath() was obviously used in both display and persist cases (unknown to the author of the fix (me) at the time).

Instead, the image name is now encoded in EntryListing.js right before displaying.

**- Test plan**

Images display in cards. Uploaded images should no longer have "%20" in their names.
Posts and page types display normally.

**- Description for the changelog**

Image name is now encoded in EntryListing.js rather than pathHelper.js.

**- A picture of a cute animal (not mandatory but encouraged)**

![image](https://user-images.githubusercontent.com/3292160/27816926-8d6f2948-605c-11e7-8210-1c0a9db326dd.png)
