### PR TITLE
Make sure we strip trailing slashes for dir listing

### DIFF
--- a/src/backends/github/API.js
+++ b/src/backends/github/API.js
@@ -169,7 +169,7 @@ export default class API {
   }
 
   listFiles(path) {
-    return this.request(`${ this.repoURL }/contents/${ path }`, {
+    return this.request(`${ this.repoURL }/contents/${ path.replace(/\/$/, '') }`, {
       params: { ref: this.branch },
     })
     .then(files => {


### PR DESCRIPTION
In some cases we're calling the dir listing with a trailing slash, which causes extra redirects from GitHub's API (and breaks the git-gateway backend). This should make sure we always trip trailing slashes.