### PR TITLE
Fixes #855 Update Slate plugins to drop data arg

### DIFF
--- a/package.json
+++ b/package.json
@@ -129,6 +129,7 @@
     "gray-matter": "^3.0.6",
     "history": "^4.7.2",
     "immutable": "^3.7.6",
+    "is-hotkey": "^0.1.1",
     "js-base64": "^2.1.9",
     "js-yaml": "^3.10.0",
     "jwt-decode": "^2.1.0",

--- a/src/components/EditorWidgets/Markdown/MarkdownControl/VisualEditor/keys.js
+++ b/src/components/EditorWidgets/Markdown/MarkdownControl/VisualEditor/keys.js
@@ -3,37 +3,6 @@ import { isHotkey } from 'is-hotkey';
 
 export default onKeyDown;
 
-/**
- * Minimal re-implementation of Slate's undo/redo functionality, but with focus
- * forced back into editor afterward.
- */
-function changeHistory(change, type) {
-
-  /**
-   * Get the history for undo or redo (determined via `type` param).
-   */
-  const { history } = change.value;
-  if (!history) return;
-  const historyOfType = history[`${type}s`];
-
-  /**
-   * If there is a next history item to apply, and it's valid, apply it.
-   */
-  const next = historyOfType.first();
-  const historyOfTypeIsValid = historyOfType.size > 1
-    || (next && next.length > 1)
-    || (next && next[0] && next[0].type !== 'set_selection';
-
-  if (next && historyOfTypeIsValid) {
-    change[type]();
-  }
-
-  /**
-   * Always ensure focus is set.
-   */
-  return change.focus();
-}
-
 function onKeyDown(event, change) {
   const createDefaultBlock = () => {
     return Block.create({
@@ -70,26 +39,9 @@ function onKeyDown(event, change) {
   }
 
   if (isHotkey(`mod+${event.key}`, event)) {
-
-    /**
-     * Undo and redo work automatically with Slate, but focus is lost in certain
-     * actions. We override Slate's built in undo/redo here and force focus
-     * back to the editor each time.
-     */
-    if (event.key === 'y') {
-      event.preventDefault();
-      return changeHistory(change, 'redo');
-    }
-
-    if (event.key === 'z') {
-      event.preventDefault();
-      return changeHistory(change, event.isShift ? 'redo' : 'undo');
-    }
-
     const marks = {
       b: 'bold',
       i: 'italic',
-      u: 'underline',
       s: 'strikethrough',
       '`': 'code',
     };

--- a/src/components/EditorWidgets/Markdown/MarkdownControl/VisualEditor/keys.js
+++ b/src/components/EditorWidgets/Markdown/MarkdownControl/VisualEditor/keys.js
@@ -11,7 +11,7 @@ function onKeyDown(event, change) {
     });
   };
 
-  if (event.key === 'Enter') {
+  if (isHotkey('Enter', event)) {
     /**
      * If "Enter" is pressed while a single void block is selected, a new
      * paragraph should be added above or below it, and the current selection

--- a/src/components/EditorWidgets/Markdown/MarkdownControl/VisualEditor/keys.js
+++ b/src/components/EditorWidgets/Markdown/MarkdownControl/VisualEditor/keys.js
@@ -22,9 +22,9 @@ function changeHistory(change, type) {
   const next = historyOfType.first();
   const historyOfTypeIsValid = historyOfType.size > 1
     || (next && next.length > 1)
-    || (next && next[0] && next[0].type !== 'set_selection');
+    || (next && next[0] && next[0].type !== 'set_selection';
 
-  if (historyOfTypeIsValid) {
+  if (next && historyOfTypeIsValid) {
     change[type]();
   }
 

--- a/src/components/EditorWidgets/Markdown/MarkdownControl/VisualEditor/keys.js
+++ b/src/components/EditorWidgets/Markdown/MarkdownControl/VisualEditor/keys.js
@@ -1,5 +1,5 @@
 import { Block, Text } from 'slate';
-import { isHotkey } from 'is-hotkey';
+import isHotkey from 'is-hotkey';
 
 export default onKeyDown;
 
@@ -38,19 +38,17 @@ function onKeyDown(event, change) {
       .collapseToStartOf(newBlock);
   }
 
-  if (isHotkey(`mod+${event.key}`, event)) {
-    const marks = {
-      b: 'bold',
-      i: 'italic',
-      s: 'strikethrough',
-      '`': 'code',
-    };
+  const marks = [
+    [ 'b', 'bold' ],
+    [ 'i', 'italic' ],
+    [ 's', 'strikethrough' ],
+    [ '`', 'code' ],
+  ];
 
-    const mark = marks[event.key];
+  const [ markKey, markName ] = marks.find(([ key ]) => isHotkey(`mod+${key}`, event)) || [];
 
-    if (mark) {
-      event.preventDefault();
-      return change.toggleMark(mark);
-    }
+  if (markName) {
+    event.preventDefault();
+    return change.toggleMark(markName);
   }
 };

--- a/src/components/EditorWidgets/Markdown/MarkdownControl/VisualEditor/keys.js
+++ b/src/components/EditorWidgets/Markdown/MarkdownControl/VisualEditor/keys.js
@@ -21,7 +21,8 @@ function changeHistory(change, type) {
    */
   const next = historyOfType.first();
   const historyOfTypeIsValid = historyOfType.size > 1
-    || ( next && next.length > 1 && next[0].type !== 'set_selection' );
+    || (next && next.length > 1)
+    || (next && next[0] && next[0].type !== 'set_selection');
 
   if (historyOfTypeIsValid) {
     change[type]();

--- a/src/components/EditorWidgets/Markdown/MarkdownControl/VisualEditor/plugins.js
+++ b/src/components/EditorWidgets/Markdown/MarkdownControl/VisualEditor/plugins.js
@@ -4,9 +4,9 @@ import EditList from 'slate-edit-list';
 import EditTable from 'slate-edit-table';
 
 const SoftBreak = (options = {}) => ({
-  onKeyDown(e, data, change) {
-    if (data.key != 'enter') return;
-    if (options.shift && e.shiftKey == false) return;
+  onKeyDown(event, change) {
+    if (event.key != 'Enter') return;
+    if (options.shift && event.shiftKey == false) return;
 
     const { onlyIn, ignoreIn, defaultBlock = 'paragraph' } = options;
     const { type, text } = change.value.startBlock;
@@ -38,9 +38,9 @@ export const SoftBreakConfigured = SoftBreak(SoftBreakOpts);
 export const ParagraphSoftBreakConfigured = SoftBreak({ onlyIn: ['paragraph'], shift: true });
 
 const BreakToDefaultBlock = ({ onlyIn = [], defaultBlock = 'paragraph' }) => ({
-  onKeyDown(e, data, change) {
+  onKeyDown(event, change) {
     const { value } = change;
-    if (data.key != 'enter' || e.shiftKey == true || value.isExpanded) return;
+    if (event.key != 'Enter' || event.shiftKey == true || value.isExpanded) return;
     if (onlyIn.includes(value.startBlock.type)) {
       return change.insertBlock(defaultBlock);
     }

--- a/src/components/EditorWidgets/Markdown/MarkdownControl/VisualEditor/plugins.js
+++ b/src/components/EditorWidgets/Markdown/MarkdownControl/VisualEditor/plugins.js
@@ -1,12 +1,13 @@
 import { Text, Inline } from 'slate';
+import isHotkey from 'is-hotkey';
 import SlateSoftBreak from 'slate-soft-break';
 import EditList from 'slate-edit-list';
 import EditTable from 'slate-edit-table';
 
 const SoftBreak = (options = {}) => ({
   onKeyDown(event, change) {
-    if (event.key != 'Enter') return;
-    if (options.shift && event.shiftKey == false) return;
+    if (options.shift && !isHotkey('shift+enter', event)) return;
+    if (!options.shift && !isHotkey('enter', event)) return;
 
     const { onlyIn, ignoreIn, defaultBlock = 'paragraph' } = options;
     const { type, text } = change.value.startBlock;
@@ -40,7 +41,7 @@ export const ParagraphSoftBreakConfigured = SoftBreak({ onlyIn: ['paragraph'], s
 const BreakToDefaultBlock = ({ onlyIn = [], defaultBlock = 'paragraph' }) => ({
   onKeyDown(event, change) {
     const { value } = change;
-    if (event.key != 'Enter' || event.shiftKey == true || value.isExpanded) return;
+    if (!isHotkey('enter', event) || value.isExpanded) return;
     if (onlyIn.includes(value.startBlock.type)) {
       return change.insertBlock(defaultBlock);
     }


### PR DESCRIPTION
**- Summary**

Fixes #855 Update Slate plugins to drop data arg

**- Test plan**
- Check SoftBreak and BreakToDefaultBlock are okay.
- Check you can use `cmd + z` and `cmd + y` to undo and redo.
- Check you can toggle marks with `cmd + ( b, i, s, u )`.

**- Description for the changelog**
- Remove data arg due to breaking changes introduced in [0.6.0](https://github.com/ianstormtaylor/slate/blob/master/packages/slate-react/Changelog.md#060--october-16-2017).
- Use [is-hotkey](https://github.com/ianstormtaylor/is-hotkey).
- Fix underline typo for togglemark `cmd + u` ( but doesn't work either it throws an error ).
- Check next is defined before changeHistory to avoid error length of undefined.