### PR TITLE
Fix list item reordering #437

### DIFF
--- a/src/components/Widgets/MarkdownControlElements/VisualEditor/index.js
+++ b/src/components/Widgets/MarkdownControlElements/VisualEditor/index.js
@@ -135,8 +135,10 @@ export default class Editor extends Component {
 
   componentDidUpdate(prevProps, prevState) {
     const editorValue = this.state.serializer.serialize(this.view.state.doc);
-
+    // Check that the content of the editor is well synchronized with the props value after rendering.
+    // Sometimes the editor isn't well updated (eg. after items reordering)
     if (editorValue !== this.props.value && editorValue !== prevProps.value) {
+      // If the content of the editor isn't correct, we update its state with a new one.
       this.view.updateState(this.createEditorState());
     }
   }

--- a/src/components/Widgets/MarkdownControlElements/VisualEditor/index.js
+++ b/src/components/Widgets/MarkdownControlElements/VisualEditor/index.js
@@ -105,27 +105,40 @@ export default class Editor extends Component {
   }
 
   componentDidMount() {
-    const { schema, parser } = this.state;
-    const doc = parser.parse(this.props.value || '');
     this.view = new EditorView(this.ref, {
-      state: EditorState.create({
-        doc,
-        schema,
-        plugins: [
-          inputRules({
-            rules: allInputRules.concat(buildInputRules(schema)),
-          }),
-          keymap(buildKeymap(schema)),
-          keymap(baseKeymap),
-          history.history(),
-          keymap({
-            'Mod-z': history.undo,
-            'Mod-y': history.redo,
-          }),
-        ],
-      }),
+      state: this.createEditorState(),
       onAction: this.handleAction,
     });
+  }
+
+  createEditorState() {
+    const { schema, parser } = this.state;
+    const doc = parser.parse(this.props.value || '');
+
+    return EditorState.create({
+      doc,
+      schema,
+      plugins: [
+        inputRules({
+          rules: allInputRules.concat(buildInputRules(schema)),
+        }),
+        keymap(buildKeymap(schema)),
+        keymap(baseKeymap),
+        history.history(),
+        keymap({
+          'Mod-z': history.undo,
+          'Mod-y': history.redo,
+        }),
+      ],
+    });
+  }
+
+  componentDidUpdate(prevProps, prevState) {
+    const editorValue = this.state.serializer.serialize(this.view.state.doc);
+
+    if (editorValue !== this.props.value && editorValue !== prevProps.value) {
+      this.view.updateState(this.createEditorState());
+    }
   }
 
   handleAction = (action) => {


### PR DESCRIPTION
**- Summary**
Fix list item reordering. As explain in the issue #437.

**- Test plan**
In the example project:

- Open the authors entry in the settings collection
- Update the author descriptions to be distinct
( editor have to be on visual mode, markdown disabled )
- Reorder the authors
- Check the descriptions
- Before, the descriptions wasn't correctly updated, now it should be correct.

**- Description for the changelog**
After component did update, check the editor content is the same that the state value.
If it isn't the same, reset the state using a mutualized `createState` method.
I think it isn't the cleanest way to fix this bug.
It's better than nothing but if you have any other idea ...
