### PR TITLE
Fix collections breaking if folder has trailing slash.

### DIFF
--- a/src/reducers/collections.js
+++ b/src/reducers/collections.js
@@ -42,7 +42,7 @@ const selectors = {
       return collection.get('fields');
     },
     entryPath(collection, slug) {
-      return `${ collection.get('folder') }/${ slug }.${ this.entryExtension(collection) }`;
+      return `${ collection.get('folder').replace(/\/$/, '') }/${ slug }.${ this.entryExtension(collection) }`;
     },
     entrySlug(collection, path) {
       return path.split('/').pop().replace(/\.[^\.]+$/, '');


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines;
https://github.com/netlify/netlify-cms/blob/master/CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first three fields are mandatory:
-->

**- Summary**

If the `folder` for a collection has a trailing slash in the config, this breaks the collection when another slash is added. This PR fixes this by trimming a trailing slash from the folder value if it exists.

Fixes #615.

**- Test plan**

Manually tested with config from #615 and example config.

**- Description for the changelog**

Fix collections breaking if folder has trailing slash.

**- A picture of a cute animal (not mandatory but encouraged)**
