### PR TITLE
Datetime format

### DIFF
--- a/docs/widgets.md
+++ b/docs/widgets.md
@@ -99,3 +99,14 @@ collections:
         searchFields: [name, twitterHandle]
         valueField: name
 ```
+
+### Date Widget / DateTime Widget
+
+The date and datetime widgets provide date or datetime pickers when the widget is active. The resulting date string can be formatted (uses Moment.js), and accepts a default value. The initial value will be the current date unless `false` or an empty string are provided as the default value.
+
+The following field configuration properties are specific to fields using the date or datetime widget:
+
+Property | Accepted Values | Description
+--- | --- | ---
+`format` | string | format string uses Moment.js [tokens](https://momentjs.com/docs/#/parsing/string-format/)
+`default` | boolean, string | can be a date string, or else an empty string - defaults to current date

--- a/src/components/Widgets/DateControl.js
+++ b/src/components/Widgets/DateControl.js
@@ -4,13 +4,28 @@ import DateTime from 'react-datetime';
 import moment from 'moment';
 
 function format(format, value) {
-  return moment(value).format(format || moment.defaultFormat);
+  if (format) {
+    return moment(value).format(format || moment.defaultFormat);
+  }
+  return value;
+}
+
+function toDate(format, value) {
+  if (format) {
+    return moment(value, format);
+  }
+  return value;
 }
 
 export default class DateTimeControl extends React.Component {
   componentDidMount() {
-    if (!this.props.value) {
-      this.props.onChange(format(this.props.field.get('format'), new Date()));
+    const {value, field, onChange} = this.props;
+    if (!value) {
+      if (field.get('format')) {
+        onChange(format(field.get('format'), new Date()));
+      } else {
+        onChange(new Date());
+      }
     }
   }
 
@@ -22,7 +37,7 @@ export default class DateTimeControl extends React.Component {
     return (
       <DateTime
         timeFormat={this.props.includeTime || false}
-        value={moment(this.props.value, this.props.field.get('format'))}
+        value={toDate(this.props.field.get('format'), this.props.value)}
         onChange={this.handleChange}
     />);
   }

--- a/src/components/Widgets/DateControl.js
+++ b/src/components/Widgets/DateControl.js
@@ -1,28 +1,41 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import DateTime from 'react-datetime';
+import moment from 'moment';
 
-export default class DateControl extends React.Component {
+function format(format, value) {
+  return moment(value).format(format || moment.defaultFormat);
+}
+
+export default class DateTimeControl extends React.Component {
   componentDidMount() {
     if (!this.props.value) {
-      this.props.onChange(new Date());
+      this.props.onChange(format(this.props.field.get('format'), new Date()));
     }
   }
 
   handleChange = (datetime) => {
-    this.props.onChange(datetime);
+    this.props.onChange(format(this.props.field.get('format'), datetime));
   };
 
   render() {
-    return (<DateTime
-      timeFormat={false}
-      value={this.props.value}
-      onChange={this.handleChange}
+    return (
+      <DateTime
+        timeFormat={this.props.includeTime || false}
+        value={moment(this.props.value, this.props.field.get('format'))}
+        onChange={this.handleChange}
     />);
   }
 }
 
-DateControl.propTypes = {
+DateTimeControl.propTypes = {
   onChange: PropTypes.func.isRequired,
-  value: PropTypes.object, // eslint-disable-line
+  value: PropTypes.oneOfType([
+    PropTypes.object,
+    PropTypes.string,
+  ]),
+  includeTime: PropTypes.bool,
+  field: PropTypes.object
 };
+
+

--- a/src/components/Widgets/DateControl.js
+++ b/src/components/Widgets/DateControl.js
@@ -28,7 +28,7 @@ export default class DateControl extends React.Component {
     const { field, includeTime, value } = this.props;
     const format = field.get('format', moment.defaultFormat);
     return (<DateTime
-      timeFormat={includeTime}
+      timeFormat={!!includeTime}
       value={moment(value, format)}
       onChange={this.handleChange}
     />);

--- a/src/components/Widgets/DateControl.js
+++ b/src/components/Widgets/DateControl.js
@@ -6,27 +6,22 @@ import moment from 'moment';
 export default class DateControl extends React.Component {
   componentDidMount() {
     const { value, field, onChange } = this.props;
+    this.format = field.get('format');
     if (!value) {
-      const format = field.get('format');
-      const newValue = format
-        ? moment(new Date()).format(format)
-        : new Date();
-      onChange(newValue);
+      this.handleChange(new Date());
     }
   }
 
-  handleChange = (datetime) => {
-    const { onChange, field } = this.props;
-    const format = field.get('format');
-    const newValue = format
-      ? moment(datetime).format(format)
+  handleChange = datetime => {
+    const newValue = this.format
+      ? moment(datetime).format(this.format)
       : datetime;
     onChange(newValue);
   };
 
   render() {
-    const { field, includeTime, value } = this.props;
-    const format = field.get('format', moment.defaultFormat);
+    const { includeTime, value } = this.props;
+    const format = this.format || moment.defaultFormat;
     return (<DateTime
       timeFormat={!!includeTime}
       value={moment(value, format)}

--- a/src/components/Widgets/DateControl.js
+++ b/src/components/Widgets/DateControl.js
@@ -3,54 +3,44 @@ import React from 'react';
 import DateTime from 'react-datetime';
 import moment from 'moment';
 
-function format(format, value) {
-  if (format) {
-    return moment(value).format(format || moment.defaultFormat);
-  }
-  return value;
-}
-
-function toDate(format, value) {
-  if (format) {
-    return moment(value, format);
-  }
-  return value;
-}
-
-export default class DateTimeControl extends React.Component {
+export default class DateControl extends React.Component {
   componentDidMount() {
-    const {value, field, onChange} = this.props;
+    const { value, field, onChange } = this.props;
     if (!value) {
-      if (field.get('format')) {
-        onChange(format(field.get('format'), new Date()));
-      } else {
-        onChange(new Date());
-      }
+      const format = field.get('format');
+      const newValue = format
+        ? moment(new Date()).format(format)
+        : new Date();
+      onChange(newValue);
     }
   }
 
   handleChange = (datetime) => {
-    this.props.onChange(format(this.props.field.get('format'), datetime));
+    const { onChange, field } = this.props;
+    const format = field.get('format');
+    const newValue = format
+      ? moment(datetime).format(format)
+      : datetime;
+    onChange(newValue);
   };
 
   render() {
-    return (
-      <DateTime
-        timeFormat={this.props.includeTime || false}
-        value={toDate(this.props.field.get('format'), this.props.value)}
-        onChange={this.handleChange}
+    const { field, includeTime, value } = this.props;
+    const format = field.get('format', moment.defaultFormat);
+    return (<DateTime
+      timeFormat={includeTime}
+      value={moment(value, format)}
+      onChange={this.handleChange}
     />);
   }
 }
 
-DateTimeControl.propTypes = {
+DateControl.propTypes = {
   onChange: PropTypes.func.isRequired,
   value: PropTypes.oneOfType([
     PropTypes.object,
     PropTypes.string,
   ]),
   includeTime: PropTypes.bool,
-  field: PropTypes.object
+  field: PropTypes.object,
 };
-
-

--- a/src/components/Widgets/DateControl.js
+++ b/src/components/Widgets/DateControl.js
@@ -7,7 +7,12 @@ export default class DateControl extends React.Component {
   componentDidMount() {
     const { value, field, onChange } = this.props;
     this.format = field.get('format');
-    if (!value) {
+
+    /**
+     * Set the current date as default value if no default value is provided. An
+     * empty string means the value is intentionally blank.
+     */
+    if (!value && value !== '') {
       this.handleChange(new Date());
     }
   }
@@ -16,7 +21,7 @@ export default class DateControl extends React.Component {
     const newValue = this.format
       ? moment(datetime).format(this.format)
       : datetime;
-    onChange(newValue);
+    this.props.onChange(newValue);
   };
 
   render() {

--- a/src/components/Widgets/DateTimeControl.js
+++ b/src/components/Widgets/DateTimeControl.js
@@ -1,27 +1,9 @@
-import PropTypes from 'prop-types';
 import React from 'react';
-import DateTime from 'react-datetime';
+import DateControl from './DateControl';
 
 export default class DateTimeControl extends React.Component {
-  componentDidMount() {
-    if (!this.props.value) {
-      this.props.onChange(new Date());
-    }
-  }
-
-  handleChange = (datetime) => {
-    this.props.onChange(datetime);
-  };
-
   render() {
-    return <DateTime value={this.props.value} onChange={this.handleChange} />;
+    const {onChange, format, value, field} = this.props;
+    return <DateControl onChange={onChange} format={format} value={value} field={field} includeTime={true}/>;
   }
-}
-
-DateTimeControl.propTypes = {
-  onChange: PropTypes.func.isRequired,
-  value: PropTypes.oneOfType([
-    PropTypes.object,
-    PropTypes.string,
-  ]),
 };

--- a/src/components/Widgets/DateTimeControl.js
+++ b/src/components/Widgets/DateTimeControl.js
@@ -3,7 +3,7 @@ import DateControl from './DateControl';
 
 export default class DateTimeControl extends React.Component {
   render() {
-    const {onChange, format, value, field} = this.props;
-    return <DateControl onChange={onChange} format={format} value={value} field={field} includeTime={true}/>;
+    const { field, format, onChange, value } = this.props;
+    return <DateControl onChange={onChange} format={format} value={value} field={field} includeTime />;
   }
-};
+}


### PR DESCRIPTION
An earlier change broke the `format` attribute for date and datetime widgets (see #529).

Before this was handled by always treating the value as a `moment` object and having the YAML serializer respect that.

This takes a slightly different approach and always treats the value of date and datetime widgets as a formatted string. If we take this approach we should get rid of the moment specific code for formats in the YAML serializer.

The downside of this is that some future supported formats might handle actual date/datetime objects - but it seems this is the only approach I can think of where the `format` attribute would be respected across any output format apart from that...