### PR TITLE
Fix broken Editorial Workflow link

### DIFF
--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -64,7 +64,7 @@ backend:
 These lines specify your backend protocol and your publication branch. Git Gateway is an open source API that acts as a proxy between authenticated users of your site and your site repo. (We'll get to the details of that in the [Authentication section](#authentication) below.) If you leave out the `branch` declaration, it will default to `master`.
 
 ### Editorial Workflow
-By default, saving a post in the CMS interface will push a commit directly to the publication branch specified in `backend`. However, you also have the option to enable the [Editorial Workflow](editorial-workflow.md), which adds an interface for drafting, reviewing, and approving posts. To do this, add the following line to your `config.yml`:
+By default, saving a post in the CMS interface will push a commit directly to the publication branch specified in `backend`. However, you also have the option to enable the [Editorial Workflow](/docs/editorial-workflow), which adds an interface for drafting, reviewing, and approving posts. To do this, add the following line to your `config.yml`:
 
 ``` yaml
 publish_mode: editorial_workflow


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines;
https://github.com/netlify/netlify-cms/blob/master/CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first three fields are mandatory:
-->

**- Summary**

<!--
Explain the **motivation** for making this change.
What existing problem does the pull request solve?
-->

The Editorial Workflow link is set up to work within GitHub but redirects to a 404 page on the actual Docs site.

**- Test plan**

<!--
Demonstrate the code is solid.
Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.
-->

Editorial Workflow link will navigate to `/docs/editorial-workflow/` (correct URL) instead of `/docs/quick-start/editorial-workflow.md` (does not exist).

**- Description for the changelog**

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Fix broken Editorial Workflow link

**- A picture of a cute animal (not mandatory but encouraged)**

![download](https://user-images.githubusercontent.com/3718939/31867944-5ff0c064-b75d-11e7-8f06-bfcf472751cd.jpeg)

