### PR TITLE
Fix proptype warning

### DIFF
--- a/src/components/Collection/Collection.js
+++ b/src/components/Collection/Collection.js
@@ -36,7 +36,7 @@ class Collection extends React.Component {
 
   render() {
     const { collection, collections, collectionName, isSearchResults, searchTerm } = this.props;
-    const newEntryUrl = collection.get('create') && getNewEntryUrl(collectionName);
+    const newEntryUrl = collection.get('create') ? getNewEntryUrl(collectionName) : '';
     return (
       <div className="nc-collectionPage-container">
         <Sidebar collections={collections} searchTerm={searchTerm}/>


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines;
https://github.com/netlify/netlify-cms/blob/master/CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first three fields are mandatory:
-->

Closes #997.

**- Summary**

<!--
Explain the **motivation** for making this change.
What existing problem does the pull request solve?
-->

Load any page and this appears in the console:

> Warning: Failed prop type: Invalid prop newEntryUrl of type boolean supplied to CollectionTop, expected string.

About the change, later `newEntryUrl` is evaluated on a truey/falsey base and used directly as a string, so we can supply an empty string and it will be evaluated as falsey just the same.

**- Test plan**

<!--
Demonstrate the code is solid.
Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.
-->

Load any page, warning shouldn't appear in the console.

**- Description for the changelog**

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Fix PropType warning in console.