### PR TITLE
Move storybook back to dev deps.

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,6 @@
   "author": "Netlify",
   "license": "MIT",
   "devDependencies": {
-    "@kadira/storybook": "^1.36.0",
     "all-contributors-cli": "^4.4.0",
     "autoprefixer": "^6.3.3",
     "babel": "^6.5.2",
@@ -109,6 +108,7 @@
     "webpack-postcss-tools": "^1.1.1"
   },
   "dependencies": {
+    "@kadira/storybook": "^1.36.0",
     "classnames": "^2.2.5",
     "create-react-class": "^15.6.0",
     "fuzzy": "^0.1.1",


### PR DESCRIPTION
This was breaking some sites that depended on the CMS because they were
accidentally using storybook's deps instead of adding them as their own
(particularly the babel presets). We are going to hold off on this until
the next version so that we can add a release warning.

This reverts commit 4634918001e474ec2f195fbdddae18591d3207ab.
