### PR TITLE
Fix confusing "yaml/yml" distinction in formats.js

### DIFF
--- a/src/formats/formats.js
+++ b/src/formats/formats.js
@@ -15,6 +15,7 @@ function formatByType(type) {
 export function formatByExtension(extension) {
   return {
     yml: yamlFormatter,
+    yaml: yamlFormatter,
     json: jsonFormatter,
     md: FrontmatterFormatter,
     markdown: FrontmatterFormatter,
@@ -24,6 +25,7 @@ export function formatByExtension(extension) {
 
 function formatByName(name) {
   return {
+    yml: yamlFormatter,
     yaml: yamlFormatter,
     frontmatter: FrontmatterFormatter,
   }[name] || FrontmatterFormatter;


### PR DESCRIPTION
**- Summary**

Makes "yml" and "yaml" synonyms for both file extensions and format
settings. Makes YAML work as the output format for `format: yml` and
`extension: yaml` settings on collections.

**- Test plan**

Manually tested.

**- Description for the changelog**

Fix confusing "yaml/yml" distinction in formats.js