### PR TITLE
Cleanup file formatters.

### DIFF
--- a/src/formats/__tests__/frontmatter.spec.js
+++ b/src/formats/__tests__/frontmatter.spec.js
@@ -1,8 +1,6 @@
-import Frontmatter from '../frontmatter';
+import FrontmatterFormatter from '../frontmatter';
 
 jest.mock("../../valueObjects/AssetProxy.js");
-
-const FrontmatterFormatter = new Frontmatter();
 
 describe('Frontmatter', () => {
   it('should parse YAML with --- delimiters', () => {

--- a/src/formats/formats.js
+++ b/src/formats/formats.js
@@ -3,6 +3,14 @@ import TOML from './toml';
 import JSONFormatter from './json';
 import Frontmatter from './frontmatter';
 
+export const formatToExtension = format => ({
+  markdown: 'md',
+  yaml: 'yml',
+  toml: 'toml',
+  json: 'json',
+  html: 'html',
+}[format]);
+
 const yamlFormatter = new YAML();
 const tomlFormatter = new TOML();
 const jsonFormatter = new JSONFormatter();

--- a/src/formats/formats.js
+++ b/src/formats/formats.js
@@ -1,7 +1,7 @@
-import YAML from './yaml';
-import TOML from './toml';
-import JSONFormatter from './json';
-import Frontmatter from './frontmatter';
+import yamlFormatter from './yaml';
+import tomlFormatter from './toml';
+import jsonFormatter from './json';
+import FrontmatterFormatter from './frontmatter';
 
 export const formatToExtension = format => ({
   markdown: 'md',
@@ -10,11 +10,6 @@ export const formatToExtension = format => ({
   json: 'json',
   html: 'html',
 }[format]);
-
-const yamlFormatter = new YAML();
-const tomlFormatter = new TOML();
-const jsonFormatter = new JSONFormatter();
-const FrontmatterFormatter = new Frontmatter();
 
 function formatByType(type) {
   // Right now the only type is "editorialWorkflow" and

--- a/src/formats/frontmatter.js
+++ b/src/formats/frontmatter.js
@@ -40,21 +40,14 @@ function inferFrontmatterFormat(str) {
 export default class Frontmatter {
   fromFile(content) {
     const result = matter(content, { engines: parsers, ...inferFrontmatterFormat(content) });
-    const data = result.data;
-    data.body = result.content;
-    return data;
+    return {
+      ...result.data,
+      body: result.content,
+    };
   }
 
   toFile(data, sortedKeys) {
-    const meta = {};
-    let body = '';
-    Object.keys(data).forEach((key) => {
-      if (key === 'body') {
-        body = data[key];
-      } else {
-        meta[key] = data[key];
-      }
-    });
+    const { body, ...meta } = data;
 
     // always stringify to YAML
     const parser = {

--- a/src/formats/frontmatter.js
+++ b/src/formats/frontmatter.js
@@ -1,8 +1,6 @@
 import matter from 'gray-matter';
-import TOML from './toml';
-import YAML from './yaml';
-
-const tomlFormatter = new TOML();
+import tomlFormatter from './toml';
+import yamlFormatter from './yaml';
 
 const parsers = {
   toml: tomlFormatter.fromFile.bind(tomlFormatter),
@@ -37,14 +35,14 @@ function inferFrontmatterFormat(str) {
   }
 }
 
-export default class Frontmatter {
+export default {
   fromFile(content) {
     const result = matter(content, { engines: parsers, ...inferFrontmatterFormat(content) });
     return {
       ...result.data,
       body: result.content,
     };
-  }
+  },
 
   toFile(data, sortedKeys) {
     const { body, ...meta } = data;
@@ -52,7 +50,7 @@ export default class Frontmatter {
     // always stringify to YAML
     const parser = {
       stringify(metadata) {
-        return new YAML().toFile(metadata, sortedKeys);
+        return yamlFormatter.toFile(metadata, sortedKeys);
       },
     };
     return matter.stringify(body, meta, { language: "yaml", delimiters: "---", engines: { yaml: parser } });

--- a/src/formats/frontmatter.js
+++ b/src/formats/frontmatter.js
@@ -1,10 +1,11 @@
 import matter from 'gray-matter';
 import tomlFormatter from './toml';
 import yamlFormatter from './yaml';
+import jsonFormatter from './json';
 
 const parsers = {
-  toml: tomlFormatter.fromFile.bind(tomlFormatter),
-  json: (input) => {
+  toml: input => tomlFormatter.fromFile(input),
+  json: input => {
     let JSONinput = input.trim();
     // Fix JSON if leading and trailing brackets were trimmed.
     if (JSONinput.substr(0, 1) !== '{') {
@@ -13,8 +14,9 @@ const parsers = {
     if (JSONinput.substr(-1) !== '}') {
       JSONinput = JSONinput + '}';
     }
-    return matter.engines.json.parse(JSONinput);
+    return jsonFormatter.fromFile(JSONinput);
   },
+  yaml: input => yamlFormatter.fromFile(input),
 }
 
 function inferFrontmatterFormat(str) {

--- a/src/formats/frontmatter.js
+++ b/src/formats/frontmatter.js
@@ -16,7 +16,10 @@ const parsers = {
     }
     return jsonFormatter.fromFile(JSONinput);
   },
-  yaml: input => yamlFormatter.fromFile(input),
+  yaml: {
+    parse: input => yamlFormatter.fromFile(input),
+    stringify: (metadata, { sortedKeys }) => yamlFormatter.toFile(metadata, sortedKeys),
+  },
 }
 
 function inferFrontmatterFormat(str) {
@@ -50,11 +53,7 @@ export default {
     const { body, ...meta } = data;
 
     // always stringify to YAML
-    const parser = {
-      stringify(metadata) {
-        return yamlFormatter.toFile(metadata, sortedKeys);
-      },
-    };
-    return matter.stringify(body, meta, { language: "yaml", delimiters: "---", engines: { yaml: parser } });
+    // `sortedKeys` is not recognized by gray-matter, so it gets passed through to the parser
+    return matter.stringify(body, meta, { engines: parsers, language: "yaml", delimiters: "---", sortedKeys });
   }
 }

--- a/src/formats/json.js
+++ b/src/formats/json.js
@@ -1,7 +1,7 @@
-export default class JSONFormatter {
+export default {
   fromFile(content) {
     return JSON.parse(content);
-  }
+  },
 
   toFile(data) {
     return JSON.stringify(data);

--- a/src/formats/toml.js
+++ b/src/formats/toml.js
@@ -15,10 +15,10 @@ const outputReplacer = (key, value) => {
   return false;
 };
 
-export default class TOML {
+export default {
   fromFile(content) {
     return toml.parse(content);
-  }
+  },
 
   toFile(data, sortedKeys = []) {
     return tomlify.toToml(data, { replace: outputReplacer, sort: sortKeys(sortedKeys) });

--- a/src/formats/yaml.js
+++ b/src/formats/yaml.js
@@ -36,10 +36,10 @@ const OutputSchema = new yaml.Schema({
   explicit: yaml.DEFAULT_SAFE_SCHEMA.explicit,
 });
 
-export default class YAML {
+export default {
   fromFile(content) {
     return yaml.safeLoad(content);
-  }
+  },
 
   toFile(data, sortedKeys = []) {
     return yaml.safeDump(data, { schema: OutputSchema, sortKeys: sortKeys(sortedKeys) });

--- a/src/reducers/collections.js
+++ b/src/reducers/collections.js
@@ -4,6 +4,7 @@ import consoleError from '../lib/consoleError';
 import { CONFIG_SUCCESS } from '../actions/config';
 import { FILES, FOLDER } from '../constants/collectionTypes';
 import { INFERABLE_FIELDS } from '../constants/fieldInference';
+import { formatToExtension } from '../formats/formats';
 
 const collections = (state = null, action) => {
   const configCollections = action.payload && action.payload.collections;
@@ -25,14 +26,6 @@ const collections = (state = null, action) => {
       return state;
   }
 };
-
-const formatToExtension = format => ({
-  markdown: 'md',
-  yaml: 'yml',
-  toml: 'toml',
-  json: 'json',
-  html: 'html',
-}[format]);
 
 const selectors = {
   [FOLDER]: {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines;
https://github.com/netlify/netlify-cms/blob/master/CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first three fields are mandatory:
-->

**- Summary**

This PR aims to clean up the `/src/formats` code.

@erquhart @Benaiah What do you think on "Use same parsers for files and frontmatter."? I think this will be better to retain consistency in the future -- so things like AssetProxy and Moment.js can be interpreted correctly in frontmatter as well (instead of just in the data-file formatters).

FOR REVIEW: The easiest way to review this PR will probably be to review each commit separately, the history should be clean.

**- Test plan**

Tested manually with example site to ensure files are still being saved with correct format/extension.
<!--
Demonstrate the code is solid.
Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.
-->

**- Description for the changelog**

Cleanup file formatters.
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

**- A picture of a cute animal (not mandatory but encouraged)**
