### PR TITLE
#895 Adding an image to an empty rich text editor doesn't trigger the Image widget

### DIFF
--- a/src/components/MarkdownPlugins/image.js
+++ b/src/components/MarkdownPlugins/image.js
@@ -7,9 +7,9 @@ const image = {
     image: match[2],
     alt: match[1],
   },
-  toBlock: data => `![${ data.alt || '' }](${ data.image || '' })`,
+  toBlock: data => `![${ data.alt }](${ data.image || '' })`,
   toPreview: (data, getAsset) => <img src={getAsset(data.image || '')} alt={data.alt || ''} />,
-  pattern: /^!\[([^\]]+)]\(([^)]+)\)$/,
+  pattern: /^!\[([\S]*)]\(([\S]*)\)/,
   fields: [{
     label: 'Image',
     name: 'image',

--- a/src/components/MarkdownPlugins/image.js
+++ b/src/components/MarkdownPlugins/image.js
@@ -9,7 +9,7 @@ const image = {
   },
   toBlock: data => `![${ data.alt }](${ data.image || '' })`,
   toPreview: (data, getAsset) => <img src={getAsset(data.image || '')} alt={data.alt || ''} />,
-  pattern: /^!\[([\S]*)]\(([\S]*)\)/,
+  pattern: /^!\[([\S]*)\]\(([\S]*)\)$/,
   fields: [{
     label: 'Image',
     name: 'image',

--- a/src/components/MarkdownPlugins/image.js
+++ b/src/components/MarkdownPlugins/image.js
@@ -7,9 +7,9 @@ const image = {
     image: match[2],
     alt: match[1],
   },
-  toBlock: data => `![${ data.alt }](${ data.image || '' })`,
-  toPreview: (data, getAsset) => <img src={getAsset(data.image || '')} alt={data.alt || ''} />,
-  pattern: /^!\[([\S\s]*)\]\(([\S\s]*)\)$/,
+  toBlock: data => `![${ data.alt || '' }](${ data.image || '' })`,
+  toPreview: (data, getAsset) => <img src={getAsset(data.image) || ''} alt={data.alt || ''} />,
+  pattern: /^!\[(.*)\]\((.*)\)$/,
   fields: [{
     label: 'Image',
     name: 'image',

--- a/src/components/MarkdownPlugins/image.js
+++ b/src/components/MarkdownPlugins/image.js
@@ -9,7 +9,7 @@ const image = {
   },
   toBlock: data => `![${ data.alt }](${ data.image || '' })`,
   toPreview: (data, getAsset) => <img src={getAsset(data.image || '')} alt={data.alt || ''} />,
-  pattern: /^!\[([\S]*)\]\(([\S]*)\)$/,
+  pattern: /^!\[([\S\s]*)\]\(([\S\s]*)\)$/,
   fields: [{
     label: 'Image',
     name: 'image',


### PR DESCRIPTION
Fixes #895 : Adding an image to an empty rich text editor doesn't trigger the Image widget.

**- Summary**

- Improve RegExp
- Do not fallback undefined alt to an empty string.
  Input will be filled with `undefined` label ( the youtube widget has this behavior ).

**- Test plan**

Add an image to an empty rich text editor

**- Description for the changelog**

- Improve RegExp
- Do not fallback undefined alt to an empty string
  Input will be filled with `undefined` label ( the youtube widget has this behavior ).