### PR TITLE
Minor docs fixes

### DIFF
--- a/website/config/variables.js
+++ b/website/config/variables.js
@@ -35,7 +35,7 @@ module.exports = {
   medium: '40px',
   large: '64px',
   xl: '104px',
-  xxl: '168px',
+  xxl: '152px',
 
   // border radius
   borderRadius: '4px',

--- a/website/site/content/docs/add-to-your-site.md
+++ b/website/site/content/docs/add-to-your-site.md
@@ -72,7 +72,7 @@ backend:
 These lines specify your backend protocol and your publication branch. Git Gateway is an open source API that acts as a proxy between authenticated users of your site and your site repo. (We'll get to the details of that in the [Authentication section](#authentication) below.) If you leave out the `branch` declaration, it will default to `master`.
 
 ### Editorial Workflow
-By default, saving a post in the CMS interface will push a commit directly to the publication branch specified in `backend`. However, you also have the option to enable the [Editorial Workflow](/docs/editorial-workflow), which adds an interface for drafting, reviewing, and approving posts. To do this, add the following line to your `config.yml`:
+By default, saving a post in the CMS interface will push a commit directly to the publication branch specified in `backend`. However, you also have the option to enable the [Editorial Workflow](https://www.netlifycms.org/docs/configuration-options/#publish-mode), which adds an interface for drafting, reviewing, and approving posts. To do this, add the following line to your `config.yml`:
 
 ``` yaml
 publish_mode: editorial_workflow
@@ -170,7 +170,7 @@ Let's break that down:
   </tr>
 </table>
 
-As described above, the `widget` property specifies a built-in or custom UI widget for a given field. When a content editor enters a value into a widget, that value will be saved in the document front matter as the value for the `name` specified for that field. A full listing of available widgets can be found in the [Widgets doc](/docs/widgets).
+As described above, the `widget` property specifies a built-in or custom UI widget for a given field. When a content editor enters a value into a widget, that value will be saved in the document front matter as the value for the `name` specified for that field. A full listing of available widgets can be found in the [Widgets doc](https://www.netlifycms.org/docs/widgets).
 
 Based on this example, you can go through the post types in your site and add the appropriate settings to your `config.yml` file. Each post type should be listed as a separate node under the `collections` field.
 
@@ -192,7 +192,7 @@ collections:
 
 ## Authentication
 
-Now that you have your Netlify CMS files in place and configured, all that's left is to enable authentication. There are [many ways to do this](/docs/custom-authentication) (with or without deploying to Netlify), but this example uses Netlify because it's one of the quickest ways to get started.
+Now that you have your Netlify CMS files in place and configured, all that's left is to enable authentication. There are [many ways to do this](https://www.netlifycms.org/docs/authentication-backends) (with or without deploying to Netlify), but this example uses Netlify because it's one of the quickest ways to get started.
 
 ### Setup on Netlify
 Netlify offers a built-in authentication service called Identity. In order to use it, you'll need to connect your site repo with Netlify. Netlify has published a general [Step-by-Step Guide](https://www.netlify.com/blog/2016/10/27/a-step-by-step-guide-deploying-a-static-site-or-single-page-app/) for this, along with detailed guides for many popular static site generators, including [Jekyll](https://www.netlify.com/blog/2015/10/28/a-step-by-step-guide-jekyll-3.0-on-netlify/), [Hugo](https://www.netlify.com/blog/2016/09/21/a-step-by-step-guide-victor-hugo-on-netlify/), [Hexo](https://www.netlify.com/blog/2015/10/26/a-step-by-step-guide-hexo-on-netlify/), [Middleman](https://www.netlify.com/blog/2015/10/01/a-step-by-step-guide-middleman-on-netlify/), [Gatsby](https://www.netlify.com/blog/2016/02/24/a-step-by-step-guide-gatsby-on-netlify/) and more.

--- a/website/site/content/docs/authentication-backends.md
+++ b/website/site/content/docs/authentication-backends.md
@@ -9,7 +9,7 @@ Netlify CMS stores content in your GitHub repository. (GitLab and Bitbucket comi
 
 ## Git Gateway with Netlify Identity
 
-[Git Gateway](https://github.com/netlify/git-gateway) is a Netlify open source project that allows you to add editors to your site CMS without giving them direct push access to your GitHub repository. [Netlify Identity](https://www.netlify.com/docs/identity/) service handles the authentication and provides a simple interface for user management. The Netlify CMS [Test Drive](/test-drive/) is a working example of this backend.
+[Git Gateway](https://github.com/netlify/git-gateway) is a Netlify open source project that allows you to add editors to your site CMS without giving them direct push access to your GitHub repository. [Netlify Identity](https://www.netlify.com/docs/identity/) service handles the authentication and provides a simple interface for user management. The Netlify CMS [featured templates](https://www.netlifycms.org/docs/start-with-a-template) are working examples of this backend.
 
 To use it in your own project, follow these steps:
 

--- a/website/site/content/docs/configuration-options.md
+++ b/website/site/content/docs/configuration-options.md
@@ -7,7 +7,7 @@ position: 23
 
 All configuration options for Netlify CMS are specified in the `config.yml` file, in the folder where you access the editor UI (usually in the `/admin` folder).
 
-To see working configuration examples, you can [start from a template](https://www.netlifycms.org/test-drive) or check out the [CMS demo site](https://cms-demo.netlify.com). (No login required: click the login button and the CMS will open.) You can refer to the demo [configuration code](https://github.com/netlify/netlify-cms/blob/master/example/config.yml) to see how each option was configured.
+To see working configuration examples, you can [start from a template](https://www.netlifycms.org/docs/start-with-a-template) or check out the [CMS demo site](https://cms-demo.netlify.com). (No login required: click the login button and the CMS will open.) You can refer to the demo [configuration code](https://github.com/netlify/netlify-cms/blob/master/example/config.yml) to see how each option was configured.
 
 You can find details about all configuration options below. Note that [YAML syntax](https://en.wikipedia.org/wiki/YAML#Basic_components) allows lists and objects to be written in block or inline style, and the code samples below include a mix of both.
 

--- a/website/site/content/docs/start-with-a-template.md
+++ b/website/site/content/docs/start-with-a-template.md
@@ -21,15 +21,15 @@ Netlify CMS can be [added to an existing site](https://www.netlifycms.org/docs/a
 After clicking one of those buttons, you’ll authenticate with GitHub and choose a repository name. Netlify will then automatically create a repository in your GitHub account with a copy of the files from the template. Next, it will build and deploy the new site on Netlify, bringing you to the site dashboard when the build is complete.
 
 
-## Accessing Netlify CMS on your new site
+## Access Netlify CMS on your new site
 
 1. The template deploy process will send you an invitation to your new site, sent from `no-reply@netlify.com`.
 
-    ![Sample email subject line: You've been invited to join radiologist-amanda-53841.netlify.com](/img/email-subject.png?raw=true)
+    ![Sample email subject line: You've been invited to join radiologist-amanda-53841.netlify.com](https://www.netlifycms.org/img/email-subject.png?raw=true)
 
 2. Click the link to accept the invite, and you’ll be directed to your site, with a prompt to create a password.
 
-    !["Complete your signup" modal on the Kaldi coffee site](/img/create-password.png?raw=true)
+    !["Complete your signup" modal on the Kaldi coffee site](https://www.netlifycms.org/img/create-password.png?raw=true)
 
 3. Enter a password, sign in, and you’ll be directed straight to the CMS. (For future visits, you can go straight to `<yoursiteaddress.com>/admin`.)
 

--- a/website/src/css/imports/base.css
+++ b/website/src/css/imports/base.css
@@ -58,7 +58,7 @@ h3 > p {
 p, ul {
   font-size: $tiny;
   line-height: 26px;
-  margin: 0;
+  margin-top: 0;
 }
 
 a {


### PR DESCRIPTION
- Updates a few links so they point to the correct doc titles
- Changes inline page links to absolute so links aren't broken in the GitHub repo view
- Re-add the default 16px bottom-margin to paragraphs (with adjustment to offset minor effects on landing page)