### PR TITLE
Allow setting an empty default date(time).

### DIFF
--- a/docs/widgets.md
+++ b/docs/widgets.md
@@ -11,7 +11,8 @@ Widgets define the data type and interface for entry fields. Netlify CMS comes w
 | `text`     | textarea input                     | string (multiline)                                 |
 | `number`   | number input                       | number                                             |
 | `markdown` | rich text editor                   | string (markdown)                                  |
-| `datetime` | date picker                        | string (ISO date)                                  |
+| `date`     | date picker                        | string (ISO datetime)                              |
+| `datetime` | datetime picker                    | string (ISO datetime)                              |
 | `select`   | select input (dropdown)            | string                                             |
 | `image`    | file picker w/ drag-and-drop       | image file                                         |
 | `file`     | file picker w/ drag-and-drop       | file                                               |

--- a/src/components/Widgets/DateControl.js
+++ b/src/components/Widgets/DateControl.js
@@ -2,15 +2,29 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import DateTimeControl from './DateTimeControl';
 import DateTime from 'react-datetime';
+import { Map } from 'immutable';
+import ImmutablePropTypes from 'react-immutable-proptypes';
 
-export default class DateControl extends DateTimeControl {
+export default class DateControl extends React.Component {
   render() {
-    return (<DateTime
-      timeFormat={false}
-      value={this.props.value}
-      onChange={this.handleChange}
+    return (<DateTimeControl
+      {...this.props}
+      field={this.props.field.updateIn([ 'field' ], (val = Map({})) => val.set('timeFormat', false))}
+      onChange={(datetime) => this.props.onChange(datetime)}
     />);
   }
 }
 
-DateControl.propTypes = DateTimeControl.propTypes;
+DateControl.propTypes = {
+  onChange: PropTypes.func.isRequired,
+  value: PropTypes.oneOfType([
+    PropTypes.object,
+    PropTypes.string,
+  ]),
+  field: ImmutablePropTypes.mapContains({
+    dateFormat: PropTypes.oneOfType([
+      PropTypes.string,
+      PropTypes.bool,
+    ]),
+  })
+};

--- a/src/components/Widgets/DateControl.js
+++ b/src/components/Widgets/DateControl.js
@@ -1,18 +1,9 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import DateTimeControl from './DateTimeControl';
 import DateTime from 'react-datetime';
 
-export default class DateControl extends React.Component {
-  componentDidMount() {
-    if (!this.props.value) {
-      this.props.onChange(new Date());
-    }
-  }
-
-  handleChange = (datetime) => {
-    this.props.onChange(datetime);
-  };
-
+export default class DateControl extends DateTimeControl {
   render() {
     return (<DateTime
       timeFormat={false}
@@ -22,7 +13,4 @@ export default class DateControl extends React.Component {
   }
 }
 
-DateControl.propTypes = {
-  onChange: PropTypes.func.isRequired,
-  value: PropTypes.object, // eslint-disable-line
-};
+DateControl.propTypes = DateTimeControl.propTypes;

--- a/src/components/Widgets/DateControl.js
+++ b/src/components/Widgets/DateControl.js
@@ -9,7 +9,7 @@ export default class DateControl extends React.Component {
   render() {
     return (<DateTimeControl
       {...this.props}
-      options={this.props.field.updateIn([ 'options' ], (val = Map({})) => val.set('timeFormat', false))}
+      field={this.props.field.updateIn([ 'options' ], (val = Map({})) => val.set('timeFormat', false))}
       onChange={(datetime) => this.props.onChange(datetime)}
     />);
   }

--- a/src/components/Widgets/DateControl.js
+++ b/src/components/Widgets/DateControl.js
@@ -9,7 +9,7 @@ export default class DateControl extends React.Component {
   render() {
     return (<DateTimeControl
       {...this.props}
-      field={this.props.field.updateIn([ 'field' ], (val = Map({})) => val.set('timeFormat', false))}
+      options={this.props.field.updateIn([ 'options' ], (val = Map({})) => val.set('timeFormat', false))}
       onChange={(datetime) => this.props.onChange(datetime)}
     />);
   }
@@ -21,7 +21,7 @@ DateControl.propTypes = {
     PropTypes.object,
     PropTypes.string,
   ]),
-  field: ImmutablePropTypes.mapContains({
+  options: ImmutablePropTypes.mapContains({
     dateFormat: PropTypes.oneOfType([
       PropTypes.string,
       PropTypes.bool,

--- a/src/components/Widgets/DatePreview.js
+++ b/src/components/Widgets/DatePreview.js
@@ -7,5 +7,8 @@ export default function DatePreview({ value }) {
 }
 
 DatePreview.propTypes = {
-  value: PropTypes.object,
+  value: PropTypes.oneOfType([
+    PropTypes.object,
+    PropTypes.string,
+  ]),
 };

--- a/src/components/Widgets/DateTimeControl.js
+++ b/src/components/Widgets/DateTimeControl.js
@@ -2,18 +2,14 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import DateTime from 'react-datetime';
 import ImmutablePropTypes from 'react-immutable-proptypes';
+import { Map } from 'immutable';
 
 export default class DateTimeControl extends React.Component {
-  constructor(props) {
-    super(props);
-    this.state = { value: this.getStateValue(this.props.value) };
-  }
-
   handleChange = (datetime) => {
     this.props.onChange(datetime);
   };
 
-  getStateValue(value) {
+  getValue(value) {
     if (value === false || value === '') {
       return '';
     } else if(!value) {
@@ -24,25 +20,18 @@ export default class DateTimeControl extends React.Component {
   }
 
   componentWillReceiveProps(props) {
-    const { value: newValue } = props;
-    if(newValue !== this.props.value) {
-      this.setState({ value: this.getStateValue(newValue) }, () => {
-        this.handleChange(this.state.value);
-      });
-    }
+    this.handleChange(this.getValue(props.value));
   }
 
   componentDidMount() {
-    this.handleChange(this.state.value);
+    this.handleChange(this.getValue(this.props.value));
   }
 
   render() {
-    const _fieldProps = this.props.field.get('field');
-    const fieldProps = _fieldProps && _fieldProps.toJSON ? _fieldProps.toJSON() : _fieldProps
-    const { value } = this.state;
+    const fieldProps = this.props.field.get('options', Map()).toJS();
     return (<DateTime
       {...fieldProps}
-      value={value}
+      value={this.getValue(this.props.value)}
       onChange={this.handleChange}
     />);
   }
@@ -55,7 +44,7 @@ DateTimeControl.propTypes = {
     PropTypes.string,
     PropTypes.bool,
   ]),
-  field: ImmutablePropTypes.mapContains({
+  options: ImmutablePropTypes.mapContains({
     dateFormat: PropTypes.oneOfType([
       PropTypes.string,
       PropTypes.bool,

--- a/src/components/Widgets/DateTimeControl.js
+++ b/src/components/Widgets/DateTimeControl.js
@@ -4,8 +4,12 @@ import DateTime from 'react-datetime';
 
 export default class DateTimeControl extends React.Component {
   componentDidMount() {
-    if (!this.props.value) {
-      this.props.onChange(new Date());
+    const { value, onChange } = this.props;
+    if (value == null) {
+      onChange(new Date());
+    }
+    if (value === false) {
+      onChange('');
     }
   }
 

--- a/src/components/Widgets/DateTimeControl.js
+++ b/src/components/Widgets/DateTimeControl.js
@@ -1,24 +1,50 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import DateTime from 'react-datetime';
+import ImmutablePropTypes from 'react-immutable-proptypes';
 
 export default class DateTimeControl extends React.Component {
-  componentDidMount() {
-    const { value, onChange } = this.props;
-    if (value == null) {
-      onChange(new Date());
-    }
-    if (value === false) {
-      onChange('');
-    }
+  constructor(props) {
+    super(props);
+    this.state = { value: this.getStateValue(this.props.value) };
   }
 
   handleChange = (datetime) => {
     this.props.onChange(datetime);
   };
 
+  getStateValue(value) {
+    if (value === false || value === '') {
+      return '';
+    } else if(!value) {
+      return new Date();
+    } else {
+      return value;
+    }
+  }
+
+  componentWillReceiveProps(props) {
+    const { value: newValue } = props;
+    if(newValue !== this.props.value) {
+      this.setState({ value: this.getStateValue(newValue) }, () => {
+        this.handleChange(this.state.value);
+      });
+    }
+  }
+
+  componentDidMount() {
+    this.handleChange(this.state.value);
+  }
+
   render() {
-    return <DateTime value={this.props.value} onChange={this.handleChange} />;
+    const _fieldProps = this.props.field.get('field');
+    const fieldProps = _fieldProps && _fieldProps.toJSON ? _fieldProps.toJSON() : _fieldProps
+    const { value } = this.state;
+    return (<DateTime
+      {...fieldProps}
+      value={value}
+      onChange={this.handleChange}
+    />);
   }
 }
 
@@ -27,5 +53,16 @@ DateTimeControl.propTypes = {
   value: PropTypes.oneOfType([
     PropTypes.object,
     PropTypes.string,
+    PropTypes.bool,
   ]),
+  field: ImmutablePropTypes.mapContains({
+    dateFormat: PropTypes.oneOfType([
+      PropTypes.string,
+      PropTypes.bool,
+    ]),
+    timeFormat: PropTypes.oneOfType([
+      PropTypes.string,
+      PropTypes.bool,
+    ]),
+  })
 };

--- a/src/components/Widgets/DateTimePreview.js
+++ b/src/components/Widgets/DateTimePreview.js
@@ -7,5 +7,8 @@ export default function DateTimePreview({ value }) {
 }
 
 DateTimePreview.propTypes = {
-  value: PropTypes.object,
+  value: PropTypes.oneOfType([
+    PropTypes.object,
+    PropTypes.string,
+  ]),
 };


### PR DESCRIPTION
**- Summary**

Allow setting an empty default for the Date and DateTime widgets.

This is done by setting the default to `false` (in an attempt to not change the existing behaviour too much). In this situation the field is actually set to `''` because this is what would happen if a date field was cleared manually previously. (Not sure whether `''` or `null` is preferred in this situation? Hence going with how it was done before.)

We've got an optional `expiry` date field (for post expiry) that we don't want set by default, however we want the option to set this field.

Previously this would be set to the current date by default which was a usability issue for us.

**- Test plan**

Tested manually.

When default is set to false and required is false and the value is not set: the field is saved as `''`.

When default is set to false and required is true and the value is not set: the post won't save (because of validation).

Everything else appears to remain the same.

**- Description for the changelog**

Allow setting an empty default value in the Date and DateTime widgets by setting `default: false`. *Note: empty values are saved as an empty string (`''`) not `null`.*

**- A picture of a cute animal (not mandatory but encouraged)**

![img](https://user-images.githubusercontent.com/1100280/31101585-20d8be56-a81a-11e7-8b03-488095b543ad.jpg)

**- Side notes**

Any thoughts on the fact that the Date component saves a DateTime string? I was inclined to modify it to save just a date (ie `yyyy-mm-dd`) but wanted to get feedback before doing so.

Also happy to change the null/empty/false handling in this, just went with backwards compat in this case...