### PR TITLE
fix ControlHOC ref for redux container widgets

### DIFF
--- a/src/components/Widgets/ControlHOC.js
+++ b/src/components/Widgets/ControlHOC.js
@@ -36,8 +36,17 @@ class ControlHOC extends Component {
     return this.props.value !== nextProps.value;
   }
 
-  processInnerControlRef = (wrappedControl) => {
-    if (!wrappedControl) return;
+  processInnerControlRef = ref => {
+    if (!ref) return;
+
+    /**
+     * If the widget is a container that receives state updates from the store,
+     * we'll need to get the ref of the actual control via the `react-redux`
+     * `getWrappedInstance` method. Note that connected widgets must pass
+     * `withRef: true` to `connect` in the options object.
+     */
+    const wrappedControl = ref.getWrappedInstance ? ref.getWrappedInstance() : ref;
+
     this.wrappedControlValid = wrappedControl.isValid || truthy;
 
     /**

--- a/src/components/Widgets/RelationControl.js
+++ b/src/components/Widgets/RelationControl.js
@@ -128,5 +128,9 @@ export default connect(
   {
     query,
     clearSearch,
+  },
+  null,
+  {
+    withRef: true,
   }
 )(RelationControl);


### PR DESCRIPTION
If a widget uses `connect` to receive state updates from the store, `ControlHOC` can no longer get the control instance ref. This fix checks for this case and uses a connect option to obtain the wrapped control ref.