### PR TITLE
Do not infer file format if collection specified.

### DIFF
--- a/src/formats/formats.js
+++ b/src/formats/formats.js
@@ -34,9 +34,19 @@ function formatByName(name) {
 }
 
 export function resolveFormat(collectionOrEntity, entry) {
-  const path = entry && entry.path;
-  if (path) {
-    return formatByExtension(path.split('.').pop());
+  // If the format is specified in the collection, use that format.
+  const format = collectionOrEntity.get('format');
+  if (format) {
+    return formatByName(format);
   }
-  return formatByName(collectionOrEntity.get('format'));
+
+  // If a file already exists, infer the format from its file extension.
+  const filePath = entry && entry.path;
+  if (filePath) {
+    const fileExtension = filePath.split('.').pop();
+    return formatByExtension(fileExtension);
+  }
+
+  // If no format is specified and it cannot be inferred, return the default.
+  return formatByName();
 }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines;
https://github.com/netlify/netlify-cms/blob/master/CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first three fields are mandatory:
-->

**- Summary**

Before, we always tried to infer a file's format, even if it was
explicitly specified in the collection's config. This commit makes it so
that we always use the format from the config if it is specified, and
only if it is not set do we try to infer it from the file extension.

Fixes #763.

NOTE: Please review this fairly intensely -- I really don't want to break anything (don't think you are either).

**- Test plan**

Used CMS `/example`, as well as test case in the related issue.

**- Description for the changelog**

Do not infer file format if collection specified.

**- A picture of a cute animal (not mandatory but encouraged)**
