### PR TITLE
Fix thumbs for new uploads to private repos

### DIFF
--- a/src/backends/github/API.js
+++ b/src/backends/github/API.js
@@ -30,6 +30,11 @@ export default class API {
       });
   }
 
+  isPrivateRepo() {
+    return this.request(this.repoURL)
+      .then(repo => repo.private);
+  }
+
   requestHeaders(headers = {}) {
     const baseHeader = {
       "Content-Type": "application/json",

--- a/src/backends/github/implementation.js
+++ b/src/backends/github/implementation.js
@@ -136,7 +136,18 @@ export default class GitHub {
       const response = await this.api.persistFiles(null, [mediaFile], options);
       const repo = this.repo || this.getRepoFromResponseUrl(response.url);
       const { value, size, path, fileObj } = mediaFile;
-      const url = `https://raw.githubusercontent.com/${repo}/${this.branch}${path}`;
+      let url = `https://raw.githubusercontent.com/${repo}/${this.branch}${path}`;
+
+      // Assets uploaded to private repos will need valid access tokens.
+      const isPrivateRepo = await this.api.isPrivateRepo();
+      if (isPrivateRepo) {
+        const files = await this.api.listFiles(this.config.get('media_folder'));
+        const file = files.find(f => (f.sha === mediaFile.sha));
+        if (file) {
+          url = file.download_url;
+        }
+      }
+
       return { id: mediaFile.sha, name: value, size: fileObj.size, url, path: trimStart(path, '/') };
     }
     catch(error) {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines;
https://github.com/netlify/netlify-cms/blob/master/CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first three fields are mandatory:
-->

Closes #993.

**- Summary**

When working on a private repo, new image uploads don't show the thumbnail until you reload the page, leading the user sometimes to think the upload failed because they see a broken thumbnail icon. The src url of new images don't have the token query parameter that is applied when the page loads.

This fix reloads the file list of the upload directory from the git API (as if it was first loading the media library), and fetches the url of the newly uploaded file from that list. I left the previous built-in-the-method url as a fallback, *just in case*.

**Note:** my fix seems the "simplest" in terms of what I could already find in the code, but if you think there's a better way to do it, I'm all up for it. 😄 

<!--
Explain the **motivation** for making this change.
What existing problem does the pull request solve?
-->

**- Test plan**

<!--
Demonstrate the code is solid.
Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.
-->

Tested uploading an image, to a private repository, through the media library. The thumbnail appeared immediately as expected. Also tested in a public repo, all fine as before as well.

**- Description for the changelog**

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

(Media Library) Fix broken thumbnail when uploading an image to a private repository

**- A picture of a cute animal (not mandatory but encouraged)**
![img_20171126_123023](https://user-images.githubusercontent.com/802086/34682890-46dd6582-f498-11e7-9af6-977323fa2743.jpg)
