### PR TITLE
Fix EntryPage showing double confirmations if changes not saved.

### DIFF
--- a/src/containers/EntryPage.js
+++ b/src/containers/EntryPage.js
@@ -56,10 +56,17 @@ class EntryPage extends React.Component {
       loadEntry(collection, slug);
     }
 
-    this.unblock = history.block((location) => {
+    const unblock = history.block((location) => {
       if (this.props.entryDraft.get('hasChanged')) {
         return "Are you sure you want to leave this page?";
       }
+    });
+
+    // This will run as soon as the location actually changes.
+    //   (The confirmation above will run first.)
+    this.unlisten = history.listen(() => {
+      unblock();
+      this.unlisten();
     });
   }
 
@@ -83,7 +90,6 @@ class EntryPage extends React.Component {
 
   componentWillUnmount() {
     this.props.discardDraft();
-    this.unblock();
   }
 
   createDraft = (entry) => {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines;
https://github.com/netlify/netlify-cms/blob/master/CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first three fields are mandatory:
-->

**- Summary**

There is a small regression as of React 16: If someone edits an entry, then without saving, they exit the entry editor, they are presented with two confirm dialogs, instead of just one.

The normal flow:
1. User clicks Home button to go to Dashboard.
2. User is prompted to save changes. **If changes Rejected:**
    1. Location changed to `/`.
    2. `DRAFT_DISCARD` runs.
    3. Location redirects to default entry listing (e.g. `/collections/posts`)

The current (broken) flow:
1. User clicks Home button to go to Dashboard.
2. User is prompted to save changes. **If changes Rejected:**
    1. Location changed to `/`.
    2. Location redirects to default entry listing (e.g. `/collections/posts`)
    3. `DRAFT_DISCARD` runs.

The change comes where 2.ii. and 2.iii. are switched.

This may be related to https://reactjs.org/blog/2017/09/26/react-v16.0.html#breaking-changes.
> When replacing <code>&lt;A /&gt;</code> with <code>&lt;B /&gt;</code>,  <code>B.componentWillMount</code> now always happens before  <code>A.componentWillUnmount</code>. Previously, <code>A.componentWillUnmount</code> could fire first in some cases.

**- Test plan**

Manually tested to be working.

**- Description for the changelog**

Fix EntryPage showing double confirmations if changes not saved.

**- A picture of a cute animal (not mandatory but encouraged)**
