### PR TITLE
fix image not shown after upload for git gateway

### DIFF
--- a/src/backends/github/implementation.js
+++ b/src/backends/github/implementation.js
@@ -102,11 +102,37 @@ export default class GitHub {
     return this.api.persistFiles(entry, mediaFiles, options);
   }
 
+  /**
+   * Pulls repo info from a `repos` response url property.
+   *
+   * Turns this:
+   * '<api_root>/repo/<username>/<repo>/...'
+   *
+   * Into this:
+   * '<username>/<repo>'
+   */
+  getRepoFromResponseUrl(url) {
+    return url
+
+      // -> '/repo/<username>/<repo>/...'
+      .slice(this.api_root.length)
+
+      // -> [ '', 'repo', '<username>', '<repo>', ... ]
+      .split('/')
+
+      // -> [ '<username>', '<repo>' ]
+      .slice(2, 4)
+
+      // -> '<username>/<repo>'
+      .join('/');
+  }
+
   async persistMedia(mediaFile, options = {}) {
     try {
       const response = await this.api.persistFiles(null, [mediaFile], options);
+      const repo = this.repo || this.getRepoFromResponseUrl(response.url);
       const { value, size, path, fileObj } = mediaFile;
-      const url = `https://raw.githubusercontent.com/${this.repo}/${this.branch}${path}`;
+      const url = `https://raw.githubusercontent.com/${repo}/${this.branch}${path}`;
       return { id: response.sha, name: value, size: fileObj.size, url, path: trimStart(path, '/') };
     }
     catch(error) {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines;
https://github.com/netlify/netlify-cms/blob/master/CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first three fields are mandatory:
-->

**- Summary**

<!--
Explain the **motivation** for making this change.
What existing problem does the pull request solve?
-->

Closes #788.

Images weren't visible until refresh after uploading in Git Gateway. Fixes image url construction by pulling the username/repo from the response url if no repo is set in the CMS config (as is the case in Git Gateway installations).