### PR TITLE
Fix no users being allowed to login when `accept_roles` set.

### DIFF
--- a/src/backends/git-gateway/implementation.js
+++ b/src/backends/git-gateway/implementation.js
@@ -55,9 +55,9 @@ export default class GitGateway extends GitHubBackend {
     .then((token) => {
       let validRole = true;
       if (this.accept_roles && this.accept_roles.length > 0) {
+        const userRoles = get(jwtDecode(token), 'app_metadata.roles', []);
         validRole = intersection(userRoles, this.accept_roles).length > 0;
       }
-      const userRoles = get(jwtDecode(token), 'app_metadata.roles', []);
       if (validRole) {
         const userData = {
           name: user.user_metadata.name || user.email.split('@').shift(),


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines;
https://github.com/netlify/netlify-cms/blob/master/CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first three fields are mandatory:
-->

**- Summary**

The actual code was invalid here. I haven't done much work with `git-gateway` yet, so I don't completely understand the code, but this looks like the right place to put it. Fixes #792.

**- Test plan**

Logging into `git-gateway`, both with and without `accept_roles`, seems to work normally.

**- Description for the changelog**

Fix no users being allowed to login when `accept_roles` set.

**- A picture of a cute animal (not mandatory but encouraged)**
