### PR TITLE
Use cached images for new uploads

### DIFF
--- a/src/valueObjects/AssetProxy.js
+++ b/src/valueObjects/AssetProxy.js
@@ -20,6 +20,7 @@ export default function AssetProxy(value, fileObj, uploaded = false, asset) {
 }
 
 AssetProxy.prototype.toString = function () {
+  // Use the deployed image path if we do not have a locally cached copy.
   if (this.uploaded && !this.fileObj) return this.public_path;
   try {
     return window.URL.createObjectURL(this.fileObj);

--- a/src/valueObjects/AssetProxy.js
+++ b/src/valueObjects/AssetProxy.js
@@ -20,7 +20,7 @@ export default function AssetProxy(value, fileObj, uploaded = false, asset) {
 }
 
 AssetProxy.prototype.toString = function () {
-  if (this.uploaded) return this.public_path;
+  if (this.uploaded && !this.fileObj) return this.public_path;
   try {
     return window.URL.createObjectURL(this.fileObj);
   } catch (error) {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines;
https://github.com/netlify/netlify-cms/blob/master/CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first three fields are mandatory:
-->

**- Summary**

Before we had the media library, we used uploaded image data directly when it was first uploaded, since it was likely not deployed yet. With the media library, we should be able to do this as well.

@erquhart Is this the correct fix, or do we need more in-depth changes?


<!--
Explain the **motivation** for making this change.
What existing problem does the pull request solve?
-->

**- Test plan**

<!--
Demonstrate the code is solid.
Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.
-->

**- Description for the changelog**

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

**- A picture of a cute animal (not mandatory but encouraged)**
