### PR TITLE
Add ScrollSync Button to Preview UI

### DIFF
--- a/src/components/EntryEditor/EntryEditor.css
+++ b/src/components/EntryEditor/EntryEditor.css
@@ -3,16 +3,18 @@
   height: 100%;
 }
 
-.nc-entryEditor-previewToggle {
+.nc-entryEditor-toggleButtons {
   position: absolute;
   top: 8px;
-  right: 40px;
+  right: 20px;
   z-index: 1000;
   opacity: 0.8;
+  display: flex;
+  justify-content: flex-end;
 }
 
-.nc-entryEditor-previewToggleShow {
-  right: 60px;
+.nc-entryEditor-toggleButtons > * + * {
+  margin-left: 10px;
 }
 
 .nc-entryEditor-controlPane {

--- a/src/components/EntryEditor/EntryEditor.css
+++ b/src/components/EntryEditor/EntryEditor.css
@@ -3,7 +3,7 @@
   height: 100%;
 }
 
-.nc-entryEditor-toggleButtons {
+.nc-entryEditor-controlPaneButtons {
   position: absolute;
   top: 8px;
   right: 20px;
@@ -13,8 +13,12 @@
   justify-content: flex-end;
 }
 
-.nc-entryEditor-toggleButtons > * + * {
-  margin-left: 10px;
+.nc-entryEditor-toggleButton {
+  margin-left: 5px;
+}
+
+.nc-entryEditor-toggleButtonShow {
+  right: 60px;
 }
 
 .nc-entryEditor-controlPane {

--- a/src/components/EntryEditor/EntryEditor.js
+++ b/src/components/EntryEditor/EntryEditor.js
@@ -86,7 +86,7 @@ class EntryEditor extends Component {
           <div className="nc-entryEditor-controlPaneButtons">
             { previewVisible && (
               <ToggleButton
-                icon={scrollSyncEnabled ? 'sync_disabled' : 'sync'}
+                icon={scrollSyncEnabled ? 'sync' : 'sync_disabled'}
                 onClick={this.handleToggleScrollSync}
               />
             ) }

--- a/src/components/EntryEditor/EntryEditor.js
+++ b/src/components/EntryEditor/EntryEditor.js
@@ -67,21 +67,11 @@ class EntryEditor extends Component {
 
     const collectionPreviewEnabled = collection.getIn(['editor', 'preview'], true);
 
-    const TogglePreviewButton = () => (
+    const ToggleButton = ({ icon, onClick }) => (
       <Button
-        className="nc-entryEditor-toggleButtons"
-        onClick={this.handleTogglePreview}
-        icon={previewVisible ? 'visibility_off' : 'visibility'}
-        floating
-        mini
-      />
-    );
-
-    const ToggleScrollSyncButton = () => (
-      <Button
-        className="nc-entryEditor-toggleButtons"
-        onClick={this.handleToggleScrollSync}
-        icon={scrollSyncEnabled ? 'sync_disabled' : 'sync'}
+        className={classnames('nc-entryEditor-toggleButton', { previewVisible: 'nc-entryEditor-toggleButtonShow' })}
+        icon={icon}
+        onClick={onClick}
         floating
         mini
       />
@@ -89,13 +79,21 @@ class EntryEditor extends Component {
 
     const editor = (
       <StickyContext
-        className={classnames('nc-entryEditor-controlPane', { ['nc-entryEditor-blocker']: showEventBlocker })}
+        className={classnames('nc-entryEditor-controlPane', { 'nc-entryEditor-blocker': showEventBlocker })}
         registerListener={fn => this.updateStickyContext = fn}
       >
         { collectionPreviewEnabled ? (
-          <div className={classnames(styles.toggleButtons)}>
-            { previewVisible && <ToggleScrollSyncButton /> }
-            <TogglePreviewButton />
+          <div className="nc-entryEditor-controlPaneButtons">
+            { previewVisible && (
+              <ToggleButton
+                icon={scrollSyncEnabled ? 'sync_disabled' : 'sync'}
+                onClick={this.handleToggleScrollSync}
+              />
+            ) }
+            <ToggleButton
+              icon={previewVisible ? 'visibility_off' : 'visibility'}
+              onClick={this.handleTogglePreview}
+            />
           </div>
         ) : null }
         <ControlPane
@@ -124,7 +122,7 @@ class EntryEditor extends Component {
             onChange={this.updateStickyContext}
           >
             <ScrollSyncPane>{editor}</ScrollSyncPane>
-            <div className={classnames('nc-entryEditor-previewPane', { ['nc-entryEditor-blocker']: showEventBlocker })}>
+            <div className={classnames('nc-entryEditor-previewPane', { 'nc-entryEditor-blocker': showEventBlocker })}>
               <PreviewPane
                 collection={collection}
                 entry={entry}

--- a/src/components/EntryEditor/EntryEditor.js
+++ b/src/components/EntryEditor/EntryEditor.js
@@ -11,11 +11,13 @@ import Toolbar from './EntryEditorToolbar';
 import { StickyContext } from '../UI/Sticky/Sticky';
 
 const PREVIEW_VISIBLE = 'cms.preview-visible';
+const SCROLL_SYNC_ENABLED = 'cms.scroll-sync-enabled';
 
 class EntryEditor extends Component {
   state = {
     showEventBlocker: false,
     previewVisible: localStorage.getItem(PREVIEW_VISIBLE) !== "false",
+    scrollSyncEnabled: localStorage.getItem(SCROLL_SYNC_ENABLED) !== "false",
   };
 
   handleSplitPaneDragStart = () => {
@@ -37,6 +39,12 @@ class EntryEditor extends Component {
     localStorage.setItem(PREVIEW_VISIBLE, newPreviewVisible);
   };
 
+  handleToggleScrollSync = () => {
+    const newScrollSyncEnabled = !this.state.scrollSyncEnabled;
+    this.setState({ scrollSyncEnabled: newScrollSyncEnabled });
+    localStorage.setItem(SCROLL_SYNC_ENABLED, newScrollSyncEnabled);
+  };
+
   render() {
     const {
         collection,
@@ -55,15 +63,25 @@ class EntryEditor extends Component {
         onCancelEdit,
     } = this.props;
 
-    const { previewVisible, showEventBlocker } = this.state;
+    const { previewVisible, scrollSyncEnabled, showEventBlocker } = this.state;
 
     const collectionPreviewEnabled = collection.getIn(['editor', 'preview'], true);
 
-    const togglePreviewButton = (
+    const TogglePreviewButton = () => (
       <Button
-        className={classnames('nc-entryEditor-previewToggle', { previewVisible: 'nc-entryEditor-previewToggleShow' })}
+        className="nc-entryEditor-toggleButtons"
         onClick={this.handleTogglePreview}
         icon={previewVisible ? 'visibility_off' : 'visibility'}
+        floating
+        mini
+      />
+    );
+
+    const ToggleScrollSyncButton = () => (
+      <Button
+        className="nc-entryEditor-toggleButtons"
+        onClick={this.handleToggleScrollSync}
+        icon={scrollSyncEnabled ? 'sync_disabled' : 'sync'}
         floating
         mini
       />
@@ -74,7 +92,12 @@ class EntryEditor extends Component {
         className={classnames('nc-entryEditor-controlPane', { ['nc-entryEditor-blocker']: showEventBlocker })}
         registerListener={fn => this.updateStickyContext = fn}
       >
-        { collectionPreviewEnabled ? togglePreviewButton : null }
+        { collectionPreviewEnabled ? (
+          <div className={classnames(styles.toggleButtons)}>
+            { previewVisible && <ToggleScrollSyncButton /> }
+            <TogglePreviewButton />
+          </div>
+        ) : null }
         <ControlPane
           collection={collection}
           entry={entry}
@@ -92,7 +115,7 @@ class EntryEditor extends Component {
     );
 
     const editorWithPreview = (
-      <ScrollSync>
+      <ScrollSync enabled={this.state.scrollSyncEnabled}>
         <div className="nc-entryEditor-container">
           <SplitPane
             defaultSize="50%"

--- a/src/components/ScrollSync/ScrollSync.js
+++ b/src/components/ScrollSync/ScrollSync.js
@@ -6,6 +6,7 @@ export default class ScrollSync extends Component {
 
   static propTypes = {
     children: PropTypes.element.isRequired,
+    enabled: PropTypes.bool.isRequired
   };
 
   static childContextTypes = {
@@ -51,6 +52,7 @@ export default class ScrollSync extends Component {
   };
 
   handlePaneScroll = (node) => {
+    if (!this.props.enabled) return false
     // const node = evt.target
     window.requestAnimationFrame(() => {
       this.syncScrollPositions(node);

--- a/src/components/ScrollSync/ScrollSync.js
+++ b/src/components/ScrollSync/ScrollSync.js
@@ -6,7 +6,7 @@ export default class ScrollSync extends Component {
 
   static propTypes = {
     children: PropTypes.element.isRequired,
-    enabled: PropTypes.bool.isRequired
+    enabled: PropTypes.bool.isRequired,
   };
 
   static childContextTypes = {
@@ -52,7 +52,7 @@ export default class ScrollSync extends Component {
   };
 
   handlePaneScroll = (node) => {
-    if (!this.props.enabled) return false
+    if (!this.props.enabled) return false;
     // const node = evt.target
     window.requestAnimationFrame(() => {
       this.syncScrollPositions(node);


### PR DESCRIPTION
Closes #532 

**- Summary**

- A new button allows the user to toggle preview auto-scroll behaviour.
- This button is only rendered when preview is enabled
- Button state is stored and read via localStorage (same as preview button)
- Uses `sync` and `sync-disabled` icon

**- Test plan**

Manually tested UI (see screen capture). If I should be adding formal tests, please let me know.

![scroll](https://user-images.githubusercontent.com/3147296/31572491-abf719f0-b0ea-11e7-9fa9-45be464e5cda.gif)

**- Description for the changelog**

Added button to toggle preview scroll-sync.

**- A picture of a cute animal (not mandatory but encouraged)**

![wallaby](https://user-images.githubusercontent.com/3147296/31572528-c0558e6c-b0eb-11e7-879b-6afca62528d0.jpg)
