### PR TITLE
Add "empty" field to date and datetime widgets.

### DIFF
--- a/src/components/Widgets/DateControl.js
+++ b/src/components/Widgets/DateControl.js
@@ -4,7 +4,9 @@ import DateTime from 'react-datetime';
 
 export default class DateControl extends React.Component {
   componentDidMount() {
-    if (!this.props.value) {
+    const { field, value } = this.props;
+    
+    if (!value && !field.get('empty')) {
       this.props.onChange(new Date());
     }
   }
@@ -23,6 +25,7 @@ export default class DateControl extends React.Component {
 }
 
 DateControl.propTypes = {
+  field: PropTypes.object,
   onChange: PropTypes.func.isRequired,
   value: PropTypes.object, // eslint-disable-line
 };

--- a/src/components/Widgets/DateTimeControl.js
+++ b/src/components/Widgets/DateTimeControl.js
@@ -4,7 +4,9 @@ import DateTime from 'react-datetime';
 
 export default class DateTimeControl extends React.Component {
   componentDidMount() {
-    if (!this.props.value) {
+    const { field, value } = this.props;
+
+    if (!value && !field.get('empty')) {
       this.props.onChange(new Date());
     }
   }
@@ -19,6 +21,7 @@ export default class DateTimeControl extends React.Component {
 }
 
 DateTimeControl.propTypes = {
+  field: PropTypes.object,
   onChange: PropTypes.func.isRequired,
   value: PropTypes.oneOfType([
     PropTypes.object,


### PR DESCRIPTION
**- Summary**

This PR adds an "empty" field to the date and datetime widgets. E.g. a list widget called events has a start and an end date widget. If `empty: true` is added to the end date widget, the user can set the end date optionally.

```yaml
...
fields:
  - name: events
     label: Events
     widget: list
     fields:
       - {label: "Name", name: "name", widget: "string"}
       - {label: "Start date", name: "start_date", widget: "date"}
       - {label: "End date", name: "end_date", widget: "date", empty: true}
```
