### PR TITLE
Fix denied login for users with many repos.

### DIFF
--- a/src/backends/github/API.js
+++ b/src/backends/github/API.js
@@ -20,16 +20,12 @@ export default class API {
   }
 
   isCollaborator(user) {
-    return this.request('/user/repos').then((repos) => {
-      let contributor = false
-      for (const repo of repos) {
-        if (repo.full_name.toLowerCase() === this.repo.toLowerCase() && repo.permissions.push) contributor = true;
-      }
-      return contributor;
-    }).catch((error) => {
-      console.error("Problem with response of /user/repos from GitHub");
-      throw error;
-    })
+    return this.request(this.repoURL)
+      .then(repo => repo.permissions.push)
+      .catch(error => {
+        console.error("Problem fetching repo data from GitHub");
+        throw error;
+      });
   }
 
   requestHeaders(headers = {}) {

--- a/src/backends/github/API.js
+++ b/src/backends/github/API.js
@@ -19,7 +19,7 @@ export default class API {
     return this.request("/user");
   }
 
-  isCollaborator(user) {
+  hasWriteAccess() {
     return this.request(this.repoURL)
       .then(repo => repo.permissions.push)
       .catch(error => {

--- a/src/backends/github/implementation.js
+++ b/src/backends/github/implementation.js
@@ -32,7 +32,7 @@ export default class GitHub {
     this.token = state.token;
     this.api = new API({ token: this.token, branch: this.branch, repo: this.repo, api_root: this.api_root });
     return this.api.user().then(user =>
-      this.api.isCollaborator(user.login).then((isCollab) => {
+      this.api.hasWriteAccess().then((isCollab) => {
         // Unauthorized user
         if (!isCollab) throw new Error("Your GitHub user account does not have access to this repo.");
         // Authorized user


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines;
https://github.com/netlify/netlify-cms/blob/master/CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first three fields are mandatory:
-->

**- Summary**

`isCollaborator` was created in #491 to block login if a user did not have write (push) permissions to a repo, by going through the list of a users repos until it found the right one. It did not institute pagination, however, so if a user had enough repos that the one in question was on another page, the CMS would assume that they did not have permission and block the login. Since there are only about 30 repos per page, this is a fairly significant bug.

This commit fixes the problem by calling the API for the specific repo instead of getting the whole list.

**- Test plan**

Tested manually before and after:
- repo w/permissions.

Tested errors after:
- repo w/o permissions (no permission error).
- non-existing repo ("Not Found" error).

**- Description for the changelog**

Fix denied login for users with many repos.
