### PR TITLE
only rebase EW PR if no asset store

### DIFF
--- a/src/actions/editorialWorkflow.js
+++ b/src/actions/editorialWorkflow.js
@@ -246,7 +246,7 @@ export function persistUnpublishedEntry(collection, existingUnpublishedEntry) {
 
     dispatch(unpublishedEntryPersisting(collection, serializedEntry, transactionID));
     const persistAction = existingUnpublishedEntry ? backend.persistUnpublishedEntry : backend.persistEntry;
-    return persistAction.call(backend, state.config, collection, serializedEntryDraft, assetProxies.toJS())
+    return persistAction.call(backend, state.config, collection, serializedEntryDraft, assetProxies.toJS(), state.integrations)
     .then(() => {
       dispatch(notifSend({
         message: 'Entry saved',

--- a/src/backends/backend.js
+++ b/src/backends/backend.js
@@ -3,6 +3,7 @@ import TestRepoBackend from "./test-repo/implementation";
 import GitHubBackend from "./github/implementation";
 import GitGatewayBackend from "./git-gateway/implementation";
 import { resolveFormat } from "../formats/formats";
+import { selectIntegration } from '../reducers/integrations';
 import { selectListMethod, selectEntrySlug, selectEntryPath, selectAllowNewEntries, selectAllowDeletion, selectFolderEntryExtension } from "../reducers/collections";
 import { createEntry } from "../valueObjects/Entry";
 import { sanitizeSlug } from "../lib/urlHelper";
@@ -205,7 +206,7 @@ class Backend {
     .then(this.entryWithFormat(collection, slug));
   }
 
-  persistEntry(config, collection, entryDraft, MediaFiles, options) {
+  persistEntry(config, collection, entryDraft, MediaFiles, integrations, options = {}) {
     const newEntry = entryDraft.getIn(["entry", "newRecord"]) || false;
 
     const parsedData = {
@@ -243,8 +244,14 @@ class Backend {
 
     const collectionName = collection.get("name");
 
+    /**
+     * Determine whether an asset store integration is in use.
+     */
+    const hasAssetStore = !!selectIntegration(integrations, null, 'assetStore');
+    const updatedOptions = { ...options, hasAssetStore };
+
     return this.implementation.persistEntry(entryObj, MediaFiles, {
-      newEntry, parsedData, commitMessage, collectionName, mode, ...options,
+      newEntry, parsedData, commitMessage, collectionName, mode, ...updatedOptions,
     });
   }
 
@@ -271,8 +278,8 @@ class Backend {
     return this.implementation.deleteFile(path, commitMessage);
   }
 
-  persistUnpublishedEntry(config, collection, entryDraft, MediaFiles) {
-    return this.persistEntry(config, collection, entryDraft, MediaFiles, { unpublished: true });
+  persistUnpublishedEntry(...args) {
+    return this.persistEntry(...args, { unpublished: true });
   }
 
   updateUnpublishedEntryStatus(collection, slug, newStatus) {

--- a/src/backends/github/API.js
+++ b/src/backends/github/API.js
@@ -359,6 +359,21 @@ export default class API {
             files: uniq(files),
           };
           const updatedMetadata = { ...metadata, pr, title, description, objects };
+
+          /**
+           * If an asset store is in use, assets are always accessible, so we
+           * can just finish the persist operation here.
+           */
+          if (options.hasAssetStore) {
+            return this.storeMetadata(contentKey, updatedMetadata)
+              .then(() => this.patchBranch(branchName, newHead.sha));
+          }
+
+          /**
+           * If no asset store is in use, assets are being stored in the content
+           * repo, which means pull requests opened for editorial workflow
+           * entries must be rebased if assets have been added or removed.
+           */
           return this.rebasePullRequest(pr.number, branchName, contentKey, metadata, newHead);
         });
     }


### PR DESCRIPTION
Editorial workflow pull requests are rebased if the base has
changed to ensure that asset changes on the base branch are
reflected in the PR branch, but if an asset store is in use,
no rebasing is necessary because assets are stored outside
of the content repo.