### PR TITLE
Do not close entry page if it failed to save or delete.

### DIFF
--- a/src/actions/entries.js
+++ b/src/actions/entries.js
@@ -297,7 +297,7 @@ export function persistEntry(collection) {
           kind: 'danger',
           dismissAfter: 8000,
         }));
-        return dispatch(entryPersistFail(collection, serializedEntry, error));
+        return Promise.reject(dispatch(entryPersistFail(collection, serializedEntry, error)));
       });
   };
 }
@@ -319,7 +319,7 @@ export function deleteEntry(collection, slug) {
         dismissAfter: 8000,
       }));
       console.error(error);
-      return dispatch(entryDeleteFail(collection, slug, error));
+      return Promise.reject(dispatch(entryDeleteFail(collection, slug, error)));
     });
   };
 }


### PR DESCRIPTION
**- Summary**

Fixes #555:
> Currently, if the user tries to save an entry, but the backend has an error, the page still tries to redirect back to the dashboard. However, since the page is not saved yet, the user is presented with a popup: "Are you sure you want to leave this page?". If they click "OK", their content is lost. After the popup is closed (OK or Cancel), the red error notification show up: "Failed to persist entry: API_ERROR: ...".

**- Test plan**

Manually tested with the `test-repo` backend by returning a rejected promise from `persistEntry` and `deleteFile`.

**- Description for the changelog**

Do not close entry page if the entry failed to save or delete.

**- A picture of a cute animal (not mandatory but encouraged)**
