### PR TITLE
Fix CMS path to create new entries.

### DIFF
--- a/src/containers/App.js
+++ b/src/containers/App.js
@@ -199,7 +199,7 @@ class App extends React.Component {
               <Switch>
                 <Route exact path='/' component={DashboardPage} />
                 <Route exact path="/collections/:name" component={CollectionPage} />
-                <Route path="/collections/:name/entries/new" render={(props) => (<EntryPage {...props} newRecord={true}/>)} />
+                <Route path="/collections/:name/new" render={(props) => (<EntryPage {...props} newRecord />)} />
                 <Route path="/collections/:name/entries/:slug" component={EntryPage} />
                 <Route path="/search/:searchTerm" component={SearchPage} />
                 <Route component={NotFoundPage} />

--- a/src/lib/urlHelper.js
+++ b/src/lib/urlHelper.js
@@ -10,7 +10,7 @@ export function getCollectionUrl(collectionName, direct) {
 }
 
 export function getNewEntryUrl(collectionName, direct) {
-  return getUrl(`/collections/${ collectionName }/entries/new`, direct);
+  return getUrl(`/collections/${ collectionName }/new`, direct);
 }
 
 /* See https://www.w3.org/International/articles/idn-and-iri/#path.


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines;
https://github.com/netlify/netlify-cms/blob/master/CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first three fields are mandatory:
-->

**- Summary**

Right now we use `/collections/:name/entries/new` to create a new entry, but this prevents any entry that has a slug of `new` from being edited. This PR changes the path to be `/collections/:name/new` instead.

Closes #692.

**- Test plan**

Manually tested creating new entries with example site (simple and editorial workflow). Also tested with filename slug set to `new`.
<!--
Demonstrate the code is solid.
Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.
-->

**- Description for the changelog**

Fix CMS path to create new entries.

**- A picture of a cute animal (not mandatory but encouraged)**
