### PR TITLE
Fix position of editor view controls

### DIFF
--- a/src/components/Editor/EditorInterface.css
+++ b/src/components/Editor/EditorInterface.css
@@ -69,7 +69,7 @@
 .nc-entryEditor-viewControls {
   position: absolute;
   top: 10px;
-  right: -10px;
+  right: 10px;
   z-index: 299;
 }
 


### PR DESCRIPTION
These were so far off to the right tht they got cut off by the screen.
This aligns them with the user icon

<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines;
https://github.com/netlify/netlify-cms/blob/master/CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first three fields are mandatory:
-->

**- Summary**

<!--
Explain the **motivation** for making this change.
What existing problem does the pull request solve?
-->

**- Test plan**

<!--
Demonstrate the code is solid.
Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.
-->

**- Description for the changelog**

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

**- A picture of a cute animal (not mandatory but encouraged)**
