### PR TITLE
Disable "Save" button when entry has not been changed.

### DIFF
--- a/src/components/EntryEditor/EntryEditor.js
+++ b/src/components/EntryEditor/EntryEditor.js
@@ -47,7 +47,7 @@ class EntryEditor extends Component {
         fieldsErrors,
         getAsset,
         onChange,
-        hasChanged,
+        enableSave,
         showDelete,
         onDelete,
         onValidate,
@@ -132,7 +132,7 @@ class EntryEditor extends Component {
             onCancelEdit={onCancelEdit}
             onDelete={onDelete}
             showDelete={showDelete}
-            hasChanged={hasChanged}
+            enableSave={enableSave}
           />
         </div>
       </div>
@@ -151,7 +151,7 @@ EntryEditor.propTypes = {
   onChange: PropTypes.func.isRequired,
   onValidate: PropTypes.func.isRequired,
   onPersist: PropTypes.func.isRequired,
-  hasChanged: PropTypes.bool.isRequired,
+  enableSave: PropTypes.bool.isRequired,
   showDelete: PropTypes.bool.isRequired,
   onDelete: PropTypes.func.isRequired,
   onRemoveAsset: PropTypes.func.isRequired,

--- a/src/components/EntryEditor/EntryEditor.js
+++ b/src/components/EntryEditor/EntryEditor.js
@@ -47,6 +47,7 @@ class EntryEditor extends Component {
         fieldsErrors,
         getAsset,
         onChange,
+        hasChanged,
         showDelete,
         onDelete,
         onValidate,
@@ -131,6 +132,7 @@ class EntryEditor extends Component {
             onCancelEdit={onCancelEdit}
             onDelete={onDelete}
             showDelete={showDelete}
+            hasChanged={hasChanged}
           />
         </div>
       </div>
@@ -149,6 +151,7 @@ EntryEditor.propTypes = {
   onChange: PropTypes.func.isRequired,
   onValidate: PropTypes.func.isRequired,
   onPersist: PropTypes.func.isRequired,
+  hasChanged: PropTypes.bool.isRequired,
   showDelete: PropTypes.bool.isRequired,
   onDelete: PropTypes.func.isRequired,
   onRemoveAsset: PropTypes.func.isRequired,

--- a/src/components/EntryEditor/EntryEditorToolbar.js
+++ b/src/components/EntryEditor/EntryEditorToolbar.js
@@ -5,12 +5,12 @@ const EntryEditorToolbar = (
   {
     isPersisting,
     onPersist,
-    hasChanged,
+    enableSave,
     showDelete,
     onDelete,
     onCancelEdit,
   }) => {
-  const disabled = !hasChanged || isPersisting;
+  const disabled = !enableSave || isPersisting;
   return (
     <div>
       <Button
@@ -38,7 +38,7 @@ const EntryEditorToolbar = (
 EntryEditorToolbar.propTypes = {
   isPersisting: PropTypes.bool,
   onPersist: PropTypes.func.isRequired,
-  hasChanged: PropTypes.bool.isRequired,
+  enableSave: PropTypes.bool.isRequired,
   showDelete: PropTypes.bool.isRequired,
   onDelete: PropTypes.func.isRequired,
   onCancelEdit: PropTypes.func.isRequired,

--- a/src/components/EntryEditor/EntryEditorToolbar.js
+++ b/src/components/EntryEditor/EntryEditorToolbar.js
@@ -5,11 +5,12 @@ const EntryEditorToolbar = (
   {
     isPersisting,
     onPersist,
+    hasChanged,
     showDelete,
     onDelete,
     onCancelEdit,
   }) => {
-  const disabled = isPersisting;
+  const disabled = !hasChanged || isPersisting;
   return (
     <div>
       <Button
@@ -37,6 +38,7 @@ const EntryEditorToolbar = (
 EntryEditorToolbar.propTypes = {
   isPersisting: PropTypes.bool,
   onPersist: PropTypes.func.isRequired,
+  hasChanged: PropTypes.bool.isRequired,
   showDelete: PropTypes.bool.isRequired,
   onDelete: PropTypes.func.isRequired,
   onCancelEdit: PropTypes.func.isRequired,

--- a/src/components/EntryEditor/__tests__/EntryEditorToolbar.spec.js
+++ b/src/components/EntryEditor/__tests__/EntryEditorToolbar.spec.js
@@ -3,9 +3,22 @@ import { shallow } from 'enzyme';
 import EntryEditorToolbar from '../EntryEditorToolbar';
 
 describe('EntryEditorToolbar', () => {
-  it('should have both buttons enabled initially', () => {
+  it('should have the Save button disabled initally, and the Cancel button enabled', () => {
     const component = shallow(
       <EntryEditorToolbar
+        onPersist={() => {}}
+        onCancelEdit={() => {}}
+        onDelete={() => {}}
+      />
+    );
+    const tree = component.html();
+    expect(tree).toMatchSnapshot();
+  });
+
+  it('should enable the Save button', () => {
+    const component = shallow(
+      <EntryEditorToolbar
+        enableSave
         onPersist={() => {}}
         onCancelEdit={() => {}}
         onDelete={() => {}}

--- a/src/components/EntryEditor/__tests__/__snapshots__/EntryEditorToolbar.spec.js.snap
+++ b/src/components/EntryEditor/__tests__/__snapshots__/EntryEditorToolbar.spec.js.snap
@@ -2,4 +2,6 @@
 
 exports[`EntryEditorToolbar should disable and update label of Save button when persisting 1`] = `"<div><button disabled=\\"\\" class=\\"\\" type=\\"button\\" data-react-toolbox=\\"button\\">Saving...</button> <button class=\\"\\" type=\\"button\\" data-react-toolbox=\\"button\\">Cancel</button></div>"`;
 
-exports[`EntryEditorToolbar should have both buttons enabled initially 1`] = `"<div><button class=\\"\\" type=\\"button\\" data-react-toolbox=\\"button\\">Save</button> <button class=\\"\\" type=\\"button\\" data-react-toolbox=\\"button\\">Cancel</button></div>"`;
+exports[`EntryEditorToolbar should enable the Save button 1`] = `"<div><button class=\\"\\" type=\\"button\\" data-react-toolbox=\\"button\\">Save</button> <button class=\\"\\" type=\\"button\\" data-react-toolbox=\\"button\\">Cancel</button></div>"`;
+
+exports[`EntryEditorToolbar should have the Save button disabled initally, and the Cancel button enabled 1`] = `"<div><button disabled=\\"\\" class=\\"\\" type=\\"button\\" data-react-toolbox=\\"button\\">Save</button> <button class=\\"\\" type=\\"button\\" data-react-toolbox=\\"button\\">Cancel</button></div>"`;

--- a/src/containers/EntryPage.js
+++ b/src/containers/EntryPage.js
@@ -151,7 +151,7 @@ class EntryPage extends React.Component {
         onPersist={this.handlePersistEntry}
         onDelete={this.handleDeleteEntry}
         showDelete={this.props.showDelete}
-        hasChanged={entryDraft.get('hasChanged')}
+        enableSave={entryDraft.get('hasChanged')}
         onCancelEdit={this.handleCloseEntry}
       />
     );

--- a/src/containers/EntryPage.js
+++ b/src/containers/EntryPage.js
@@ -151,6 +151,7 @@ class EntryPage extends React.Component {
         onPersist={this.handlePersistEntry}
         onDelete={this.handleDeleteEntry}
         showDelete={this.props.showDelete}
+        hasChanged={entryDraft.get('hasChanged')}
         onCancelEdit={this.handleCloseEntry}
       />
     );


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines;
https://github.com/netlify/netlify-cms/blob/master/CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first three fields are mandatory:
-->

**- Summary**

Fixes #573.
This disables the "Save" button until a user has changed an entry. This also applies to new entries -- the user must modify a field before the "Save" button works.

@erquhart Do you think it is worth naming the prop that is passed to the component something other than `hasChanged`, kind of like was done for `showDelete`?

**- Test plan**

Manually tested using example config.

**- Description for the changelog**

Disable "Save" button when entry has no changes.

**- A picture of a cute animal (not mandatory but encouraged)**
