### PR TITLE
Make Gatsby setup docs simpler.

### DIFF
--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -38,7 +38,7 @@ Hexo, Middleman | `/source`
 Spike | `/views`
 
 Notes:
-- Gatsby treats the `static` folder more strictly and will not render the admin page as the other generators. You will have to make a [page component](https://www.gatsbyjs.org/docs/building-with-components/) containing the necessary scripts of the Netlify CMS app in the admin page. However, the `config.yml` is to be placed in the `static` folder in the same way.
+- Gatsby treats the `static` folder more strictly when you are using `gatsby develop` and will not render the admin page if you go to `/admin` like the other generators. Instead, you must go to `/admin/index.html`. When you actually build the site with `gatsby build`, it should resolve correctly.
 
 If your generator isn't listed here, you can check its documentation, or as a shortcut, look in your project for a `CSS` or `images` folder. They're usually processed as static files, so it's likely you can store your `admin` folder next to those. (When you've found the location, feel free to add it to these docs by [filing a pull request](https://github.com/netlify/netlify-cms/blob/master/CONTRIBUTING.md)!).
 


### PR DESCRIPTION
**- Summary**

The Gatsby instructions that were added in #527 didn't actually need to be that complex. I tested the template that the author had, and the problem with it not showing up at `/admin/index.html` was that the script was in the `head` instead of in `body`. There is still a small difference with `gatsby develop` -- you must go to `/admin/index.html` instead of `/admin`, so I left that as a note.

**- Test plan**
N/A -- docs update

**- Description for the changelog**

Make Gatsby setup docs simpler.

**- A picture of a cute animal (not mandatory but encouraged)**
