### PR TITLE
fix markdown widget re-rendering on load

### DIFF
--- a/src/components/EditorWidgets/Markdown/MarkdownControl/VisualEditor/index.js
+++ b/src/components/EditorWidgets/Markdown/MarkdownControl/VisualEditor/index.js
@@ -44,17 +44,7 @@ export default class Editor extends Component {
   }
 
   shouldComponentUpdate(nextProps, nextState) {
-    return (this.props.value !== null && nextProps.value === null)
-      || (this.props.value === null && nextProps.value !== null)
-      || !this.state.value.equals(nextState.value);
-  }
-
-  componentWillUpdate(nextProps) {
-    const shouldResetState = (this.props.value !== null && nextProps.value === null)
-      || (this.props.value === null && nextProps.value !== null)
-    if (shouldResetState) {
-      this.setState({ value: createSlateValue(nextProps.value) });
-    }
+    return !this.state.value.equals(nextState.value);
   }
 
   handlePaste = (e, data, change) => {


### PR DESCRIPTION
I added this in the UI update to fix markdown widget state persisting across entries (#754), but it was rushed and introduced odd regressions like #901.

Closes #901.