### PR TITLE
Check user permissions and metadata every CMS load.

### DIFF
--- a/src/backends/backend.js
+++ b/src/backends/backend.js
@@ -78,7 +78,10 @@ class Backend {
     if (this.user) { return this.user; }
     const stored = this.authStore && this.authStore.retrieve();
     if (stored) {
-      return Promise.resolve(this.implementation.setUser(stored)).then(() => stored);
+      return Promise.resolve(this.implementation.setUser(stored)).then((user) => {
+        this.authStore.store(user);
+        return user;
+      });
     }
     return Promise.resolve(null);
   }

--- a/src/backends/backend.js
+++ b/src/backends/backend.js
@@ -66,8 +66,9 @@ const slugFormatter = (template = "{{slug}}", entryData) => {
 };
 
 class Backend {
-  constructor(implementation, authStore = null) {
+  constructor(implementation, backendName, authStore = null) {
     this.implementation = implementation;
+    this.backendName = backendName;
     this.authStore = authStore;
     if (this.implementation === null) {
       throw new Error("Cannot instantiate a Backend with no implementation");
@@ -77,10 +78,12 @@ class Backend {
   currentUser() {
     if (this.user) { return this.user; }
     const stored = this.authStore && this.authStore.retrieve();
-    if (stored) {
+    if (stored && stored.backendName === this.backendName) {
       return Promise.resolve(this.implementation.setUser(stored)).then((user) => {
-        this.authStore.store(user);
-        return user;
+        const newUser = {...user, backendName: this.backendName};
+        // return confirmed/rehydrated user object instead of stored
+        this.authStore.store(newUser);
+        return newUser;
       });
     }
     return Promise.resolve(null);
@@ -92,8 +95,9 @@ class Backend {
 
   authenticate(credentials) {
     return this.implementation.authenticate(credentials).then((user) => {
-      if (this.authStore) { this.authStore.store(user); }
-      return user;
+      const newUser = {...user, backendName: this.backendName};
+      if (this.authStore) { this.authStore.store(newUser); }
+      return newUser;
     });
   }
 
@@ -299,11 +303,11 @@ export function resolveBackend(config) {
 
   switch (name) {
     case "test-repo":
-      return new Backend(new TestRepoBackend(config), authStore);
+      return new Backend(new TestRepoBackend(config), name, authStore);
     case "github":
-      return new Backend(new GitHubBackend(config), authStore);
+      return new Backend(new GitHubBackend(config), name, authStore);
     case "git-gateway":
-      return new Backend(new GitGatewayBackend(config), authStore);
+      return new Backend(new GitGatewayBackend(config), name, authStore);
     default:
       throw new Error(`Backend not found: ${ name }`);
   }

--- a/src/backends/backend.js
+++ b/src/backends/backend.js
@@ -79,7 +79,7 @@ class Backend {
     if (this.user) { return this.user; }
     const stored = this.authStore && this.authStore.retrieve();
     if (stored && stored.backendName === this.backendName) {
-      return Promise.resolve(this.implementation.setUser(stored)).then((user) => {
+      return Promise.resolve(this.implementation.restoreUser(stored)).then((user) => {
         const newUser = {...user, backendName: this.backendName};
         // return confirmed/rehydrated user object instead of stored
         this.authStore.store(newUser);

--- a/src/backends/git-gateway/implementation.js
+++ b/src/backends/git-gateway/implementation.js
@@ -43,7 +43,7 @@ export default class GitGateway extends GitHubBackend {
     AuthenticationPage.authClient = this.authClient;
   }
 
-  setUser() {
+  restoreUser() {
     const user = this.authClient && this.authClient.currentUser();
     if (!user) return Promise.reject();
     return this.authenticate(user);

--- a/src/backends/github/implementation.js
+++ b/src/backends/github/implementation.js
@@ -23,7 +23,7 @@ export default class GitHub {
     return AuthenticationPage;
   }
 
-  setUser(user) {
+  restoreUser(user) {
     return this.authenticate(user);
   }
 

--- a/src/backends/github/implementation.js
+++ b/src/backends/github/implementation.js
@@ -24,8 +24,7 @@ export default class GitHub {
   }
 
   setUser(user) {
-    this.token = user.token;
-    this.api = new API({ token: this.token, branch: this.branch, repo: this.repo });
+    return this.authenticate(user);
   }
 
   authenticate(state) {

--- a/src/backends/test-repo/implementation.js
+++ b/src/backends/test-repo/implementation.js
@@ -26,12 +26,14 @@ export default class TestRepo {
     this.config = config;
   }
 
-  setUser() {}
-
   authComponent() {
     return AuthenticationPage;
   }
 
+  setUser(user) {
+    return this.authenticate(user);
+  }
+  
   authenticate(state) {
     return Promise.resolve({ email: state.email, name: nameFromEmail(state.email) });
   }

--- a/src/backends/test-repo/implementation.js
+++ b/src/backends/test-repo/implementation.js
@@ -30,10 +30,10 @@ export default class TestRepo {
     return AuthenticationPage;
   }
 
-  setUser(user) {
+  restoreUser(user) {
     return this.authenticate(user);
   }
-  
+
   authenticate(state) {
     return Promise.resolve({ email: state.email, name: nameFromEmail(state.email) });
   }


### PR DESCRIPTION
**- Summary**
Fixes #556.
Before, if the CMS was loading user OAuth credentials from `localStorage`, then user write access would not be checked again. However, the `config.yml` repo could be changed, which would cause the user to be still logged in even if they did not have write permissions. Also, if the user had updated their metadata (avatar, etc.), the CMS would not update that either.

The main change that this PR makes is that it expects `setUser` to return a rehydrated user object, instead of just taking the user object that it was fed and using it.

**- Test plan**

- [x] GitHub backend
- [x] `test-repo` backend
- [x] `git-gateway` backend

**- Description for the changelog**

Check user permissions and metadata *every* CMS load.
