### PR TITLE
fix registerEditorComponent example

### DIFF
--- a/website/site/content/docs/custom-widgets.md
+++ b/website/site/content/docs/custom-widgets.md
@@ -92,7 +92,7 @@ CMS.registerEditorComponent({
   // Fields the user need to fill out when adding an instance of the component
   fields: [{name: 'id', label: 'Youtube Video ID', widget: 'string'}],
   // Pattern to identify a block as being an instance of this component
-  pattern: /youtube (\S+)\s/,
+  pattern: /^youtube (\S+)$/,
   // Function to extract data elements from the regexp match
   fromBlock: function(match) {
     return {


### PR DESCRIPTION
The sample given in the documentation for `registerEditorComponent` does not work. The component is not correctly detected in the markdown content.

The problem is with the pattern given which does not match anything. The PR changes the documentation so that the given example works correctly.