### PR TITLE
Fix deletion for the `test-repo` backend.

### DIFF
--- a/src/backends/test-repo/implementation.js
+++ b/src/backends/test-repo/implementation.js
@@ -93,10 +93,10 @@ export default class TestRepo {
     return Promise.resolve();
   }
 
-  deleteEntry(path, commitMessage) {
+  deleteFile(path, commitMessage) {
     const folder = path.substring(0, path.lastIndexOf('/'));
     const fileName = path.substring(path.lastIndexOf('/') + 1);
-    window.repoFiles[folder][fileName] = undefined;
+    delete window.repoFiles[folder][fileName];
     return Promise.resolve();
   }
 }


### PR DESCRIPTION
**- Summary**

Fixes #537.

Deletion was added in #485, but the function for the `test-repo` backend was `deleteEntry` instead of `deleteFile` like it was supposed to be. Therefore, files could not be deleted.

Also, setting the key for a deleted file to `undefined` did not really remove that file from the object, so there were then errors stating `file.content` is not defined. `delete`ing the "file" from the object fixes this bug.

**- Test plan**

Manually tested with `npm run start`, then adding and deleting posts. Also deleted some default posts.

**- Description for the changelog**

Fix broken entry deletion for the `test-repo` backend.
