### PR TITLE
fix list widget default values

### DIFF
--- a/src/components/EditorWidgets/List/ListControl.js
+++ b/src/components/EditorWidgets/List/ListControl.js
@@ -71,7 +71,7 @@ export default class ListControl extends Component {
     super(props);
     const { field, value } = props;
     const allItemsCollapsed = field.get('collapsed', true);
-    const itemsCollapsed = Array(value.size).fill(allItemsCollapsed);
+    const itemsCollapsed = value && Array(value.size).fill(allItemsCollapsed);
 
     this.state = {
       itemsCollapsed: List(itemsCollapsed),


### PR DESCRIPTION
Fixes some gaps where `defaultProps` doesn't work because a `null` value was explicitly supplied.