### PR TITLE
Fix other than markdown editorial workflow entries on dashboard.

### DIFF
--- a/src/actions/editorialWorkflow.js
+++ b/src/actions/editorialWorkflow.js
@@ -209,13 +209,13 @@ export function loadUnpublishedEntry(collection, slug) {
   };
 }
 
-export function loadUnpublishedEntries() {
+export function loadUnpublishedEntries(collections) {
   return (dispatch, getState) => {
     const state = getState();
     if (state.config.get('publish_mode') !== EDITORIAL_WORKFLOW) return;
     const backend = currentBackend(state.config);
     dispatch(unpublishedEntriesLoading());
-    backend.unpublishedEntries().then(
+    backend.unpublishedEntries(collections).then(
       response => dispatch(unpublishedEntriesLoaded(response.entries, response.pagination)),
       error => dispatch(unpublishedEntriesFailed(error))
     );

--- a/src/backends/backend.js
+++ b/src/backends/backend.js
@@ -164,8 +164,8 @@ class Backend {
     };
   }
 
-  unpublishedEntries(page, perPage) {
-    return this.implementation.unpublishedEntries(page, perPage)
+  unpublishedEntries(collections) {
+    return this.implementation.unpublishedEntries()
     .then(loadedEntries => loadedEntries.filter(entry => entry !== null))
     .then(entries => (
       entries.map((loadedEntry) => {
@@ -184,7 +184,10 @@ class Backend {
     ))
     .then(entries => ({
       pagination: 0,
-      entries: entries.map(this.entryWithFormat("editorialWorkflow")),
+      entries: entries.map(entry => {
+        const collection = collections.get(entry.collection);
+        return this.entryWithFormat(collection)(entry);
+      }),
     }));
   }
 

--- a/src/containers/editorialWorkflow/UnpublishedEntriesPanel.js
+++ b/src/containers/editorialWorkflow/UnpublishedEntriesPanel.js
@@ -16,6 +16,7 @@ import { Loader } from '../../components/UI';
 
 class unpublishedEntriesPanel extends Component {
   static propTypes = {
+    collections: ImmutablePropTypes.orderedMap,
     isEditorialWorkflow: PropTypes.bool.isRequired,
     isFetching: PropTypes.bool,
     unpublishedEntries: ImmutablePropTypes.map,
@@ -26,9 +27,9 @@ class unpublishedEntriesPanel extends Component {
   };
 
   componentDidMount() {
-    const { loadUnpublishedEntries, isEditorialWorkflow } = this.props;
+    const { loadUnpublishedEntries, isEditorialWorkflow, collections } = this.props;
     if (isEditorialWorkflow) {
-      loadUnpublishedEntries();
+      loadUnpublishedEntries(collections);
     }
   }
 
@@ -49,8 +50,9 @@ class unpublishedEntriesPanel extends Component {
 }
 
 function mapStateToProps(state) {
+  const { collections } = state;
   const isEditorialWorkflow = (state.config.get('publish_mode') === EDITORIAL_WORKFLOW);
-  const returnObj = { isEditorialWorkflow };
+  const returnObj = { collections, isEditorialWorkflow };
 
   if (isEditorialWorkflow) {
     returnObj.isFetching = state.editorialWorkflow.getIn(['pages', 'isFetching'], false);

--- a/src/formats/formats.js
+++ b/src/formats/formats.js
@@ -11,12 +11,6 @@ export const formatToExtension = format => ({
   html: 'html',
 }[format]);
 
-function formatByType(type) {
-  // Right now the only type is "editorialWorkflow" and
-  // we always returns the same format
-  return FrontmatterFormatter;
-}
-
 export function formatByExtension(extension) {
   return {
     yml: yamlFormatter,
@@ -39,9 +33,6 @@ function formatByName(name) {
 }
 
 export function resolveFormat(collectionOrEntity, entry) {
-  if (typeof collectionOrEntity === 'string') {
-    return formatByType(collectionOrEntity);
-  }
   const path = entry && entry.path;
   if (path) {
     return formatByExtension(path.split('.').pop());


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines;
https://github.com/netlify/netlify-cms/blob/master/CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first three fields are mandatory:
-->

**- Summary**

When entries were loaded for the editorial workflow dashboard, they were
all assumed to be FrontMatter/MarkDown files. This PR allows them to be
any supported format.

Fixes #743.

**- Test plan**

Tested use case in #743.
Also tested simple workflow -- no regressions found.
<!--
Demonstrate the code is solid.
Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.
-->

**- Description for the changelog**

Fix other than markdown editorial workflow entries on dashboard.
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

**- A picture of a cute animal (not mandatory but encouraged)**
