### PR TITLE
Disable Sticky functionality when toolbar plugin is active

### DIFF
--- a/src/components/UI/Sticky/Sticky.js
+++ b/src/components/UI/Sticky/Sticky.js
@@ -207,9 +207,9 @@ export class Sticky extends Component {
             props.className,
             styles.sticky,
             {
-              [styles.stickyActive]: state.shouldStick,
-              [props.classNameActive]: state.shouldStick,
-              [styles.stickyAtBottom]: state.shouldStickAtBottom,
+              [styles.stickyActive]: (state.shouldStick && !props.disableSticky),
+              [props.classNameActive]: (state.shouldStick && !props.disableSticky),
+              [styles.stickyAtBottom]: (state.shouldStickAtBottom && !props.disableSticky)
             },
           )}
           style={

--- a/src/components/Widgets/MarkdownControlElements/RawEditor/index.js
+++ b/src/components/Widgets/MarkdownControlElements/RawEditor/index.js
@@ -67,7 +67,10 @@ export default class RawEditor extends React.Component {
   constructor(props) {
     super(props);
     const plugins = registry.getEditorComponents();
-    this.state = { plugins };
+    this.state = {
+      plugins,
+      activePlugin: null
+    };
     this.shortcuts = {
       meta: {
         b: this.handleBold,
@@ -92,6 +95,10 @@ export default class RawEditor extends React.Component {
   componentWillUnmount() {
     this.element.removeEventListener('paste', this.handlePaste);
   }
+
+  onActivePlugin = (plugin) => {
+    this.setState({ activePlugin: plugin });
+  };
 
   getSelection() {
     const start = this.element.selectionStart;
@@ -307,7 +314,7 @@ export default class RawEditor extends React.Component {
 
   render() {
     const { onAddAsset, onRemoveAsset, getAsset } = this.props;
-    const { plugins, selectionPosition, dragging } = this.state;
+    const { plugins, selectionPosition, dragging, activePlugin } = this.state;
     const classNames = [styles.root];
     if (dragging) {
       classNames.push(styles.dragging);
@@ -324,6 +331,7 @@ export default class RawEditor extends React.Component {
         className={styles.editorControlBar}
         classNameActive={styles.editorControlBarSticky}
         fillContainerWidth
+        disableSticky={activePlugin !== null}
       >
         <Toolbar
           selectionPosition={selectionPosition}
@@ -338,6 +346,7 @@ export default class RawEditor extends React.Component {
           onAddAsset={onAddAsset}
           onRemoveAsset={onRemoveAsset}
           getAsset={getAsset}
+          onActivePlugin={this.onActivePlugin}
           rawMode
         />
       </Sticky>

--- a/src/components/Widgets/MarkdownControlElements/Toolbar/Toolbar.js
+++ b/src/components/Widgets/MarkdownControlElements/Toolbar/Toolbar.js
@@ -23,6 +23,7 @@ export default class Toolbar extends React.Component {
     onAddAsset: PropTypes.func.isRequired,
     onRemoveAsset: PropTypes.func.isRequired,
     getAsset: PropTypes.func.isRequired,
+    onActivePlugin: PropTypes.func
   };
 
   constructor(props) {
@@ -33,16 +34,23 @@ export default class Toolbar extends React.Component {
   }
 
   handlePluginFormDisplay = (plugin) => {
-    this.setState({ activePlugin: plugin });
-  }
+    this.setState({ activePlugin: plugin }, () => {
+      if (this.props.onActivePlugin) this.props.onActivePlugin(plugin);
+    });
+  };
 
   handlePluginFormSubmit = (plugin, pluginData) => {
     this.props.onSubmit(plugin, pluginData);
-    this.setState({ activePlugin: null });
+
+    this.setState({ activePlugin: null }, () => {
+      if (this.props.onActivePlugin) this.props.onActivePlugin(null);
+    });
   };
 
   handlePluginFormCancel = (e) => {
-    this.setState({ activePlugin: null });
+    this.setState({ activePlugin: null }, () => {
+      if (this.props.onActivePlugin) this.props.onActivePlugin(null);
+    });
   };
 
   render() {
@@ -57,7 +65,7 @@ export default class Toolbar extends React.Component {
       plugins,
       onAddAsset,
       onRemoveAsset,
-      getAsset,
+      getAsset
     } = this.props;
 
     const { activePlugin } = this.state;

--- a/src/components/Widgets/MarkdownControlElements/VisualEditor/index.js
+++ b/src/components/Widgets/MarkdownControlElements/VisualEditor/index.js
@@ -101,6 +101,7 @@ export default class Editor extends Component {
       schema,
       parser: createMarkdownParser(schema, plugins),
       serializer: createSerializer(schema, plugins),
+      activePlugin: null
     };
   }
 
@@ -275,9 +276,13 @@ export default class Editor extends Component {
     this.props.onMode('raw');
   };
 
+  onActivePlugin = (plugin) => {
+    this.setState({ activePlugin: plugin });
+  };
+
   render() {
     const { onAddAsset, onRemoveAsset, getAsset } = this.props;
-    const { plugins, selectionPosition, dragging } = this.state;
+    const { plugins, selectionPosition, dragging, activePlugin } = this.state;
     const classNames = [styles.editor];
     if (dragging) {
       classNames.push(styles.dragging);
@@ -294,6 +299,7 @@ export default class Editor extends Component {
         className={styles.editorControlBar}
         classNameActive={styles.editorControlBarSticky}
         fillContainerWidth
+        disableSticky={activePlugin !== null}
       >
         <Toolbar
           selectionPosition={selectionPosition}
@@ -308,6 +314,7 @@ export default class Editor extends Component {
           onAddAsset={onAddAsset}
           onRemoveAsset={onRemoveAsset}
           getAsset={getAsset}
+          onActivePlugin={this.onActivePlugin}
         />
       </Sticky>
       <div ref={this.handleRef} />


### PR DESCRIPTION
**- Summary**
Stumbled across issue #516 earlier this week, and this fixes it! Issue happening is that when a component block was open in a Markdown widget, sticky functionality was triggering even if the component block height exceeded the height of the markdown block (and created a weird scrolling flash). You can see an example here: http://bokeh-staging.netlify.com/img/example.mp4.

**- Detailed Summary of what I've done**
- Both `VisualEditor` and `RawEditor` now track an `activePlugin` state
- They pass an `onActivePlugin` function down to `Toolbar`. (onActivePlugin updates `activePlugin` state for both Editors)
- `Toolbar` continues to track `activePlugin` state within itself, but also passes the plugin value up to `onActivePlugin`
- Pass a prop to `Sticky` (`disableSticky`) when the Editor activePlugin state exists.
- `disableSticky` prevents default Sticky behaviour from happening when active.

**- Test plan**
- Add following code snippet to `example/index.html`: (plugin example longer than Markdown widget)
```
CMS.registerEditorComponent({
      id: "three_up",
      label: "Three-Up Images",
      fields: [{name: 'image-one', label: 'First Image - Portrait', widget: 'object', fields: [
        {name: 'image', label: 'Image', widget: 'image'},
        {name: 'alt', label: 'Alt text', widget: 'string'}
      ]}, {name: 'image-two', label: 'Second Image', widget: 'object', fields: [
        {name: 'image', label: 'Image', widget: 'image'},
        {name: 'alt', label: 'Alt text', widget: 'string'}
      ]}, {name: 'image-three', label: 'Third Image', widget: 'object', fields: [
        {name: 'image', label: 'Image', widget: 'image'},
        {name: 'alt', label: 'Alt text', widget: 'string'}
      ]}],
      pattern: /three_up (\S+)\s/,
      fromBlock: function(match) {
        return {
          id: match[1]
        };
      },
      toBlock: function(obj) {
        return (`<div></div>`);
      },
      toPreview: function(obj) {
        return (`<div></div>`);
      }
    });
```
- Go into admin to any post with a Markdown widget.
- Open Three-Up Images component
- Scroll (notice that jumping no longer happens)

**- Description for the changelog**
When a editor component is open, sticky toolbar behaviour is disabled.

**- A picture of a cute animal (not mandatory but encouraged)**
![cute-baby-animals-10](https://user-images.githubusercontent.com/8507983/29245436-8187a456-7fa7-11e7-8258-a20bf2d446d2.jpg)
