### PR TITLE
Number editor return number.

### DIFF
--- a/src/components/Widgets/NumberControl.js
+++ b/src/components/Widgets/NumberControl.js
@@ -2,11 +2,24 @@ import React, { PropTypes } from 'react';
 
 export default class NumberControl extends React.Component {
   handleChange = (e) => {
-    this.props.onChange(parseInt(e.target.value, 10));
+    const valueType = this.props.field.get('valueType')
+    let value
+    if(valueType === 'int') {
+      value = parseInt(e.target.value, 10)
+    } else if(valueType === 'float') {
+      value = parseFloat(e.target.value)
+    } else {
+      value = e.target.value
+    }
+    this.props.onChange(value);
   };
 
   render() {
-    return <input type="number" id={this.props.forID} value={this.props.value || ''} onChange={this.handleChange} />;
+    const { field, value, forID } = this.props
+    const min = field.get('min')
+    const max = field.get('max')
+    const step = field.get('step')
+    return <input type="number" id={forID} value={value || ''} step={step == null ? (field.get('valueType') === 'int' ? 1 : '') : step} min={min == null ? '' : min} max={max == null ? '' : max} onChange={this.handleChange} />;
   }
 }
 
@@ -14,4 +27,8 @@ NumberControl.propTypes = {
   onChange: PropTypes.func.isRequired,
   value: PropTypes.node,
   forID: PropTypes.string,
+  valueType: PropTypes.string,
+  step: PropTypes.number,
+  min: PropTypes.number,
+  max: PropTypes.number,
 };

--- a/src/components/Widgets/NumberControl.js
+++ b/src/components/Widgets/NumberControl.js
@@ -3,23 +3,30 @@ import React, { PropTypes } from 'react';
 export default class NumberControl extends React.Component {
   handleChange = (e) => {
     const valueType = this.props.field.get('valueType');
-    let value;
+    const { onChange } = this.props;
     if(valueType === 'int') {
-      value = parseInt(e.target.value, 10);
+      onChange(parseInt(e.target.value, 10));
     } else if(valueType === 'float') {
-      value = parseFloat(e.target.value);
+      onChange(parseFloat(e.target.value));
     } else {
-      value = e.target.value;
+      onChange(e.target.value);
     }
-    this.props.onChange(value);
   };
 
   render() {
     const { field, value, forID } = this.props;
-    const min = field.get('min');
-    const max = field.get('max');
-    const step = field.get('step');
-    return <input type="number" id={forID} value={value || ''} step={step == null ? (field.get('valueType') === 'int' ? 1 : '') : step} min={min == null ? '' : min} max={max == null ? '' : max} onChange={this.handleChange} />;
+    const min = field.get('min', '');
+    const max = field.get('max', '');
+    const step = field.get('step', field.get('valueType') === 'int' ? 1 : '');
+    return <input
+      type="number"
+      id={forID}
+      value={value || ''}
+      step={step}
+      min={min}
+      max={max}
+      onChange={this.handleChange}
+    />;
   }
 }
 

--- a/src/components/Widgets/NumberControl.js
+++ b/src/components/Widgets/NumberControl.js
@@ -1,8 +1,8 @@
 import React, { PropTypes } from 'react';
 
-export default class StringControl extends React.Component {
+export default class NumberControl extends React.Component {
   handleChange = (e) => {
-    this.props.onChange(e.target.value);
+    this.props.onChange(parseInt(e.target.value, 10));
   };
 
   render() {
@@ -10,7 +10,7 @@ export default class StringControl extends React.Component {
   }
 }
 
-StringControl.propTypes = {
+NumberControl.propTypes = {
   onChange: PropTypes.func.isRequired,
   value: PropTypes.node,
   forID: PropTypes.string,

--- a/src/components/Widgets/NumberControl.js
+++ b/src/components/Widgets/NumberControl.js
@@ -2,23 +2,23 @@ import React, { PropTypes } from 'react';
 
 export default class NumberControl extends React.Component {
   handleChange = (e) => {
-    const valueType = this.props.field.get('valueType')
-    let value
+    const valueType = this.props.field.get('valueType');
+    let value;
     if(valueType === 'int') {
-      value = parseInt(e.target.value, 10)
+      value = parseInt(e.target.value, 10);
     } else if(valueType === 'float') {
-      value = parseFloat(e.target.value)
+      value = parseFloat(e.target.value);
     } else {
-      value = e.target.value
+      value = e.target.value;
     }
     this.props.onChange(value);
   };
 
   render() {
-    const { field, value, forID } = this.props
-    const min = field.get('min')
-    const max = field.get('max')
-    const step = field.get('step')
+    const { field, value, forID } = this.props;
+    const min = field.get('min');
+    const max = field.get('max');
+    const step = field.get('step');
     return <input type="number" id={forID} value={value || ''} step={step == null ? (field.get('valueType') === 'int' ? 1 : '') : step} min={min == null ? '' : min} max={max == null ? '' : max} onChange={this.handleChange} />;
   }
 }


### PR DESCRIPTION
**- Summary**

Number editor creates strings not numbers. Use parseInt to ensure a number is created.

**- Test plan**

Tested manually, issue noticed because Jekyll's sort complained. (Couldn't find the widget tests? But didn't look too hard :-s It's a pretty trivial change...)

**- Description for the changelog**

Ensure Number widget saves values as numbers not strings.

**- A picture of a cute animal (not mandatory but encouraged)**

![](https://user-images.githubusercontent.com/1100280/29483208-bcdc7454-84e4-11e7-8f52-9730394f196f.jpg)
