### PR TITLE
Update validation.md

### DIFF
--- a/docs/validation.md
+++ b/docs/validation.md
@@ -6,7 +6,7 @@
 `- {label: "Subtitle", name: "subtitle", widget: "string", required: false}`
 
 - Pattern: Field configuration can specify a regex pattern with the appropriate error message. Example:
-`- {label: "Title", name: "title", widget: "string", pattern: [".{10,}", "Should have more than 10 characters"] }`
+`- {label: "Title", name: "title", widget: "string", pattern: ['.{10,}', "Should have more than 10 characters"] }`
 
 
 ## Advanced Guide (For widget authors)


### PR DESCRIPTION


**- Summary**

#675 - Using single quotes for pattern does not parse escape sequences. This makes it easier to use regex without having to use double escapes. Also helps with people who aren't too familiar with yaml and wondering why they are getting a parsing error.

**- Test plan**

N / A

**- Description for the changelog**

Documentation for validation updated to use single quotes for pattern regex string.

**- A picture of a cute animal (not mandatory but encouraged)**
