### PR TITLE
GitHub svg media library preview support

### DIFF
--- a/src/backends/github/implementation.js
+++ b/src/backends/github/implementation.js
@@ -96,7 +96,7 @@ export default class GitHub {
       .then(files => files.map(({ sha, name, size, download_url, path }) => {
         const url = new URL(download_url);
         if (url.pathname.match(/.svg$/)) {
-          url.searchParams.append('sanitize', true);
+          url.search += (url.search.slice(1) === '' ? '?' : '&') + 'sanitize=true';
         }
         return { id: sha, name, size, url: url.href, path };
       }));

--- a/src/backends/github/implementation.js
+++ b/src/backends/github/implementation.js
@@ -94,7 +94,11 @@ export default class GitHub {
     return this.api.listFiles(this.config.get('media_folder'))
       .then(files => files.filter(file => file.type === 'file'))
       .then(files => files.map(({ sha, name, size, download_url, path }) => {
-        return { id: sha, name, size, url: download_url, path };
+        const url = new URL(download_url);
+        if (url.pathname.match(/.svg$/)) {
+          url.searchParams.append('sanitize', true);
+        }
+        return { id: sha, name, size, url: url.href, path };
       }));
   }
 

--- a/src/components/MediaLibrary/MediaLibrary.js
+++ b/src/components/MediaLibrary/MediaLibrary.js
@@ -21,8 +21,8 @@ import { Icon } from 'UI';
  * Extensions used to determine which files to show when the media library is
  * accessed from an image insertion field.
  */
-const IMAGE_EXTENSIONS_VIEWABLE = [ 'jpg', 'jpeg', 'webp', 'gif', 'png', 'bmp', 'tiff' ];
-const IMAGE_EXTENSIONS = [ ...IMAGE_EXTENSIONS_VIEWABLE, 'svg' ];
+const IMAGE_EXTENSIONS_VIEWABLE = [ 'jpg', 'jpeg', 'webp', 'gif', 'png', 'bmp', 'tiff', 'svg' ];
+const IMAGE_EXTENSIONS = [ ...IMAGE_EXTENSIONS_VIEWABLE ];
 
 class MediaLibrary extends React.Component {
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines;
https://github.com/netlify/netlify-cms/blob/master/CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first three fields are mandatory:
-->

**- Summary**

<!--
Explain the **motivation** for making this change.
What existing problem does the pull request solve?
-->

In the media library, SVG media loaded from https://raw.githubusercontent.com was unable to be displayed due to github's response content-type set to *text/plain* rather than *image/svg+xml*.

Appending a `sanitize=true` query to the url allows github to return the correct content-type.  

**- Test plan**

Example working SVG preview:  
<img width="301" alt="screen shot 2017-12-21 at 3 32 27 pm" src="https://user-images.githubusercontent.com/3147296/34241874-2ea86bf2-e664-11e7-9c24-0fdc68764400.png">

<!--
Demonstrate the code is solid.
Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.
-->

**- Description for the changelog**

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Enable SVG preview in media library.

**- A picture of a cute animal (not mandatory but encouraged)**

![emu](https://user-images.githubusercontent.com/3147296/34241829-e1677f04-e663-11e7-967a-c60409691f3b.jpg)

