### PR TITLE
Fix history warning when opening entry.

### DIFF
--- a/src/components/EntryListing/EntryListing.js
+++ b/src/components/EntryListing/EntryListing.js
@@ -48,7 +48,7 @@ export default class EntryListing extends React.Component {
     return (
       <Card
         key={entry.get('slug')}
-        onClick={history.push.bind(this, path)} // eslint-disable-line
+        onClick={() => history.push(path)} // eslint-disable-line
         className="nc-entryListing-card"
       >
         { image &&


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines;
https://github.com/netlify/netlify-cms/blob/master/CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first three fields are mandatory:
-->

**- Summary**

When clicking on a entry in the listing, a console error would be logged
by `history` (react-router): "Hash history cannot push state; it is
ignored". This was caused because using `bind` in the click handler
caused the return value to be passed to the `history.push` as the second
param. This was ignored in react-router v2, but gives a warning in v4.


**- Test plan**

Opening an entry works fine, with no console error.

**- Description for the changelog**

Fix `history` warning when opening entry.

**- A picture of a cute animal (not mandatory but encouraged)**
