### PR TITLE
Fix position of editor view controls

### DIFF
--- a/src/components/Editor/EditorInterface.css
+++ b/src/components/Editor/EditorInterface.css
@@ -69,7 +69,7 @@
 .nc-entryEditor-viewControls {
   position: absolute;
   top: 10px;
-  right: -10px;
+  right: 10px;
   z-index: 299;
 }
 


### PR DESCRIPTION
Before:

<img width="215" alt="screen shot 2017-12-07 at 8 15 27 am" src="https://user-images.githubusercontent.com/6515/33725392-dac9224e-db26-11e7-94cc-ab520f255eb4.png">

After:

<img width="217" alt="screen shot 2017-12-07 at 8 15 39 am" src="https://user-images.githubusercontent.com/6515/33725399-df099df2-db26-11e7-97f2-fb66b10922d7.png">
