### PR TITLE
Add delete flag in configuration

### DIFF
--- a/example/config.yml
+++ b/example/config.yml
@@ -10,7 +10,6 @@ collections: # A list of collections the CMS should be able to edit
     folder: "_posts"
     slug: "{{year}}-{{month}}-{{day}}-{{slug}}"
     create: true # Allow users to create new documents in this collection
-    delete: true # Allow users to delete documents from this collection
     fields: # The fields each document in this collection have
       - {label: "Title", name: "title", widget: "string", tagname: "h1"}
       - {label: "Publish Date", name: "date", widget: "datetime", format: "YYYY-MM-DD hh:mma"}
@@ -23,14 +22,13 @@ collections: # A list of collections the CMS should be able to edit
     label: "FAQ" # Used in the UI, ie.: "New Post"
     folder: "_faqs"
     create: true # Allow users to create new documents in this collection
-    delete: true # Allow users to delete documents from this collection
     fields: # The fields each document in this collection have
       - {label: "Question", name: "title", widget: "string", tagname: "h1"}
       - {label: "Answer", name: "body", widget: "markdown"}
 
   - name: "settings"
     label: "Settings"
-    delete: false
+    delete: false # Prevent users from delteing documents in this collectoin
     editor:
       preview: false
     files:

--- a/example/config.yml
+++ b/example/config.yml
@@ -28,7 +28,7 @@ collections: # A list of collections the CMS should be able to edit
 
   - name: "settings"
     label: "Settings"
-    delete: false # Prevent users from delteing documents in this collectoin
+    delete: false # Prevent users from deleting documents in this collection
     editor:
       preview: false
     files:

--- a/example/config.yml
+++ b/example/config.yml
@@ -10,6 +10,7 @@ collections: # A list of collections the CMS should be able to edit
     folder: "_posts"
     slug: "{{year}}-{{month}}-{{day}}-{{slug}}"
     create: true # Allow users to create new documents in this collection
+    delete: true # Allow users to delete documents from this collection
     fields: # The fields each document in this collection have
       - {label: "Title", name: "title", widget: "string", tagname: "h1"}
       - {label: "Publish Date", name: "date", widget: "datetime", format: "YYYY-MM-DD hh:mma"}
@@ -22,12 +23,14 @@ collections: # A list of collections the CMS should be able to edit
     label: "FAQ" # Used in the UI, ie.: "New Post"
     folder: "_faqs"
     create: true # Allow users to create new documents in this collection
+    delete: true # Allow users to delete documents from this collection
     fields: # The fields each document in this collection have
       - {label: "Question", name: "title", widget: "string", tagname: "h1"}
       - {label: "Answer", name: "body", widget: "markdown"}
 
   - name: "settings"
     label: "Settings"
+    delete: false
     editor:
       preview: false
     files:

--- a/src/backends/backend.js
+++ b/src/backends/backend.js
@@ -3,7 +3,7 @@ import TestRepoBackend from "./test-repo/implementation";
 import GitHubBackend from "./github/implementation";
 import GitGatewayBackend from "./git-gateway/implementation";
 import { resolveFormat } from "../formats/formats";
-import { selectListMethod, selectEntrySlug, selectEntryPath, selectAllowNewEntries, selectFolderEntryExtension } from "../reducers/collections";
+import { selectListMethod, selectEntrySlug, selectEntryPath, selectAllowNewEntries, selectAllowDeletion, selectFolderEntryExtension } from "../reducers/collections";
 import { createEntry } from "../valueObjects/Entry";
 import { sanitizeSlug } from "../lib/urlHelper";
 
@@ -246,6 +246,11 @@ class Backend {
 
   deleteEntry(config, collection, slug) {
     const path = selectEntryPath(collection, slug);
+
+    if (!selectAllowDeletion(collection)) {
+      throw (new Error("Not allowed to delete entries in this collection"));
+    }
+
     const commitMessage = `Delete ${ collection.get('label') } “${ slug }”`;
     return this.implementation.deleteFile(path, commitMessage);
   }

--- a/src/containers/editorialWorkflow/EntryPageHOC.js
+++ b/src/containers/editorialWorkflow/EntryPageHOC.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 import { EDITORIAL_WORKFLOW } from '../../constants/publishModes';
 import { selectUnpublishedEntry, selectEntry } from '../../reducers';
+import { selectAllowDeletion } from "../../reducers/collections";
 import { loadUnpublishedEntry, persistUnpublishedEntry } from '../../actions/editorialWorkflow';
 
 
@@ -15,11 +16,14 @@ export default function EntryPageHOC(EntryPage) {
   function mapStateToProps(state, ownProps) {
     const { collections } = state;
     const isEditorialWorkflow = (state.config.get('publish_mode') === EDITORIAL_WORKFLOW);
-    const returnObj = { isEditorialWorkflow, showDelete: !ownProps.newEntry };
+    const collection = collections.get(ownProps.match.params.name);
+    const returnObj = {
+      isEditorialWorkflow,
+      showDelete: !ownProps.newEntry && selectAllowDeletion(collection),
+    };
     if (isEditorialWorkflow) {
       returnObj.showDelete = false;
       const slug = ownProps.match.params.slug;
-      const collection = collections.get(ownProps.match.params.name);
       const unpublishedEntry = selectUnpublishedEntry(state, collection.get('name'), slug);
       if (unpublishedEntry) {
         returnObj.unpublishedEntry = true;

--- a/src/reducers/collections.js
+++ b/src/reducers/collections.js
@@ -54,7 +54,7 @@ const selectors = {
       return collection.get('create');
     },
     allowDeletion(collection) {
-      return collection.get('delete');
+      return collection.get('delete', true);
     },
     templateName(collection) {
       return collection.get('name');
@@ -84,7 +84,7 @@ const selectors = {
       return false;
     },
     allowDeletion(collection) {
-      return collection.get('delete');
+      return collection.get('delete', true);
     },
     templateName(collection, slug) {
       return slug;

--- a/src/reducers/collections.js
+++ b/src/reducers/collections.js
@@ -53,6 +53,9 @@ const selectors = {
     allowNewEntries(collection) {
       return collection.get('create');
     },
+    allowDeletion(collection) {
+      return collection.get('delete');
+    },
     templateName(collection) {
       return collection.get('name');
     },
@@ -80,6 +83,9 @@ const selectors = {
     allowNewEntries() {
       return false;
     },
+    allowDeletion(collection) {
+      return collection.get('delete');
+    },
     templateName(collection, slug) {
       return slug;
     },
@@ -92,6 +98,7 @@ export const selectEntryPath = (collection, slug) => selectors[collection.get('t
 export const selectEntrySlug = (collection, path) => selectors[collection.get('type')].entrySlug(collection, path);
 export const selectListMethod = collection => selectors[collection.get('type')].listMethod();
 export const selectAllowNewEntries = collection => selectors[collection.get('type')].allowNewEntries(collection);
+export const selectAllowDeletion = collection => selectors[collection.get('type')].allowDeletion(collection);
 export const selectTemplateName = (collection, slug) => selectors[collection.get('type')].templateName(collection, slug);
 export const selectInferedField = (collection, fieldName) => {
   const inferableField = INFERABLE_FIELDS[fieldName];


### PR DESCRIPTION
**- Summary**
Fixes #593. Adds a `delete` flag to collections in `config.yml`. Defaults to false. This is mostly for use with files to restrict users from deleting settings files etc that are available via the CMS but can also be used to restrict the ability to delete within any collection.

I'm currently not 100% sure about the how it should handle `delete` not being set for a collection. Ideally I'd have it like I've implemented where if `delete` is not set then it counts as `false`. This is how the `create` flag works. My only worry is that when this feature is implemented and users upgrade they will suddenly find that unless they add the flag that they can't delete documents they could previously? 

**EDIT — This now defaults to `true`**

**- Test plan**
Manually tested using example config using `yarn run start`.

* **Testing `delete: true`** – Visit [http://localhost:8080/#/collections/posts/entries/2017-10-18-post-number-9](http://localhost:8080/#/collections/posts/entries/2017-10-18-post-number-9) and ensure `DELETE` button is visible and deletes the entry.
* **Testing `delete: false`** –  Visit [http://localhost:8080/#/collections/settings/entries/general](http://localhost:8080/#/collections/settings/entries/general) and ensure `DELETE` button is hidden.
* **Testing `delete` not set** –  Visit [http://localhost:8080/#/collections/kitchenSink/entries/a-big-entry-with-all-the-things](http://localhost:8080/#/collections/kitchenSink/entries/a-big-entry-with-all-the-things) and ensure `DELETE` button is hidden.

**- Description for the changelog**
Adds a `delete` flag to collections in `config.yml` to restrict users from deleting important documents via the CMS.

