### PR TITLE
Suggestion for adding Gatsby JS

### DIFF
--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -8,7 +8,7 @@ Netlify CMS relies on the GitHub API for managing files, so you'll need to have 
 
 ### Hosting with Netlify
 
-In order to use Netlify's authentication provider service, you'll need to connect your site repo with Netlify. Netlify has published a general [Step-by-Step Guide](https://www.netlify.com/blog/2016/10/27/a-step-by-step-guide-deploying-a-static-site-or-single-page-app/) for this, along with detailed guides for many popular static site generators, including [Jekyll](https://www.netlify.com/blog/2015/10/28/a-step-by-step-guide-jekyll-3.0-on-netlify/), [Hugo](https://www.netlify.com/blog/2016/09/21/a-step-by-step-guide-victor-hugo-on-netlify/), [Hexo](https://www.netlify.com/blog/2015/10/26/a-step-by-step-guide-hexo-on-netlify/), [Middleman](https://www.netlify.com/blog/2015/10/01/a-step-by-step-guide-middleman-on-netlify/), and more.
+In order to use Netlify's authentication provider service, you'll need to connect your site repo with Netlify. Netlify has published a general [Step-by-Step Guide](https://www.netlify.com/blog/2016/10/27/a-step-by-step-guide-deploying-a-static-site-or-single-page-app/) for this, along with detailed guides for many popular static site generators, including [Jekyll](https://www.netlify.com/blog/2015/10/28/a-step-by-step-guide-jekyll-3.0-on-netlify/), [Hugo](https://www.netlify.com/blog/2016/09/21/a-step-by-step-guide-victor-hugo-on-netlify/), [Hexo](https://www.netlify.com/blog/2015/10/26/a-step-by-step-guide-hexo-on-netlify/), [Middleman](https://www.netlify.com/blog/2015/10/01/a-step-by-step-guide-middleman-on-netlify/), [Gatsby](https://www.netlify.com/blog/2016/02/24/a-step-by-step-guide-gatsby-on-netlify/) and more.
 
 ### Authenticating with GitHub
 
@@ -33,9 +33,12 @@ All Netlify CMS files are contained in a static `admin` folder, stored at the ro
 These generators ... | store static files in
 --- | ---
 Jekyll, GitBook | `/` (project root)
-Hugo | `/static`
+Hugo, Gatsby* | `/static`
 Hexo, Middleman | `/source`
 Spike | `/views`
+
+Notes:
+- Gatsby treats `static` folder more strictly and will not render the admin page as the others. You will have to make a [page component](https://www.gatsbyjs.org/docs/building-with-components/) contining the necessary contents of the admin page. However, the `config.yml` is to be placed in the `static` folder in the same way. 
 
 If your generator isn't listed here, you can check its documentation, or as a shortcut, look in your project for a `CSS` or `images` folder. They're usually processed as static files, so it's likely you can store your `admin` folder next to those. (When you've found the location, feel free to add it to these docs by [filing a pull request](https://github.com/netlify/netlify-cms/blob/master/CONTRIBUTING.md)!).
 

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -38,7 +38,7 @@ Hexo, Middleman | `/source`
 Spike | `/views`
 
 Notes:
-- Gatsby treats `static` folder more strictly and will not render the admin page as the others. You will have to make a [page component](https://www.gatsbyjs.org/docs/building-with-components/) contining the necessary contents of the admin page. However, the `config.yml` is to be placed in the `static` folder in the same way. 
+- Gatsby treats the `static` folder more strictly and will not render the admin page as the other generators. You will have to make a [page component](https://www.gatsbyjs.org/docs/building-with-components/) containing the necessary scripts of the Netlify CMS app in the admin page. However, the `config.yml` is to be placed in the `static` folder in the same way.
 
 If your generator isn't listed here, you can check its documentation, or as a shortcut, look in your project for a `CSS` or `images` folder. They're usually processed as static files, so it's likely you can store your `admin` folder next to those. (When you've found the location, feel free to add it to these docs by [filing a pull request](https://github.com/netlify/netlify-cms/blob/master/CONTRIBUTING.md)!).
 


### PR DESCRIPTION
**- Summary**

I was recently trying to integrate NetlifyCMS with Netlify service and Gatsby.js. I found an open [issue](https://github.com/gatsbyjs/gatsby/issues/623) on Gatsby's repo on possible GUI for the app. I'm still in the process of making both work well, though since I also found an article [on your blog](https://www.netlify.com/blog/2016/02/24/a-step-by-step-guide-gatsby-on-netlify/) and given the increasing interest in the JAM stack, I decided this suggestion might be useful :)

**- Test plan**

Simple updates in documentation :)

**- Description for the changelog**

Notes for integrating with Gatsby statis site generator.

**- A picture of a cute animal (not mandatory but encouraged)**

![](https://lh3.googleusercontent.com/-AgV8T_SptEU/WZMRDI-9nkI/AAAAAAADY0Y/kPMDrivnB1o3FYEiamqQqn-rEL-PNK4-gCJoC/w200-h356-rw/001)