### PR TITLE
Add trailing slash to /admin links in docs

### DIFF
--- a/website/site/content/docs/add-to-your-site.md
+++ b/website/site/content/docs/add-to-your-site.md
@@ -29,7 +29,7 @@ admin
  └ config.yml
 ```
 
-The first file, `admin/index.html`, is the entry point for the Netlify CMS admin interface. This means that users can navigate to `yoursite.com/admin` to access it. On the code side, it's a basic HTML starter page that loads the necessary CSS and JavaScript files. In this example, we pull those files from a public CDN:
+The first file, `admin/index.html`, is the entry point for the Netlify CMS admin interface. This means that users can navigate to `yoursite.com/admin/` to access it. On the code side, it's a basic HTML starter page that loads the necessary CSS and JavaScript files. In this example, we pull those files from a public CDN:
 
 ```html
 <!doctype html>
@@ -218,7 +218,7 @@ With the backend set to handle authentication, now you need a frontend interface
 
 You'll need to add this to the `<head>` of your CMS index page at `/admin/index.html`, as well as the `<head>` of your site's main index page. Depending on how your site generator is set up, this may mean you need to add it to the default template, or to a "partial" or "include" template. If you can find where the site stylesheet is linked, that's probably the right place. Alternatively, you can include the script in your site using Netlify's [Script Injection](https://www.netlify.com/docs/inject-analytics-snippets/) feature.
 
-When a user logs in with the Netlify Identity widget, they will be directed to the site homepage with an access token. In order to complete the login and get back to the CMS, we'll need to redirect the user back to the `/admin` path. To do this, add the following script before the closing `body` tag of your site's main index page:
+When a user logs in with the Netlify Identity widget, they will be directed to the site homepage with an access token. In order to complete the login and get back to the CMS, we'll need to redirect the user back to the `/admin/` path. To do this, add the following script before the closing `body` tag of your site's main index page:
 
 ```html
 <script>
@@ -242,6 +242,6 @@ Your site CMS is now fully configured and ready for login!
 
 If you set your registration preference to "Invite only," you'll need to invite yourself (and anyone else you choose) as a site user. To do this, select the **Identity** tab from your site dashboard, and then select the **Invite users** button. Invited users will receive an email invitation with a confirmation link. Clicking the link will take you to your site with a login prompt.
 
-If you left your site registration open, or for return visits after comfirming an email invitation, you can access your site's CMS at `yoursite.com/admin`.
+If you left your site registration open, or for return visits after comfirming an email invitation, you can access your site's CMS at `yoursite.com/admin/`.
 
 Happy posting!

--- a/website/site/content/docs/start-with-a-template.md
+++ b/website/site/content/docs/start-with-a-template.md
@@ -31,7 +31,7 @@ After clicking one of those buttons, you’ll authenticate with GitHub and choos
 
     !["Complete your signup" modal on the Kaldi coffee site](https://www.netlifycms.org/img/create-password.png?raw=true)
 
-3. Enter a password, sign in, and you’ll be directed straight to the CMS. (For future visits, you can go straight to `<yoursiteaddress.com>/admin`.)
+3. Enter a password, sign in, and you’ll be directed straight to the CMS. (For future visits, you can go straight to `<yoursiteaddress.com>/admin/`.)
 
 Try adding and editing posts, or changing the content of the Products page. When you save, the changes will be pushed immediately to GitHub, triggering a build on Netlify, and updating the content on your site. Check out the configuration code by visiting your site repo.
 


### PR DESCRIPTION
... because going to `siteaddress.com/admin` doesn't always work.

**- A picture of a cute animal (not mandatory but encouraged)**
![screen shot 2017-12-21 at 10 29 09 am](https://user-images.githubusercontent.com/6111186/34280626-e6bc6ef6-e66d-11e7-9189-1570ac309cd1.png)
