### PR TITLE
Add code coverage output generation to npm test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ yarn-error.log
 .vscode/
 manifest.yml
 .imdone/
+
+/coverage/

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "dist/cms.js",
   "scripts": {
     "start": "webpack-dev-server -d --config webpack.dev.js",
-    "test": "jest",
+    "test": "jest --coverage",
     "test:watch": "jest --watch",
     "build": "cross-env NODE_ENV=production webpack --config webpack.prod.js --display-error-details",
     "build:scripts": "cross-env NODE_ENV=production webpack --config webpack.cli.js",
@@ -39,7 +39,11 @@
     "moduleNameMapper": {
       "^.+\\.(png|eot|woff|woff2|ttf|svg|gif)$": "<rootDir>/__mocks__/fileLoaderMock.js",
       "^.+\\.s?css$": "<rootDir>/__mocks__/styleLoaderMock.js"
-    }
+    },
+    "mapCoverage": true,
+    "coverageReporters": ["lcov"],
+    "collectCoverageFrom": [ "src/**/*.js" ],
+    "coveragePathIgnorePatterns": [ "/__tests__/" ]
   },
   "keywords": [
     "netlify",

--- a/src/components/Widgets/Markdown/serializers/remarkPaddedLinks.js
+++ b/src/components/Widgets/Markdown/serializers/remarkPaddedLinks.js
@@ -97,7 +97,15 @@ export default function remarkPaddedLinks() {
    * nesting. If `end` is truthy, get the last node, otherwise first.
    */
   function getEdgeTextChild(node, end) {
-    const findFn = end ? findLast : find;
+    /**
+     * This was changed from a ternary to a long form if due to issues with istanbul's instrumentation and babel's code 
+     * generation. 
+     * TODO: watch https://github.com/istanbuljs/babel-plugin-istanbul/issues/95
+     * when it is resolved then revert to ```const findFn = end ? findLast : find;```
+     */
+    let findFn;
+    if (end) { findFn = findLast } 
+    else { findFn = find }; 
 
     let edgeChildWithValue;
     setEdgeChildWithValue(node);


### PR DESCRIPTION
**- Summary**

This is a first step towards adding support for a 3rd party code coverage service. It adds code coverage output to the npm test command.

**- Test plan**
on your command line run 

```
npm test
```
verify you see the code coverage output as a result of the test.
verify the coverage folder is generated with the lconv output. 
verify the coverage folder is ignored by git. 

**- Description for the changelog**

Add code coverage to ```npm test```

**- A picture of a cute animal (not mandatory but encouraged)**

![1bc455ab81c687860e175b5a8a91a45e](https://user-images.githubusercontent.com/387640/30507441-b846326c-9a52-11e7-8ff0-3055809d07f2.jpg)

