### PR TITLE
Add cachebuster to git-gateway API calls

### DIFF
--- a/src/backends/git-gateway/API.js
+++ b/src/backends/git-gateway/API.js
@@ -25,7 +25,8 @@ export default class API extends GithubAPI {
 
 
   urlFor(path, options) {
-    const params = [];
+    const cacheBuster = new Date().getTime();
+    const params = [`ts=${ cacheBuster }`];
     if (options.params) {
       for (const key in options.params) {
         params.push(`${ key }=${ encodeURIComponent(options.params[key]) }`);


### PR DESCRIPTION
**- Summary**

Adds a cachebuster to GitHub API calls made by the `git-gateway` backend. This closes the last reported instance of #308.

<!--
Explain the **motivation** for making this change.
What existing problem does the pull request solve?
-->

**- Test plan**

Tested manually and added to @neutyp's user testing site. Neither test was able to reproduce the recurrence of the fast-forward error.

<!--
Demonstrate the code is solid.
Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.
-->

**- Description for the changelog**

Add cachebuster to `git-gateway` API calls.

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

**- A picture of a cute animal (not mandatory but encouraged)**

![image](https://user-images.githubusercontent.com/1425133/31403508-1ea2905a-adae-11e7-8382-f4faace39741.png)
