### PR TITLE
fix lost unsaved changes when updating status or publishing

### DIFF
--- a/src/components/Editor/Editor.js
+++ b/src/components/Editor/Editor.js
@@ -180,7 +180,11 @@ class Editor extends React.Component {
   };
 
   handleChangeStatus = (newStatusName) => {
-    const { updateUnpublishedEntryStatus, collection, slug, currentStatus } = this.props;
+    const { entryDraft, updateUnpublishedEntryStatus, collection, slug, currentStatus } = this.props;
+    if (entryDraft.get('hasChanged')) {
+      window.alert('You have unsaved changes, please save before updating status.');
+      return;
+    }
     const newStatus = status.get(newStatusName);
     this.props.updateUnpublishedEntryStatus(collection.get('name'), slug, currentStatus, newStatus);
   }
@@ -206,14 +210,11 @@ class Editor extends React.Component {
     if (currentStatus !== status.last()) {
       window.alert('Please update status to "Ready" before publishing.');
       return;
+    } else if (entryDraft.get('hasChanged')) {
+      window.alert('You have unsaved changes, please save before publishing.');
+      return;
     } else if (!window.confirm('Are you sure you want to publish this entry?')) {
       return;
-    } else if (entryDraft.get('hasChanged')) {
-      if (window.confirm('Your unsaved changes will be saved before publishing. Are you sure you want to publish?')) {
-        await persistEntry(collection);
-      } else {
-        return;
-      }
     }
 
     await publishUnpublishedEntry(collection.get('name'), slug);


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines;
https://github.com/netlify/netlify-cms/blob/master/CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first three fields are mandatory:
-->

**- Summary**

<!--
Explain the **motivation** for making this change.
What existing problem does the pull request solve?
-->

When changing status or publishing from the editor with unsaved changes, unsaved changes are lost.

**- Test plan**

<!--
Demonstrate the code is solid.
Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.
-->

Attempted changing status and publishing with unsaved changes. Both actions now result in a prompt to save before taking the attempted action.

**- Description for the changelog**

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Fix lost unsaved changes when updating status or publishing from editor
