### PR TITLE
add markdown editor soft break support

### DIFF
--- a/package.json
+++ b/package.json
@@ -156,6 +156,7 @@
     "slate": "^0.21.0",
     "slate-edit-list": "^0.7.1",
     "slate-edit-table": "^0.10.1",
+    "slate-soft-break": "^0.3.0",
     "slug": "^0.9.1",
     "unified": "^6.1.4",
     "unist-builder": "^1.0.2",

--- a/src/components/Widgets/Markdown/MarkdownControl/VisualEditor/__tests__/__snapshots__/parser.spec.js.snap
+++ b/src/components/Widgets/Markdown/MarkdownControl/VisualEditor/__tests__/__snapshots__/parser.spec.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Compile markdown to Prosemirror document structure should compile a markdown ordered list 1`] = `
+exports[`Compile markdown to Slate Raw AST should compile a markdown ordered list 1`] = `
 Object {
   "kind": "block",
   "nodes": Array [
@@ -80,7 +80,7 @@ Object {
 }
 `;
 
-exports[`Compile markdown to Prosemirror document structure should compile bulleted lists 1`] = `
+exports[`Compile markdown to Slate Raw AST should compile bulleted lists 1`] = `
 Object {
   "kind": "block",
   "nodes": Array [
@@ -160,7 +160,7 @@ Object {
 }
 `;
 
-exports[`Compile markdown to Prosemirror document structure should compile code blocks 1`] = `
+exports[`Compile markdown to Slate Raw AST should compile code blocks 1`] = `
 Object {
   "kind": "block",
   "nodes": Array [
@@ -183,28 +183,7 @@ Object {
 }
 `;
 
-exports[`Compile markdown to Prosemirror document structure should compile hard breaks (double space) 1`] = `
-Object {
-  "kind": "block",
-  "nodes": Array [
-    Object {
-      "kind": "block",
-      "nodes": Array [
-        Object {
-          "data": undefined,
-          "kind": "text",
-          "text": "blue moon  
-footballs",
-        },
-      ],
-      "type": "paragraph",
-    },
-  ],
-  "type": "root",
-}
-`;
-
-exports[`Compile markdown to Prosemirror document structure should compile horizontal rules 1`] = `
+exports[`Compile markdown to Slate Raw AST should compile horizontal rules 1`] = `
 Object {
   "kind": "block",
   "nodes": Array [
@@ -241,7 +220,7 @@ Object {
 }
 `;
 
-exports[`Compile markdown to Prosemirror document structure should compile horizontal rules 2`] = `
+exports[`Compile markdown to Slate Raw AST should compile horizontal rules 2`] = `
 Object {
   "kind": "block",
   "nodes": Array [
@@ -278,7 +257,7 @@ Object {
 }
 `;
 
-exports[`Compile markdown to Prosemirror document structure should compile images 1`] = `
+exports[`Compile markdown to Slate Raw AST should compile images 1`] = `
 Object {
   "kind": "block",
   "nodes": Array [
@@ -298,7 +277,7 @@ Object {
 }
 `;
 
-exports[`Compile markdown to Prosemirror document structure should compile inline code 1`] = `
+exports[`Compile markdown to Slate Raw AST should compile inline code 1`] = `
 Object {
   "kind": "block",
   "nodes": Array [
@@ -348,7 +327,7 @@ Object {
 }
 `;
 
-exports[`Compile markdown to Prosemirror document structure should compile kitchen sink example 1`] = `
+exports[`Compile markdown to Slate Raw AST should compile kitchen sink example 1`] = `
 Object {
   "kind": "block",
   "nodes": Array [
@@ -1048,7 +1027,7 @@ not using the official implementation, and this might work subtly differently
 }
 `;
 
-exports[`Compile markdown to Prosemirror document structure should compile links 1`] = `
+exports[`Compile markdown to Slate Raw AST should compile links 1`] = `
 Object {
   "kind": "block",
   "nodes": Array [
@@ -1099,7 +1078,7 @@ Object {
 }
 `;
 
-exports[`Compile markdown to Prosemirror document structure should compile multiple header levels 1`] = `
+exports[`Compile markdown to Slate Raw AST should compile multiple header levels 1`] = `
 Object {
   "kind": "block",
   "nodes": Array [
@@ -1141,7 +1120,7 @@ Object {
 }
 `;
 
-exports[`Compile markdown to Prosemirror document structure should compile nested inline markup 1`] = `
+exports[`Compile markdown to Slate Raw AST should compile nested inline markup 1`] = `
 Object {
   "kind": "block",
   "nodes": Array [
@@ -1235,7 +1214,7 @@ Object {
 }
 `;
 
-exports[`Compile markdown to Prosemirror document structure should compile plugins 1`] = `
+exports[`Compile markdown to Slate Raw AST should compile plugins 1`] = `
 Object {
   "kind": "block",
   "nodes": Array [
@@ -1266,7 +1245,7 @@ Object {
 }
 `;
 
-exports[`Compile markdown to Prosemirror document structure should compile simple markdown 1`] = `
+exports[`Compile markdown to Slate Raw AST should compile simple markdown 1`] = `
 Object {
   "kind": "block",
   "nodes": Array [
@@ -1288,6 +1267,37 @@ Object {
           "data": undefined,
           "kind": "text",
           "text": "sweet body",
+        },
+      ],
+      "type": "paragraph",
+    },
+  ],
+  "type": "root",
+}
+`;
+
+exports[`Compile markdown to Slate Raw AST should compile soft breaks (double space) 1`] = `
+Object {
+  "kind": "block",
+  "nodes": Array [
+    Object {
+      "kind": "block",
+      "nodes": Array [
+        Object {
+          "data": undefined,
+          "kind": "text",
+          "text": "blue moon",
+        },
+        Object {
+          "data": undefined,
+          "kind": "text",
+          "text": "
+",
+        },
+        Object {
+          "data": undefined,
+          "kind": "text",
+          "text": "footballs",
         },
       ],
       "type": "paragraph",

--- a/src/components/Widgets/Markdown/MarkdownControl/VisualEditor/__tests__/parser.spec.js
+++ b/src/components/Widgets/Markdown/MarkdownControl/VisualEditor/__tests__/parser.spec.js
@@ -46,7 +46,7 @@ const testPlugins = fromJS([
 
 const parser = markdown => remarkToSlate(markdownToRemark(markdown));
 
-describe("Compile markdown to Prosemirror document structure", () => {
+describe("Compile markdown to Slate Raw AST", () => {
   it("should compile simple markdown", () => {
     const value = `
 # H1
@@ -111,7 +111,7 @@ blue moon
     expect(parser(value)).toMatchSnapshot();
   });
 
-  it("should compile hard breaks (double space)", () => {
+  it("should compile soft breaks (double space)", () => {
     const value = `
 blue moon  
 footballs

--- a/src/components/Widgets/Markdown/MarkdownControl/VisualEditor/plugins.js
+++ b/src/components/Widgets/Markdown/MarkdownControl/VisualEditor/plugins.js
@@ -1,3 +1,4 @@
+import SlateSoftBreak from 'slate-soft-break';
 import EditList from 'slate-edit-list';
 import EditTable from 'slate-edit-table';
 
@@ -30,6 +31,8 @@ const SoftBreakOpts = {
 };
 
 export const SoftBreakConfigured = SoftBreak(SoftBreakOpts);
+
+export const ParagraphSoftBreakConfigured = SlateSoftBreak({ onlyIn: ['paragraph'], shift: true });
 
 const BackspaceCloseBlock = (options = {}) => ({
   onKeyDown(e, data, state) {
@@ -82,6 +85,7 @@ export const EditTableConfigured = EditTable(EditTableOpts);
 
 const plugins = [
   SoftBreakConfigured,
+  ParagraphSoftBreakConfigured,
   BackspaceCloseBlockConfigured,
   EditListConfigured,
   EditTableConfigured,

--- a/src/components/Widgets/Markdown/serializers/index.js
+++ b/src/components/Widgets/Markdown/serializers/index.js
@@ -110,26 +110,11 @@ import registry from '../../../../lib/registry';
  * Deserialize a Markdown string to an MDAST.
  */
 export const markdownToRemark = markdown => {
-
-  /**
-   * Disabling tokenizers allows us to turn off features within the Remark
-   * parser.
-   */
-  function disableTokenizers() {
-
-    /**
-     * Turn off soft breaks until we can properly support them across both
-     * editors.
-     */
-    pull(this.Parser.prototype.inlineMethods, 'break');
-  }
-
   /**
    * Parse the Markdown string input to an MDAST.
    */
   const parsed = unified()
     .use(markdownToRemarkPlugin, { fences: true, pedantic: true, commonmark: true })
-    .use(disableTokenizers)
     .parse(markdown);
 
   /**

--- a/src/components/Widgets/Markdown/serializers/remarkSlate.js
+++ b/src/components/Widgets/Markdown/serializers/remarkSlate.js
@@ -231,6 +231,16 @@ function convertNode(node, nodes) {
       return createBlock(slateType, nodes, { data });
     }
 
+    /**
+     * Breaks
+     *
+     * MDAST soft break nodes represent a trailing double space or trailing
+     * slash from a Markdown document. In Slate, these are simply transformed to
+     * line breaks within a text node.
+     */
+    case 'break': {
+      return createText('\n');
+    }
 
     /**
      * Thematic Breaks

--- a/yarn.lock
+++ b/yarn.lock
@@ -7844,6 +7844,10 @@ slate-edit-table@^0.10.1:
   dependencies:
     immutable "^3.8.1"
 
+slate-soft-break@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/slate-soft-break/-/slate-soft-break-0.3.0.tgz#3d28dea9e0aa4783ddcea785ff5db7277214d65f"
+
 slate@^0.21.0:
   version "0.21.4"
   resolved "https://registry.yarnpkg.com/slate/-/slate-0.21.4.tgz#ae6113379cd838b7ec68ecd94834ce9741bc36f3"


### PR DESCRIPTION
Allows soft breaks to be read/entered in raw markdown via double trailing spaces or trailing backslash. Soft breaks are always rewritten as trailing backslashes on stringify per the Commonmark spec.

Soft breaks can now also be entered in the visual editor via <kbd>Shift</kbd> + <kbd>Enter</kbd>.