### PR TITLE
update integrations check to account for null default state

### DIFF
--- a/src/backends/backend.js
+++ b/src/backends/backend.js
@@ -250,7 +250,7 @@ class Backend {
     /**
      * Determine whether an asset store integration is in use.
      */
-    const hasAssetStore = !!selectIntegration(integrations, null, 'assetStore');
+    const hasAssetStore = integrations && !!selectIntegration(integrations, null, 'assetStore');
     const updatedOptions = { ...options, hasAssetStore };
 
     return this.implementation.persistEntry(entryObj, MediaFiles, {


### PR DESCRIPTION
#804 checked the `integrations` state object with the assumption that a truthy default state (like `Map()`) was provided - this fix checks for existence first. Not switching default to `Map()` to ensure against unexpected breaks.