### PR TITLE
Make GitHub repo name comparison case-insensitive (fixes #510)

### DIFF
--- a/src/backends/github/API.js
+++ b/src/backends/github/API.js
@@ -23,7 +23,7 @@ export default class API {
     return this.request('/user/repos').then((repos) => {
       let contributor = false
       for (const repo of repos) {
-        if (repo.full_name === this.repo && repo.permissions.push) contributor = true;
+        if (repo.full_name.toLowerCase() === this.repo.toLowerCase() && repo.permissions.push) contributor = true;
       }
       return contributor;
     }).catch((error) => {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines;
https://github.com/netlify/netlify-cms/blob/master/CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first three fields are mandatory:
-->

**- Summary**

Makes comparison of repo names from the config and the GitHub API case-insensitive since GitHub's user and repo names are case-insensitive. Fixes #510.

<!--
Explain the **motivation** for making this change.
What existing problem does the pull request solve?
-->

**- Test plan**

Tested manually.

<!--
Demonstrate the code is solid.
Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.
-->

**- Description for the changelog**

Make GitHub repo name comparison case-insensitive
