### PR TITLE
Stopped the pluralization of collection name

### DIFF
--- a/package.json
+++ b/package.json
@@ -113,7 +113,6 @@
     "moment": "^2.11.2",
     "netlify-auth-js": "^0.5.5",
     "normalize.css": "^4.2.0",
-    "pluralize": "^3.0.0",
     "preliminaries": "1.1.0",
     "preliminaries-parser-toml": "1.1.0",
     "preliminaries-parser-yaml": "1.1.0",

--- a/src/components/AppHeader/AppHeader.js
+++ b/src/components/AppHeader/AppHeader.js
@@ -1,6 +1,5 @@
 import React, { PropTypes } from "react";
 import ImmutablePropTypes from "react-immutable-proptypes";
-import pluralize from "pluralize";
 import { IndexLink } from "react-router";
 import { IconMenu, Menu, MenuItem } from "react-toolbox/lib/menu";
 import Avatar from "react-toolbox/lib/avatar";
@@ -81,7 +80,7 @@ export default class AppHeader extends React.Component {
                 key={collection.get("name")}
                 value={collection.get("name")}
                 onClick={this.handleCreatePostClick.bind(this, collection.get('name'))} // eslint-disable-line
-                caption={pluralize(collection.get("label"), 1)}
+                caption={collection.get("label")}
               />
             )
           }

--- a/src/components/UnpublishedListing/UnpublishedListing.js
+++ b/src/components/UnpublishedListing/UnpublishedListing.js
@@ -3,7 +3,6 @@ import { DragSource, DropTarget, HTML5DragDrop } from 'react-simple-dnd';
 import ImmutablePropTypes from 'react-immutable-proptypes';
 import { Link } from 'react-router';
 import moment from 'moment';
-import pluralize from 'pluralize';
 import { capitalize } from 'lodash'
 import { Card, CardTitle, CardText, CardActions } from 'react-toolbox/lib/card';
 import Button from 'react-toolbox/lib/button';
@@ -82,7 +81,7 @@ class UnpublishedListing extends React.Component {
                 <div className={styles.draggable}>
                   <Card className={styles.card}>
                     <UnpublishedListingCardMeta
-                      meta={capitalize(pluralize(collection))}
+                      meta={pluralize(collection)}
                       label={isModification ? "" : "New"}
                     />
                     <CardTitle

--- a/src/components/UnpublishedListing/UnpublishedListing.js
+++ b/src/components/UnpublishedListing/UnpublishedListing.js
@@ -81,7 +81,7 @@ class UnpublishedListing extends React.Component {
                 <div className={styles.draggable}>
                   <Card className={styles.card}>
                     <UnpublishedListingCardMeta
-                      meta={pluralize(collection)}
+                      meta={capitalize(collection)}
                       label={isModification ? "" : "New"}
                     />
                     <CardTitle

--- a/src/containers/App.js
+++ b/src/containers/App.js
@@ -1,6 +1,5 @@
 import React, { PropTypes } from 'react';
 import ImmutablePropTypes from 'react-immutable-proptypes';
-import pluralize from 'pluralize';
 import { connect } from 'react-redux';
 import { IndexLink } from "react-router";
 import FontIcon from 'react-toolbox/lib/font_icon';
@@ -157,7 +156,7 @@ class App extends React.Component {
                       className={sidebarStyles.viewEntriesLink}
                       onClick={e => this.handleLinkClick(e, navigateToCollection, collectionName)}
                     >
-                      {pluralize(collection.get('label'))}
+                      {collection.get('label')}
                     </a>
                     {
                       collection.get('create') ? (


### PR DESCRIPTION
**- Summary**

Removed pluralization of collection names in the CMS.

As suggested, this is the minimalist fix for #422

**- Test plan**

Pass all current tests and no additional tests required.

**- Description for the changelog**

Stopped the pluralization of collection name