### PR TITLE
Set default time to 12am.

### DIFF
--- a/src/components/EditorWidgets/Date/DateControl.js
+++ b/src/components/EditorWidgets/Date/DateControl.js
@@ -26,7 +26,7 @@ export default class DateControl extends React.Component {
      * empty string means the value is intentionally blank.
      */
     if (!value && value !== '') {
-      this.handleChange(new Date());
+      this.handleChange(moment().startOf('day').toDate());
     }
   }
 

--- a/src/components/EditorWidgets/Date/DateControl.js
+++ b/src/components/EditorWidgets/Date/DateControl.js
@@ -15,6 +15,7 @@ export default class DateControl extends React.Component {
       PropTypes.string,
     ]),
     includeTime: PropTypes.bool,
+    defaultTime: PropTypes.string,
   };
 
   componentDidMount() {
@@ -23,13 +24,16 @@ export default class DateControl extends React.Component {
 
     /**
      * Set the current date as default value if no default value is provided. An
-     * empty string means the value is intentionally blank.
+     * empty string means the value is intentionally blank. 
+     * Default time can be now or 0:00 am.
      */
     if (!value && value !== '') {
-      this.handleChange(moment().startOf('day').toDate());
+      const { defaultTime } = this.props;
+      const now = defaultTime === 'now' ? moment().toDate() : moment().startOf('day').toDate();
+      this.handleChange(now);
     }
   }
-
+  
   handleChange = datetime => {
     const { onChange } = this.props;
     if (!this.format || datetime === '') {

--- a/src/components/EditorWidgets/Date/DateControl.js
+++ b/src/components/EditorWidgets/Date/DateControl.js
@@ -15,7 +15,7 @@ export default class DateControl extends React.Component {
       PropTypes.string,
     ]),
     includeTime: PropTypes.bool,
-    defaultTime: PropTypes.string,
+    defaultTime: PropTypes.object,
   };
 
   componentDidMount() {
@@ -28,10 +28,10 @@ export default class DateControl extends React.Component {
      * Default time can be now or 0:00 am.
      */
     if (!value && value !== '') {
-      const { defaultTime } = this.props;
-      const now = defaultTime === 'now' ? moment().toDate() : moment().startOf('day').toDate();
-      this.handleChange(now);
+      const { defaultTime = moment().startOf('day').toDate() } = this.props;
+      this.handleChange(defaultTime);
     }
+    
   }
   
   handleChange = datetime => {

--- a/src/components/EditorWidgets/DateTime/DateTimeControl.js
+++ b/src/components/EditorWidgets/DateTime/DateTimeControl.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import DateControl from 'EditorWidgets/Date/DateControl';
+import moment from 'moment';
 
 export default class DateTimeControl extends React.Component {
   static propTypes = {
@@ -37,7 +38,7 @@ export default class DateTimeControl extends React.Component {
         setActiveStyle={setActiveStyle}
         setInactiveStyle={setInactiveStyle}
         includeTime
-        defaultTime={'now'}
+        defaultTime={moment().toDate()}
       />
     );
   }

--- a/src/components/EditorWidgets/DateTime/DateTimeControl.js
+++ b/src/components/EditorWidgets/DateTime/DateTimeControl.js
@@ -37,6 +37,7 @@ export default class DateTimeControl extends React.Component {
         setActiveStyle={setActiveStyle}
         setInactiveStyle={setInactiveStyle}
         includeTime
+        defaultTime={'now'}
       />
     );
   }


### PR DESCRIPTION
**- Set default time of date widget to 12am**

I would expect the time of a date value to be at 00:00 and not the time of editing. Hence the default value is set to 12am of the current day.