### PR TITLE
Add a `displayField` property to the `relation` widget

### DIFF
--- a/docs/widgets.md
+++ b/docs/widgets.md
@@ -71,6 +71,7 @@ Property | Accepted Values | Description
 `collection` | string | name of the collection being referenced
 `searchFields` | list | one or more names of fields in the referenced colleciton to search for the typed value
 `valueField` | string | name a field from the referenced collection whose value will be stored for the relation
+`displayField` | string | name a field from the referenced collection whose value will be displayed to the user for the relation
 `name` | text input | string
 
 Let's say we have a "posts" collection and an "authors" collection, and we want to select an author for each post - our config might look something like this:
@@ -83,6 +84,7 @@ collections:
     create: true
     fields:
       - {name: name, label: Name}
+      - {name: username, label: Username}
       - {name: twitterHandle, label: "Twitter Handle"}
       - {name: bio, label: Bio, widget: text}
   - name: posts
@@ -97,5 +99,6 @@ collections:
         widget: relation
         collection: authors
         searchFields: [name, twitterHandle]
-        valueField: name
+        valueField: username
+        displayField: name
 ```

--- a/example/config.yml
+++ b/example/config.yml
@@ -68,6 +68,7 @@ collections: # A list of collections the CMS should be able to edit
         collection: "posts"
         searchFields: ["title", "body"]
         valueField: "title"
+        displayField: "title"
       - {label: "Title", name: "title", widget: "string"}
       - {label: "Boolean", name: "boolean", widget: "boolean", default: true}
       - {label: "Text", name: "text", widget: "text"}
@@ -89,6 +90,7 @@ collections: # A list of collections the CMS should be able to edit
             collection: "posts"
             searchFields: ["title", "body"]
             valueField: "title"
+            displayField: "title"
           - {label: "String", name: "string", widget: "string"}
           - {label: "Boolean", name: "boolean", widget: "boolean", default: false}
           - {label: "Text", name: "text", widget: "text"}
@@ -137,6 +139,7 @@ collections: # A list of collections the CMS should be able to edit
                     collection: "posts"
                     searchFields: ["title", "body"]
                     valueField: "title"
+                    displayField: "title"
                   - {label: "String", name: "string", widget: "string"}
                   - {label: "Boolean", name: "boolean", widget: "boolean"}
                   - {label: "Text", name: "text", widget: "text"}

--- a/src/components/Widgets/RelationControl.js
+++ b/src/components/Widgets/RelationControl.js
@@ -33,12 +33,7 @@ class RelationControl extends Component {
     const { value, field } = this.props;
     if (value) {
       const collection = field.get('collection');
-      const searchFields = [...new Set(
-        [
-          ...field.get('searchFields').toJS(),
-          field.get('valueField'),
-        ]
-      )];
+      const searchFields = [ field.get('valueField') ];
       this.props.query(this.controlID, collection, searchFields, value);
     }
   }
@@ -52,8 +47,6 @@ class RelationControl extends Component {
       this.didInitialSearch = true;
       const suggestion = nextProps.queryHits.get(this.controlID);
       if (suggestion && suggestion.length === 1) {
-        const value = this.getSuggestionValue(suggestion[0]);
-        this.props.onChange(value, { [nextProps.field.get('collection')]: { [value]: suggestion[0].data } });
         const displayValue = this.getSuggestionDisplayValue(suggestion[0]);
         this.setState({ displayValue });
       }

--- a/src/components/Widgets/RelationControl.js
+++ b/src/components/Widgets/RelationControl.js
@@ -26,6 +26,7 @@ class RelationControl extends Component {
     super(props, ctx);
     this.controlID = uuid.v4();
     this.didInitialSearch = false;
+    // use local state to store the field's display value
     this.state = { displayValue: '' };
   }
 
@@ -33,7 +34,10 @@ class RelationControl extends Component {
     const { value, field } = this.props;
     if (value) {
       const collection = field.get('collection');
+      // only perform the initial query on `valueField`
       const searchFields = [ field.get('valueField') ];
+      // the goal of this query is to fetch the linked `collection` item
+      // to then show the value of it `displayValue` field to the user
       this.props.query(this.controlID, collection, searchFields, value);
     }
   }
@@ -45,9 +49,14 @@ class RelationControl extends Component {
       nextProps.queryHits.get && nextProps.queryHits.get(this.controlID)
     ) {
       this.didInitialSearch = true;
-      const suggestion = nextProps.queryHits.get(this.controlID);
-      if (suggestion && suggestion.length === 1) {
-        const displayValue = this.getSuggestionDisplayValue(suggestion[0]);
+      // store query results
+      const matches = nextProps.queryHits.get(this.controlID);
+      // if there is only one item found
+      // it is the linked `collection` item
+      if (matches && matches.length === 1) {
+        // get the item's `displayValue` field value
+        const displayValue = this.getSuggestionDisplayValue(matches[0]);
+        // set the field `displayValue`
         this.setState({ displayValue });
       }
     }
@@ -61,7 +70,9 @@ class RelationControl extends Component {
   onSuggestionSelected = (event, { suggestion }) => {
     const value = this.getSuggestionValue(suggestion);
     this.props.onChange(value, { [this.props.field.get('collection')]: { [value]: suggestion.data } });
+    // get the suggestion item `displayValue` field value
     const displayValue = this.getSuggestionDisplayValue(suggestion);
+    // set the field `displayValue`
     this.setState({ displayValue });
   };
 
@@ -91,12 +102,19 @@ class RelationControl extends Component {
 
   renderSuggestion = (suggestion) => {
     const { field } = this.props;
+    // a suggestion should show its `displayField` value
     const displayField = field.get('displayField');
     return <span>{suggestion.data[displayField]}</span>;
   };
 
   renderInputComponent = (inputProps) => {
+    // extract the field `value`, `displayValue` and `id`
+    // separated from the other input props
+    // needed for the visible field to stay accessible
+    // https://github.com/moroshko/react-autosuggest#renderInputComponentProp
     const { value, displayValue, id, ...otherInputProps } = inputProps;
+    // have the visible field display the `displayValue`
+    // and the hidden field store the real `value`
     return (
       <div>
         <input {...otherInputProps} value={displayValue} />
@@ -111,6 +129,7 @@ class RelationControl extends Component {
     const inputProps = {
       placeholder: '',
       value: value || '',
+      // add the `displayValue` to be passed to the `renderInputComponent` function
       displayValue: this.state.displayValue || '',
       onChange: this.onChange,
       id: forID,

--- a/src/components/Widgets/RelationControl.js
+++ b/src/components/Widgets/RelationControl.js
@@ -2,16 +2,10 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import Autosuggest from 'react-autosuggest';
 import uuid from 'uuid';
-import { Map } from 'immutable';
 import { connect } from 'react-redux';
 import { debounce } from 'lodash';
 import { Loader } from '../../components/UI/index';
 import { query, clearSearch } from '../../actions/search';
-
-
-function escapeRegexCharacters(str) {
-  return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-}
 
 class RelationControl extends Component {
   static propTypes = {
@@ -45,7 +39,10 @@ class RelationControl extends Component {
 
   componentWillReceiveProps(nextProps) {
     if (this.didInitialSearch) return;
-    if (nextProps.queryHits !== this.props.queryHits && nextProps.queryHits.get && nextProps.queryHits.get(this.controlID)) {
+    if (
+      nextProps.queryHits !== this.props.queryHits &&
+      nextProps.queryHits.get && nextProps.queryHits.get(this.controlID)
+    ) {
       this.didInitialSearch = true;
       const suggestion = nextProps.queryHits.get(this.controlID);
       if (suggestion && suggestion.length === 1) {

--- a/src/components/Widgets/RelationControl.js
+++ b/src/components/Widgets/RelationControl.js
@@ -52,8 +52,9 @@ class RelationControl extends Component {
       this.didInitialSearch = true;
       const suggestion = nextProps.queryHits.get(this.controlID);
       if (suggestion && suggestion.length === 1) {
-        const { value, displayValue } = this.getSuggestionValues(suggestion[0]);
+        const value = this.getSuggestionValue(suggestion[0]);
         this.props.onChange(value, { [nextProps.field.get('collection')]: { [value]: suggestion[0].data } });
+        const displayValue = this.getSuggestionDisplayValue(suggestion[0]);
         this.setState({ displayValue });
       }
     }
@@ -65,8 +66,9 @@ class RelationControl extends Component {
   };
 
   onSuggestionSelected = (event, { suggestion }) => {
-    const { value, displayValue } = this.getSuggestionValues(suggestion);
+    const value = this.getSuggestionValue(suggestion);
     this.props.onChange(value, { [this.props.field.get('collection')]: { [value]: suggestion.data } });
+    const displayValue = this.getSuggestionDisplayValue(suggestion);
     this.setState({ displayValue });
   };
 
@@ -82,11 +84,16 @@ class RelationControl extends Component {
     this.props.clearSearch();
   };
 
-  getSuggestionValues = (suggestion) => {
+  getSuggestionValue = (suggestion) => {
     const { field } = this.props;
     const valueField = field.get('valueField');
+    return suggestion.data[valueField];
+  };
+
+  getSuggestionDisplayValue = (suggestion) => {
+    const { field } = this.props;
     const displayField = field.get('displayField');
-    return { value: suggestion.data[valueField], displayValue: suggestion.data[displayField] };
+    return suggestion.data[displayField];
   };
 
   renderSuggestion = (suggestion) => {


### PR DESCRIPTION
**- Summary**

closes #591 

**- Test plan**

Actually there's no tests for widgets ? should i make some anyway ?

**- Description for the changelog**

Add a `displayField` property to the `relation` widget, that allows displaying a different field that the linked `valueField` to the user.

**- A picture of a cute animal (not mandatory but encouraged)**

![Cutie pie](http://www.dumpaday.com/wp-content/uploads/2012/11/cute-animal-pictures-251.jpg)
