### PR TITLE
WIP: Gentle re-authentication modal/popup.

### DIFF
--- a/src/actions/auth.js
+++ b/src/actions/auth.js
@@ -7,11 +7,18 @@ export const AUTH_REQUEST = 'AUTH_REQUEST';
 export const AUTH_SUCCESS = 'AUTH_SUCCESS';
 export const AUTH_FAILURE = 'AUTH_FAILURE';
 export const AUTH_REQUEST_DONE = 'AUTH_REQUEST_DONE';
+export const REAUTHENTICATE = 'REAUTHENTICATE';
 export const LOGOUT = 'LOGOUT';
 
 export function authenticating() {
   return {
     type: AUTH_REQUEST,
+  };
+}
+
+export function reAuth() {
+  return {
+    type: REAUTHENTICATE,
   };
 }
 
@@ -48,7 +55,7 @@ export function authenticateUser() {
     const state = getState();
     const backend = currentBackend(state.config);
     dispatch(authenticating());
-    return backend.currentUser()
+    return backend.currentUser(() => dispatch(reAuth()))
       .then((user) => {
         if (user) {
           dispatch(authenticate(user));
@@ -69,7 +76,7 @@ export function loginUser(credentials) {
     const backend = currentBackend(state.config);
 
     dispatch(authenticating());
-    return backend.authenticate(credentials)
+    return backend.authenticate(credentials, () => dispatch(reAuth()))
       .then((user) => {
         dispatch(authenticate(user));
       })

--- a/src/backends/backend.js
+++ b/src/backends/backend.js
@@ -83,11 +83,11 @@ class Backend {
     }
   }
 
-  currentUser() {
+  currentUser(reAuth) {
     if (this.user) { return this.user; }
     const stored = this.authStore && this.authStore.retrieve();
     if (stored && stored.backendName === this.backendName) {
-      return Promise.resolve(this.implementation.restoreUser(stored)).then((user) => {
+      return Promise.resolve(this.implementation.restoreUser(stored, reAuth)).then((user) => {
         const newUser = {...user, backendName: this.backendName};
         // return confirmed/rehydrated user object instead of stored
         this.authStore.store(newUser);
@@ -101,8 +101,8 @@ class Backend {
     return this.implementation.authComponent();
   }
 
-  authenticate(credentials) {
-    return this.implementation.authenticate(credentials).then((user) => {
+  authenticate(credentials, reAuth) {
+    return this.implementation.authenticate(credentials, reAuth).then((user) => {
       const newUser = {...user, backendName: this.backendName};
       if (this.authStore) { this.authStore.store(newUser); }
       return newUser;

--- a/src/backends/git-gateway/API.js
+++ b/src/backends/git-gateway/API.js
@@ -2,8 +2,8 @@ import GithubAPI from "Backends/github/API";
 import { APIError } from "ValueObjects/errors";
 
 export default class API extends GithubAPI {
-  constructor(config) {
-    super(config);
+  constructor(config, reAuth) {
+    super(config, reAuth);
     this.api_root = config.api_root;
     this.tokenPromise = config.tokenPromise;
     this.commitAuthor = config.commitAuthor;

--- a/src/backends/git-gateway/AuthenticationPage.css
+++ b/src/backends/git-gateway/AuthenticationPage.css
@@ -3,7 +3,7 @@
   flex-flow: column nowrap;
   align-items: center;
   justify-content: center;
-  height: 100vh;
+  height: 100%;
 }
 
 .nc-gitGatewayAuthenticationPage-form {

--- a/src/backends/git-gateway/implementation.js
+++ b/src/backends/git-gateway/implementation.js
@@ -43,13 +43,13 @@ export default class GitGateway extends GitHubBackend {
     AuthenticationPage.authClient = this.authClient;
   }
 
-  restoreUser() {
+  restoreUser(old, reAuth) {
     const user = this.authClient && this.authClient.currentUser();
     if (!user) return Promise.reject();
-    return this.authenticate(user);
+    return this.authenticate(user, reAuth);
   }
 
-  authenticate(user) {
+  authenticate(user, reAuth) {
     this.tokenPromise = user.jwt.bind(user);
     return this.tokenPromise()
     .then((token) => {
@@ -70,7 +70,7 @@ export default class GitGateway extends GitHubBackend {
           branch: this.branch,
           tokenPromise: this.tokenPromise,
           commitAuthor: pick(userData, ["name", "email"]),
-        });
+        }, reAuth);
         return userData;
       } else {
         throw new Error("You don't have sufficient permissions to access Netlify CMS");

--- a/src/backends/github/API.js
+++ b/src/backends/github/API.js
@@ -9,7 +9,8 @@ import { APIError, EditorialWorkflowError } from "ValueObjects/errors";
 const CMS_BRANCH_PREFIX = 'cms/';
 
 export default class API {
-  constructor(config) {
+  constructor(config, reAuth) {
+    this.reAuth = reAuth;
     this.api_root = config.api_root || "https://api.github.com";
     this.token = config.token || false;
     this.branch = config.branch || "master";

--- a/src/backends/github/AuthenticationPage.css
+++ b/src/backends/github/AuthenticationPage.css
@@ -3,7 +3,7 @@
   flex-flow: column nowrap;
   align-items: center;
   justify-content: center;
-  height: 100vh;
+  height: 100%;
 }
 
 .nc-githubAuthenticationPage-logo {

--- a/src/backends/github/implementation.js
+++ b/src/backends/github/implementation.js
@@ -24,13 +24,13 @@ export default class GitHub {
     return AuthenticationPage;
   }
 
-  restoreUser(user) {
-    return this.authenticate(user);
+  restoreUser(user, reAuth) {
+    return this.authenticate(user, reAuth);
   }
 
-  authenticate(state) {
+  authenticate(state, reAuth) {
     this.token = state.token;
-    this.api = new API({ token: this.token, branch: this.branch, repo: this.repo, api_root: this.api_root });
+    this.api = new API({ token: this.token, branch: this.branch, repo: this.repo, api_root: this.api_root }, reAuth);
     return this.api.user().then(user =>
       this.api.hasWriteAccess().then((isCollab) => {
         // Unauthorized user

--- a/src/components/App/App.css
+++ b/src/components/App/App.css
@@ -6,3 +6,7 @@
   max-width: 1440px;
   margin: 0 auto;
 }
+
+.nc-auth-page {
+  height: 100vh;
+}

--- a/src/components/App/App.js
+++ b/src/components/App/App.js
@@ -160,8 +160,8 @@ class App extends React.Component {
 
 function mapStateToProps(state, ownProps) {
   const { auth, config, collections, globalUI } = state;
-  const authModalOpen = (auth && auth.get('modal')) || false;
-  const user = auth && auth.get('user');
+  const user = auth.get('user', null);
+  const authModalOpen = auth.get('modal', false);
   const isFetching = globalUI.get('isFetching');
   const publishMode = config && config.get('publish_mode');
   return { auth, config, collections, user, isFetching, publishMode, authModalOpen };

--- a/src/components/App/App.js
+++ b/src/components/App/App.js
@@ -11,7 +11,7 @@ import { currentBackend } from 'Backends/backend';
 import { showCollection, createNewEntry } from 'Actions/collections';
 import { openMediaLibrary as actionOpenMediaLibrary } from 'Actions/mediaLibrary';
 import MediaLibrary from 'MediaLibrary/MediaLibrary';
-import { Loader, Toast } from 'UI';
+import { Loader, Modal, Toast } from 'UI';
 import { getCollectionUrl, getNewEntryUrl } from 'Lib/urlHelper';
 import { SIMPLE, EDITORIAL_WORKFLOW } from 'Constants/publishModes';
 import Collection from 'Collection/Collection';
@@ -44,6 +44,7 @@ class App extends React.Component {
     isFetching: PropTypes.bool.isRequired,
     publishMode: PropTypes.oneOf([SIMPLE, EDITORIAL_WORKFLOW]),
     siteId: PropTypes.string,
+    authModalOpen: PropTypes.bool.isRequired,
   };
 
   static configError(config) {
@@ -73,19 +74,13 @@ class App extends React.Component {
       return <div><h1>Waiting for backend...</h1></div>;
     }
 
-    return (
-      <div>
-        {
-          React.createElement(backend.authComponent(), {
-            onLogin: this.handleLogin.bind(this),
-            error: auth && auth.get('error'),
-            isFetching: auth && auth.get('isFetching'),
-            siteId: this.props.config.getIn(["backend", "site_domain"]),
-            base_url: this.props.config.getIn(["backend", "base_url"], null)
-          })
-        }
-      </div>
-    );
+    return React.createElement(backend.authComponent(), {
+      onLogin: this.handleLogin.bind(this),
+      error: auth && auth.get('error'),
+      isFetching: auth && auth.get('isFetching'),
+      siteId: this.props.config.getIn(["backend", "site_domain"]),
+      base_url: this.props.config.getIn(["backend", "base_url"], null)
+    });
   }
 
   handleLinkClick(event, handler, ...args) {
@@ -102,6 +97,7 @@ class App extends React.Component {
       isFetching,
       publishMode,
       openMediaLibrary,
+      authModalOpen,
     } = this.props;
 
 
@@ -117,8 +113,12 @@ class App extends React.Component {
       return <Loader active>Loading configuration...</Loader>;
     }
 
-    if (user == null) {
-      return this.authenticating();
+    if (user == null && !authModalOpen) {
+      return (
+        <div className="nc-auth-page">
+          {this.authenticating()}
+        </div>
+      );
     }
 
     const defaultPath = `/collections/${collections.first().get('name')}`;
@@ -127,6 +127,7 @@ class App extends React.Component {
     return (
       <div className="nc-app-container">
         <Notifs CustomComponent={Toast} />
+        <Modal isOpen={authModalOpen} className="nc-auth-modal">{this.authenticating()}</Modal>
         <Header
           user={user}
           collections={collections}
@@ -159,10 +160,11 @@ class App extends React.Component {
 
 function mapStateToProps(state, ownProps) {
   const { auth, config, collections, globalUI } = state;
+  const authModalOpen = (auth && auth.get('modal')) || false;
   const user = auth && auth.get('user');
   const isFetching = globalUI.get('isFetching');
   const publishMode = config && config.get('publish_mode');
-  return { auth, config, collections, user, isFetching, publishMode };
+  return { auth, config, collections, user, isFetching, publishMode, authModalOpen };
 }
 
 function mapDispatchToProps(dispatch) {

--- a/src/reducers/__tests__/auth.spec.js
+++ b/src/reducers/__tests__/auth.spec.js
@@ -7,7 +7,7 @@ describe('auth', () => {
     expect(
       auth(undefined, {})
     ).toEqual(
-      null
+      Immutable.Map()
     );
   });
 

--- a/src/reducers/auth.js
+++ b/src/reducers/auth.js
@@ -1,5 +1,5 @@
 import Immutable from 'immutable';
-import { AUTH_REQUEST, AUTH_SUCCESS, AUTH_FAILURE, AUTH_REQUEST_DONE, LOGOUT } from 'Actions/auth';
+import { AUTH_REQUEST, AUTH_SUCCESS, AUTH_FAILURE, AUTH_REQUEST_DONE, REAUTHENTICATE, LOGOUT } from '../actions/auth';
 
 const auth = (state = null, action) => {
   switch (action.type) {
@@ -11,6 +11,8 @@ const auth = (state = null, action) => {
       return Immutable.Map({ error: action.payload.toString() });
     case AUTH_REQUEST_DONE:
       return state.remove('isFetching');
+    case REAUTHENTICATE:
+      return state.set('modal', true);
     case LOGOUT:
       return state.remove('user').remove('isFetching');
     default:

--- a/src/reducers/auth.js
+++ b/src/reducers/auth.js
@@ -1,20 +1,26 @@
 import Immutable from 'immutable';
 import { AUTH_REQUEST, AUTH_SUCCESS, AUTH_FAILURE, AUTH_REQUEST_DONE, REAUTHENTICATE, LOGOUT } from '../actions/auth';
 
-const auth = (state = null, action) => {
+const auth = (state = Immutable.Map(), action) => {
   switch (action.type) {
     case AUTH_REQUEST:
-      return Immutable.Map({ isFetching: true });
+      return state.set('isFetching', true);
     case AUTH_SUCCESS:
       return Immutable.fromJS({ user: action.payload });
     case AUTH_FAILURE:
-      return Immutable.Map({ error: action.payload.toString() });
+      return state.withMutations(map => {
+        map.set('error', action.payload.toString());
+        map.remove('isFetching');
+      });
     case AUTH_REQUEST_DONE:
       return state.remove('isFetching');
     case REAUTHENTICATE:
       return state.set('modal', true);
     case LOGOUT:
-      return state.remove('user').remove('isFetching');
+      return state.withMutations(map => {
+        map.remove('user');
+        map.remove('isFetching');
+      });
     default:
       return state;
   }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines;
https://github.com/netlify/netlify-cms/blob/master/CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first three fields are mandatory:
-->

**- Summary**

We need to have a way to gently re-authenticate the user, especially for backends for which the OAuth token times out or is otherwise invalidated.

With this implementation, **we don't re-run the user's action at all,** we just re-authenticate on API failure. For example, if the user is saving a post and we get a 401, we re-authenticate the user, but then they have to click the "Save" button again. Do you guys think that is clear enough?

This is not currently implemented at all, but it is needed (will be used) by both #517 and #525.

~~#559 needs merged before this can be finished.~~ *Done*
~~We can also use the `Dialog` from #554 for this as well.~~ *Done*
~~This PR fixes #569.~~ *No longer applicable.*
<!--
Explain the **motivation** for making this change.
What existing problem does the pull request solve?
-->

**- Test plan**:

Current authentication works correctly.

<!--
Demonstrate the code is solid.
Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.
-->

**- Description for the changelog**

Add gentle re-auth modal for backends (not currently implemented).

**- A picture of a cute animal (not mandatory but encouraged)**
[![](https://user-images.githubusercontent.com/20345941/29845354-b9dfc59c-8ccf-11e7-8216-fe504047f77b.jpg)](https://unsplash.com/photos/xgTMSz6kegE)
