### PR TITLE
Removes the index.html from the dist folder on build

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,6 @@ import React from 'react';
 import createReactClass from 'create-react-class';
 import { render } from 'react-dom';
 import { AppContainer } from 'react-hot-loader';
-import 'file-loader?name=index.html!../example/index.html';
 import 'normalize.css';
 import Root from './root';
 import registry from './lib/registry';


### PR DESCRIPTION
**- Summary**

This causes the index.html from /example to be included in the `dist` and published to the npm package.

**- Test plan**

Deploy should show no side affects, since this is a build issue.
Development `yarn start` runs with no side affects.
Run a build command to make sure the `index.html` file is excluded from the build.

**- Description for the changelog**

Remove the distribution of the index.html example file into the package `dist` folder.

**- A picture of a cute animal (not mandatory but encouraged)**
