### PR TITLE
Fix requestAnimationFrame warnings in tests.

### DIFF
--- a/package.json
+++ b/package.json
@@ -109,6 +109,7 @@
     "postcss-cssnext": "^3.0.2",
     "postcss-import": "^11.0.0",
     "postcss-loader": "^2.0.7",
+    "raf": "^3.4.0",
     "react-hot-loader": "^3.0.0-beta.7",
     "react-test-renderer": "^16.0.0",
     "style-loader": "^0.18.2",

--- a/setupTests.js
+++ b/setupTests.js
@@ -1,3 +1,4 @@
+import 'raf/polyfill';
 import enzyme from 'enzyme';
 import enzymeAdapter from 'enzyme-adapter-react-16';
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -7436,6 +7436,12 @@ raf@^3.3.2:
   dependencies:
     performance-now "^2.1.0"
 
+raf@^3.4.0:
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/raf/-/raf-3.4.0.tgz#a28876881b4bc2ca9117d4138163ddb80f781575"
+  dependencies:
+    performance-now "^2.1.0"
+
 railroad-diagrams@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/railroad-diagrams/-/railroad-diagrams-1.0.0.tgz#eb7e6267548ddedfb899c1b90e57374559cddb7e"


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines;
https://github.com/netlify/netlify-cms/blob/master/CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first three fields are mandatory:
-->

**- Summary**

React 16 needs `requestAnimationFrame` in it's environment, and this does not exist in the test environment. This PR adds a polyfill to the test environment only,

**- Test plan**

Tests pass.

**- Description for the changelog**

Fix requestAnimationFrame warnings in tests.

**- A picture of a cute animal (not mandatory but encouraged)**
