### PR TITLE
Add codecov reporting  to build process.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,3 +12,7 @@ install:
   - yarn
 notifications:
     email: false
+before_script:
+  - yarn add codecov --dev
+after_script:
+  - codecov

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,1 @@
+comment: false


### PR DESCRIPTION
**- Summary**
depends on: https://github.com/netlify/netlify-cms/pull/610
closes: https://github.com/netlify/netlify-cms/pull/609

This PR will add codecov reporting to the build process.

For this to properly work someone will need to 
1. goto https://codecov.io/gh/netlify/netlify-cms/settings and authorize codecov
2.  copy the repository upload token.
3. goto https://travis-ci.org/netlify/netlify-cms/settings
4. add an environment variable named CODECOV_TOKEN with the value of the repository upload token.

**- Test plan**

Do the above and then merge. The following master build should update the baseline info in codecov. In my experience it takes a few PRs and builds for codecov to start reporting properly.

**- Description for the changelog**

Add codecov reporting to the build process.