### PR TITLE
Fix persist with missing body from file (regression from #759)

### DIFF
--- a/src/formats/__tests__/frontmatter.spec.js
+++ b/src/formats/__tests__/frontmatter.spec.js
@@ -102,4 +102,21 @@ describe('Frontmatter', () => {
       ].join('\n')
     );
   });
+
+  it('should stringify YAML with missing body', () => {
+    expect(
+      FrontmatterFormatter.toFile({ tags: ['front matter', 'yaml'], title: 'YAML' })
+    ).toEqual(
+      [
+        '---',
+        'tags:',
+        '  - front matter',
+        '  - yaml',
+        'title: YAML',
+        '---',
+        '',
+        '',
+      ].join('\n')
+    );
+  });
 });

--- a/src/formats/frontmatter.js
+++ b/src/formats/frontmatter.js
@@ -50,7 +50,7 @@ export default {
   },
 
   toFile(data, sortedKeys) {
-    const { body, ...meta } = data;
+    const { body = '', ...meta } = data;
 
     // always stringify to YAML
     // `sortedKeys` is not recognized by gray-matter, so it gets passed through to the parser


### PR DESCRIPTION

<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines;
https://github.com/netlify/netlify-cms/blob/master/CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first three fields are mandatory:
-->

**- Summary**
Trying to save a page that does not have a value for body results in an error. This is a regression from #759, which removed the default value for `body`.
<!--
Explain the **motivation** for making this change.
What existing problem does the pull request solve?
-->

**- Test plan**
If you try to save the Kitchen Sink entry you'll end up with the following error:
```
Uncaught TypeError: Cannot read property 'content' of undefined
    at module.exports (stringify.js?2ea5:23)
    at Function.matter.stringify (index.js?1c62:131)
    at Object.toFile (frontmatter.js?cfa9:57)
    at Backend.entryToRaw (backend.js?bb12:303)
    at Backend.persistEntry (backend.js?bb12:239)
    at eval (entries.js?c1a9:300)
    at eval (index.js?8bff:9)
    at eval (bindActionCreators.js?45eb:3)
    at eval (EntryPage.js?2e7b:109)
```

Or run new `should stringify YAML with missing body` test in `frontmatter.spec.js`.
<!--
Demonstrate the code is solid.
Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.
-->

**- Description for the changelog**
Includes a failing test as well as initiates `body` with an empty string if not available from page data.
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

**- A picture of a cute animal (not mandatory but encouraged)**