### PR TITLE
Fix editor scrolls to the top #436

### DIFF
--- a/src/components/ScrollSync/ScrollSync.js
+++ b/src/components/ScrollSync/ScrollSync.js
@@ -10,6 +10,7 @@ export default class ScrollSync extends Component {
   static childContextTypes = {
     registerPane: PropTypes.func,
     unregisterPane: PropTypes.func,
+    syncScrollPositions: PropTypes.func
   };
 
   panes = [];
@@ -18,6 +19,7 @@ export default class ScrollSync extends Component {
     return {
       registerPane: this.registerPane,
       unregisterPane: this.unregisterPane,
+      syncScrollPositions: this.syncScrollPositions
     };
   }
 

--- a/src/components/ScrollSync/ScrollSyncPane.js
+++ b/src/components/ScrollSync/ScrollSyncPane.js
@@ -11,6 +11,7 @@ export default class ScrollSyncPane extends Component {
   static contextTypes = {
     registerPane: PropTypes.func.isRequired,
     unregisterPane: PropTypes.func.isRequired,
+    syncScrollPositions: PropTypes.func.isRequired
   };
 
   componentDidMount() {
@@ -20,6 +21,17 @@ export default class ScrollSyncPane extends Component {
 
   componentWillUnmount() {
     this.context.unregisterPane(this.node);
+  }
+
+  componentWillUpdate(nextProps, nextState) {
+    this.context.unregisterPane(this.node);
+  }
+
+  componentDidUpdate(nextProps, nextState) {
+    window.requestAnimationFrame(() => {
+      this.context.registerPane(this.node);
+      this.context.syncScrollPositions(this.node);
+    });
   }
 
   render() {


### PR DESCRIPTION
Fixes editor scrolls to the top with every stroke under certain conditions:  #436

**- Summary**

Avoid editor scrolls to top at each preview update.

**- Test plan**

As explain in #436, in the CMS example project:
- shrink the viewport height to something short, maybe 1000px or so
- upload a large image as the featured image
- try to enter text in the body field
- the editor scroll to the top at each preview update, now it shouldn't.

**- Description for the changelog**

Disable the event listener during the preview rendering and re-attach the event listener at the next requestAnimationFrame after the preview has been updated.
