### PR TITLE
Concurrent search queries

### DIFF
--- a/src/components/Widgets/RelationControl.js
+++ b/src/components/Widgets/RelationControl.js
@@ -2,16 +2,10 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import Autosuggest from 'react-autosuggest';
 import uuid from 'uuid';
-import { Map } from 'immutable';
 import { connect } from 'react-redux';
 import { debounce } from 'lodash';
 import { Loader } from '../../components/UI/index';
 import { query, clearSearch } from '../../actions/search';
-
-
-function escapeRegexCharacters(str) {
-  return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-}
 
 class RelationControl extends Component {
   static propTypes = {
@@ -45,7 +39,10 @@ class RelationControl extends Component {
 
   componentWillReceiveProps(nextProps) {
     if (this.didInitialSearch) return;
-    if (nextProps.queryHits !== this.props.queryHits && nextProps.queryHits.get && nextProps.queryHits.get(this.controlID)) {
+    if (
+      nextProps.queryHits !== this.props.queryHits &&
+      nextProps.queryHits.get && nextProps.queryHits.get(this.controlID)
+    ) {
       this.didInitialSearch = true;
       const suggestion = nextProps.queryHits.get(this.controlID);
       if (suggestion && suggestion.length === 1) {

--- a/src/components/Widgets/RelationControl.js
+++ b/src/components/Widgets/RelationControl.js
@@ -95,6 +95,7 @@ class RelationControl extends Component {
       id: forID,
     };
 
+    const fetching = (isFetching.getIn) ? isFetching.getIn([this.controlID, 'isFetching'], false) : false;
     const suggestions = (queryHits.get) ? queryHits.get(this.controlID, []) : [];
 
     return (
@@ -108,7 +109,7 @@ class RelationControl extends Component {
           renderSuggestion={this.renderSuggestion}
           inputProps={inputProps}
         />
-        <Loader active={isFetching === this.controlID} />
+        <Loader active={fetching} />
       </div>
     );
   }

--- a/src/reducers/__tests__/search.spec.js
+++ b/src/reducers/__tests__/search.spec.js
@@ -1,0 +1,62 @@
+import { Map, OrderedMap, fromJS } from 'immutable';
+import uuid from 'uuid';
+import * as actions from '../../actions/search';
+import reducer from '../search';
+
+const initialState = OrderedMap({ isFetching: Map({}), queryHits: Map({}) });
+
+const collection = "page";
+const searchFields = ["title"];
+const searchTerm = "test";
+const resultObject = { value: "value" };
+
+describe('queries', () => {
+  it('should mark queries as fetching', () => {
+    const namespace = uuid.v4();
+    expect(
+      reducer(initialState, actions.querying(namespace, collection, searchFields, searchTerm))
+    ).toEqual(
+      OrderedMap(fromJS({
+        isFetching: Map({
+          [namespace]: Map({
+            isFetching: true,
+            term: searchTerm,
+          }),
+        }),
+        queryHits: Map({}),
+      }))
+    );
+  });
+
+  it('should handle successful queries', () => {
+    const namespace = uuid.v4();
+    expect(
+      reducer(initialState, actions.querySuccess(
+        namespace,
+        collection,
+        searchFields,
+        searchTerm,
+        {
+          query: searchTerm,
+          hits: [
+            resultObject,
+          ],
+        },
+      ))
+    ).toEqual(
+      OrderedMap(fromJS({
+        isFetching: Map({
+          [namespace]: Map({
+            isFetching: false,
+            term: searchTerm,
+          }),
+        }),
+        queryHits: Map({
+          [namespace]: [
+            resultObject,
+          ],
+        }),
+      }))
+    );
+  });
+});

--- a/src/reducers/__tests__/search.spec.js
+++ b/src/reducers/__tests__/search.spec.js
@@ -59,4 +59,58 @@ describe('queries', () => {
       }))
     );
   });
+
+  it('should handle concurrent successful queries', () => {
+    const namespace1 = uuid.v4();
+    const namespace2 = uuid.v4();
+
+    const stateAfterReducer1 = reducer(initialState, actions.querySuccess(
+      namespace1,
+      collection,
+      searchFields,
+      searchTerm,
+      {
+        query: searchTerm,
+        hits: [
+          resultObject,
+        ],
+      },
+    ));
+
+    expect(
+      reducer(stateAfterReducer1, actions.querySuccess(
+        namespace2,
+        collection,
+        searchFields,
+        searchTerm,
+        {
+          query: searchTerm,
+          hits: [
+            resultObject,
+          ],
+        },
+      ))
+    ).toEqual(
+      OrderedMap(fromJS({
+        isFetching: Map({
+          [namespace1]: Map({
+            isFetching: false,
+            term: searchTerm,
+          }),
+          [namespace2]: Map({
+            isFetching: false,
+            term: searchTerm,
+          }),
+        }),
+        queryHits: Map({
+          [namespace1]: [
+            resultObject,
+          ],
+          [namespace2]: [
+            resultObject,
+          ],
+        }),
+      }))
+    );
+  });
 });


### PR DESCRIPTION
**- Summary**

Allows making concurrent search `queries`, will be useful for #591 , and probably for other use cases.
As of now, two queries made at a near point in time would result in the last one (in time) having its result overwriting the others.
Now results are stored unless `clearSearch` thunk is called.

closes #597 

**- Test plan**

There's simple tests included, modeled on `entries` tests.

**- Description for the changelog**

Allow concurrent search queries

**- A picture of a cute animal (not mandatory but encouraged)**

![Unicorn!!](http://geekxgirls.com/images/animals/kawaii-animals-05.jpg)
