### PR TITLE
Remove ie11 support

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,9 +70,7 @@
     "last 2 Edge versions",
     "last 2 Safari versions",
     "last 2 iOS versions",
-    "last 2 ChromeAndroid versions",
-    "IE 11",
-    "IE_mob 11"
+    "last 2 ChromeAndroid versions"
   ],
   "devDependencies": {
     "all-contributors-cli": "^4.4.0",
@@ -184,8 +182,7 @@
     "unified": "^6.1.4",
     "unist-builder": "^1.0.2",
     "unist-util-visit-parents": "^1.1.1",
-    "uuid": "^3.1.0",
-    "whatwg-fetch": "^1.0.0"
+    "uuid": "^3.1.0"
   },
   "optionalDependencies": {
     "fsevents": "^1.0.14"

--- a/webpack.base.js
+++ b/webpack.base.js
@@ -68,9 +68,6 @@ module.exports = {
   plugins: [
     new webpack.IgnorePlugin(/^esprima$/, /js-yaml/), // Ignore Esprima import for js-yaml
     new webpack.IgnorePlugin(/^\.\/locale$/, /moment$/), // Ignore all optional deps of moment.js
-    new webpack.ProvidePlugin({
-      fetch: 'imports-loader?this=>global!exports-loader?global.fetch!whatwg-fetch',
-    }),
   ],
   target: 'web', // Make web variables accessible to webpack, e.g. window
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -9720,7 +9720,7 @@ whatwg-encoding@^1.0.1:
   dependencies:
     iconv-lite "0.4.13"
 
-whatwg-fetch@>=0.10.0, whatwg-fetch@^1.0.0:
+whatwg-fetch@>=0.10.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-1.1.1.tgz#ac3c9d39f320c6dce5339969d054ef43dd333319"
 


### PR DESCRIPTION
**- Summary**

Remove any pollyfill shims for IE11 and stop targeting in babel env

Closes #695 
Replaces and Closes #699 
Replaces and Closes #698 

**- Test plan**

Test known browsers.

**- Description for the changelog**

There was a full discussion on including polyfills for IE11 alone and it was agreed to drop support for IE11 in the CMS.
Benifits will include a smaller code base and not having to manage the polyfills.
