### PR TITLE
Enable WebPack scope hoisting.

### DIFF
--- a/webpack.prod.js
+++ b/webpack.prod.js
@@ -27,6 +27,9 @@ module.exports = merge.smart(require('./webpack.base.js'), {
       NETLIFY_CMS_VERSION: JSON.stringify(require("./package.json").version),
     }),
 
+    // Combine/hoist module scopes when possibile.
+    new webpack.optimize.ModuleConcatenationPlugin(),
+
     // Minify and optimize the JavaScript
     new UglifyJsPlugin({
       sourceMap: true,


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines;
https://github.com/netlify/netlify-cms/blob/master/CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first three fields are mandatory:
-->

**- Summary**

WebPack 3 now has scope hoisting, which optimizes bundle speed at runtime. It also decreases bundle size, though the change is small. This is basically the main benefit that Rollup was designed with, except failsafe (more info here: https://medium.com/webpack/webpack-freelancing-log-book-week-5-7-4764be3266f5).

For now, this is only enabled for the production build, as it would break Hot Module Reloading.

**- Test plan**

CMS deploy preview seems to work fine for me (but that probably isn't much good as a test 😁).

**- Description for the changelog**

Enable WebPack scope hoisting.

**- A picture of a cute animal (not mandatory but encouraged)**
![cris-saur-122006](https://user-images.githubusercontent.com/20345941/33156616-b9be5f66-cfb8-11e7-8170-8035e4ab1aeb.jpg)
