### PR TITLE
Fixes #846 Backspace removes empty blocks

### DIFF
--- a/src/components/Widgets/Markdown/MarkdownControl/VisualEditor/plugins.js
+++ b/src/components/Widgets/Markdown/MarkdownControl/VisualEditor/plugins.js
@@ -54,8 +54,8 @@ const BreakToDefaultBlockOpts = {
 export const BreakToDefaultBlockConfigured = BreakToDefaultBlock(BreakToDefaultBlockOpts);
 
 const BackspaceCloseBlock = (options = {}) => ({
-  onKeyDown(data, change) {
-    if (data.key !== 'Backspace') return;
+  onKeyDown(event, change) {
+    if (event.key !== 'Backspace') return;
 
     const { defaultBlock = 'paragraph', ignoreIn, onlyIn } = options;
     const { startBlock } = change.value;

--- a/src/components/Widgets/Markdown/MarkdownControl/VisualEditor/plugins.js
+++ b/src/components/Widgets/Markdown/MarkdownControl/VisualEditor/plugins.js
@@ -54,8 +54,8 @@ const BreakToDefaultBlockOpts = {
 export const BreakToDefaultBlockConfigured = BreakToDefaultBlock(BreakToDefaultBlockOpts);
 
 const BackspaceCloseBlock = (options = {}) => ({
-  onKeyDown(e, data, change) {
-    if (data.key != 'backspace') return;
+  onKeyDown(data, change) {
+    if (data.key !== 'Backspace') return;
 
     const { defaultBlock = 'paragraph', ignoreIn, onlyIn } = options;
     const { startBlock } = change.value;


### PR DESCRIPTION
**- Summary**
Fixes #846 Backspace removes empty blocks

**- Description for the changelog**

- `onKeyDown` takes 2 arguments, not 3.
- And `backspace` starts with an uppercase.
- Consequently others functions `SoftBreak`, `BreakToDefaultBlock` should have the issue.