### PR TITLE
fix links in docs by adding file extension

### DIFF
--- a/docs/intro.md
+++ b/docs/intro.md
@@ -38,7 +38,7 @@ The JS is also available via npm and can be integrated into your regular build p
 
 ### Editorial Workflow
 
-Netlify CMS has an optional [editorial workflow](/docs/editorial-workflow) that translates common Git commands into familiar language in a simple UI:
+Netlify CMS has an optional [editorial workflow](/docs/editorial-workflow.md) that translates common Git commands into familiar language in a simple UI:
 
 Actions in Netlify UI ...	| Perform these Git actions
 --- | ---
@@ -87,7 +87,7 @@ You point to where the files are stored, and specify the fields that define them
 
 ### Widgets
 
-Widgets define the data type and interface for entry fields. Netlify CMS comes with several built-in [widgets](/docs/widgets).
+Widgets define the data type and interface for entry fields. Netlify CMS comes with several built-in [widgets](/docs/widgets.md).
 
 ## Customization
 

--- a/docs/widgets.md
+++ b/docs/widgets.md
@@ -20,7 +20,7 @@ Widgets define the data type and interface for entry fields. Netlify CMS comes w
 | `list`     | repeatable group of other widgets  | Immutable List of objects containing field values  |
 | `relation` | text input w/ suggestions dropdown | value of `valueField` in related entry (see below) |
 
-We’re always adding new widgets, and you can also [create your own](/docs/extending)!
+We’re always adding new widgets, and you can also [create your own](/docs/extending.md)!
 
 ### List Widget
 


### PR DESCRIPTION
**- Summary**

Several links in the docs were broken, sending readers to 404 pages when clicking through. This has been fixed by adding the `.md` extension to their paths.

**- Test plan**

No tests necessary, though I clicked the links (they worked)

**- Description for the changelog**

Fixed some broken links between docs pages.

**- A picture of a cute animal (not mandatory but encouraged)**

![seal](https://media.giphy.com/media/10duMjFD15zpOE/giphy.gif)