### PR TITLE
stop navigation on failed entry save in editorial workflow

### DIFF
--- a/src/actions/editorialWorkflow.js
+++ b/src/actions/editorialWorkflow.js
@@ -227,7 +227,7 @@ export function persistUnpublishedEntry(collection, existingUnpublishedEntry) {
     const entryDraft = state.entryDraft;
 
     // Early return if draft contains validation errors
-    if (!entryDraft.get('fieldsErrors').isEmpty()) return Promise.resolve();
+    if (!entryDraft.get('fieldsErrors').isEmpty()) return Promise.reject();
 
     const backend = currentBackend(state.config);
     const transactionID = uuid();
@@ -260,7 +260,7 @@ export function persistUnpublishedEntry(collection, existingUnpublishedEntry) {
         kind: 'danger',
         dismissAfter: 8000,
       }));
-      return dispatch(unpublishedEntryPersistedFail(error, transactionID));
+      return Promise.reject(dispatch(unpublishedEntryPersistedFail(error, transactionID)));
     });
   };
 }


### PR DESCRIPTION
Related to #555, extends #566 fix to also cover editorial workflow.