### PR TITLE
Use Lists for menu items, instead of maps or sequences.

### DIFF
--- a/src/components/AppHeader/AppHeader.js
+++ b/src/components/AppHeader/AppHeader.js
@@ -76,7 +76,7 @@ export default class AppHeader extends React.Component {
           onHide={this.handleCreateMenuHide}
         >
           {
-            collections.filter(collection => collection.get('create')).valueSeq().map(collection =>
+            collections.filter(collection => collection.get('create')).toList().map(collection =>
               <MenuItem
                 key={collection.get("name")}
                 value={collection.get("name")}

--- a/src/components/Widgets/Markdown/MarkdownControl/Toolbar/ToolbarComponentsMenu.js
+++ b/src/components/Widgets/Markdown/MarkdownControl/Toolbar/ToolbarComponentsMenu.js
@@ -42,7 +42,7 @@ export default class ToolbarComponentsMenu extends React.Component {
           onHide={this.handleComponentsMenuHide}
           ripple={false}
         >
-          {plugins && plugins.map(plugin => (
+          {plugins && plugins.toList().map(plugin => (
             <MenuItem
               key={plugin.get('id')}
               value={plugin.get('id')}


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines;
https://github.com/netlify/netlify-cms/blob/master/CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first three fields are mandatory:
-->

**- Summary**

Maps are actually invalid, and lists make more sense than sequences. This removes the React warning, and should make us compatible with React 16.

**- Test plan**

These two menus still work normally.

**- Description for the changelog**

BUGFIX: Use Lists for menu items, instead of maps or sequences.

**- A picture of a cute animal (not mandatory but encouraged)**
