### PR TITLE
Make YAML and TOML parsers' bundle smaller

### DIFF
--- a/package.json
+++ b/package.json
@@ -157,7 +157,7 @@
     "slate-edit-table": "^0.10.1",
     "slate-soft-break": "^0.3.0",
     "slug": "^0.9.1",
-    "toml": "^2.3.3",
+    "toml-j0.4": "^1.1.1",
     "unified": "^6.1.4",
     "unist-builder": "^1.0.2",
     "unist-util-visit-parents": "^1.1.1",

--- a/src/formats/frontmatter.js
+++ b/src/formats/frontmatter.js
@@ -1,5 +1,5 @@
 import matter from 'gray-matter';
-import tomlEng from 'toml';
+import tomlEng from 'toml-j0.4';
 import YAML from './yaml';
 
 const parsers = {

--- a/webpack.base.js
+++ b/webpack.base.js
@@ -61,6 +61,7 @@ module.exports = {
     ],
   },
   plugins: [
+    new webpack.IgnorePlugin(/^esprima$/, /js-yaml/), // Ignore Esprima import for js-yaml
     new webpack.IgnorePlugin(/^\.\/locale$/, /moment$/), // Ignore all optional deps of moment.js
     new webpack.ProvidePlugin({
       fetch: 'imports-loader?this=>global!exports-loader?global.fetch!whatwg-fetch',

--- a/yarn.lock
+++ b/yarn.lock
@@ -8576,9 +8576,9 @@ to-fast-properties@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/to-fast-properties/-/to-fast-properties-1.0.3.tgz#b83571fa4d8c25b82e231b06e3a3055de4ca1a47"
 
-toml@^2.3.3:
-  version "2.3.3"
-  resolved "https://registry.yarnpkg.com/toml/-/toml-2.3.3.tgz#8d683d729577cb286231dfc7a8affe58d31728fb"
+toml-j0.4@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/toml-j0.4/-/toml-j0.4-1.1.1.tgz#eb0c70348609a0263bb1d6e4a3dd191dcca60866"
 
 topbar@^0.1.3:
   version "0.1.3"


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines;
https://github.com/netlify/netlify-cms/blob/master/CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first three fields are mandatory:
-->

**- Summary**

This PR contains multiple commits that focus on making the bundled YAML and TOML parsers have a smaller bundle size.
- Remove Esprima from the `js-yaml` bundle.
According to the `js-yaml` docs, it is only needed if you are trying
to parse JS functions in/out of JSON, which we are not doing.
- Switch to a smaller/faster TOML parser.
@erquhart and I had previously looked at a new(er) TOML parser, `toml-j0.4`, that is much smaller and *way* faster than the one we are using now. It is also fully spec-compliant.
~ https://github.com/jakwings/toml-j0.4/issues/3

**- Test plan**

Tested input/output of each parser to make sure it was still valid. Use kitchen sink and some other tests.
<!--
Demonstrate the code is solid.
Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.
-->

**- Description for the changelog**

Make YAML and TOML parsers' bundle smaller.

**- A picture of a cute animal (not mandatory but encouraged)**
[![lara-crespo-108759](https://user-images.githubusercontent.com/20345941/31060292-5927e784-a6ce-11e7-926c-d0b6baed0aa6.jpg)](https://unsplash.com/photos/zD1J3-tuEOA)