### PR TITLE
allow widgets to access entry data behind feature flag

### DIFF
--- a/src/actions/__tests__/config.spec.js
+++ b/src/actions/__tests__/config.spec.js
@@ -11,6 +11,7 @@ describe('config', () => {
         publish_mode: 'simple',
         media_folder: 'path/to/media',
         public_folder: '/path/to/media',
+        feature_flags: {},
       });
     });
 
@@ -24,6 +25,7 @@ describe('config', () => {
         publish_mode: 'complex',
         media_folder: 'path/to/media',
         public_folder: '/path/to/media',
+        feature_flags: {},
       });
     });
 
@@ -36,6 +38,7 @@ describe('config', () => {
         publish_mode: 'simple',
         media_folder: 'path/to/media',
         public_folder: '/path/to/media',
+        feature_flags: {},
       });
     });
 
@@ -43,12 +46,13 @@ describe('config', () => {
       expect(applyDefaults({
         foo: 'bar',
         media_folder: 'path/to/media',
-        public_folder: '/publib/path',
+        public_folder: '/public/path',
       })).toEqual({
         foo: 'bar',
         publish_mode: 'simple',
         media_folder: 'path/to/media',
-        public_folder: '/publib/path',
+        public_folder: '/public/path',
+        feature_flags: {},
       });
     });
   });

--- a/src/actions/config.js
+++ b/src/actions/config.js
@@ -9,6 +9,7 @@ export const CONFIG_FAILURE = "CONFIG_FAILURE";
 
 const defaults = {
   publish_mode: publishModes.SIMPLE,
+  feature_flags: {},
 };
 
 export function applyDefaults(config) {

--- a/src/components/Editor/Editor.js
+++ b/src/components/Editor/Editor.js
@@ -70,6 +70,7 @@ class Editor extends React.Component {
     deleteUnpublishedEntry: PropTypes.func.isRequired,
     currentStatus: PropTypes.string,
     logoutUser: PropTypes.func.isRequired,
+    featureFlags: ImmutablePropTypes.map.isRequired,
   };
 
   componentDidMount() {
@@ -283,6 +284,7 @@ class Editor extends React.Component {
       isModification,
       currentStatus,
       logoutUser,
+      featureFlags,
     } = this.props;
 
     if (entry && entry.get('error')) {
@@ -323,6 +325,7 @@ class Editor extends React.Component {
         isModification={isModification}
         currentStatus={currentStatus}
         onLogoutClick={logoutUser}
+        featureFlags={featureFlags}
       />
     );
   }
@@ -342,6 +345,7 @@ function mapStateToProps(state, ownProps) {
   const hasChanged = entryDraft.get('hasChanged');
   const displayUrl = config.get('display_url');
   const hasWorkflow = config.get('publish_mode') === EDITORIAL_WORKFLOW;
+  const featureFlags = config.get('feature_flags');
   const isModification = entryDraft.getIn(['entry', 'isModification']);
   const collectionEntriesLoaded = !!entries.getIn(['entities', collectionName])
   const unpublishedEntry = selectUnpublishedEntry(state, collectionName, slug);
@@ -363,6 +367,7 @@ function mapStateToProps(state, ownProps) {
     isModification,
     collectionEntriesLoaded,
     currentStatus,
+    featureFlags,
   };
 }
 

--- a/src/components/Editor/EditorControlPane/EditorControl.js
+++ b/src/components/Editor/EditorControlPane/EditorControl.js
@@ -23,6 +23,7 @@ export default class EditorControl extends React.Component {
       onRemoveInsertedMedia,
       onValidate,
       processControlRef,
+      __experimental,
     } = this.props;
     const widgetName = field.get('widget');
     const widget = resolveWidget(widgetName);
@@ -76,6 +77,7 @@ export default class EditorControl extends React.Component {
           setInactiveStyle={() => this.setState({ styleActive: false })}
           ref={processControlRef && partial(processControlRef, fieldName)}
           editorControl={EditorControl}
+          __experimental={__experimental}
         />
       </div>
     );

--- a/src/components/Editor/EditorControlPane/EditorControlPane.js
+++ b/src/components/Editor/EditorControlPane/EditorControlPane.js
@@ -1,6 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import ImmutablePropTypes from 'react-immutable-proptypes';
+import { Map } from 'immutable';
+import { WIDGET_ENTRY_DATA } from 'Constants/featureFlags';
 import EditorControl from './EditorControl';
 
 export default class ControlPane extends React.Component {
@@ -32,6 +34,7 @@ export default class ControlPane extends React.Component {
       onAddAsset,
       onRemoveInsertedMedia,
       onValidate,
+      featureFlags,
     } = this.props;
 
     if (!collection || !fields) {
@@ -42,6 +45,10 @@ export default class ControlPane extends React.Component {
       return null;
     }
 
+    const __experimental = Map(!featureFlags.get(WIDGET_ENTRY_DATA) ? {} : {
+      entryData: entry.get('data'),
+    });
+
     return (
       <div className="nc-controlPane-root">
         {fields.map((field, i) => field.get('widget') === 'hidden' ? null :
@@ -49,6 +56,7 @@ export default class ControlPane extends React.Component {
             key={i}
             field={field}
             value={entry.getIn(['data', field.get('name')])}
+            entryData={entry.getIn(['data'])}
             fieldsMetaData={fieldsMetaData}
             fieldsErrors={fieldsErrors}
             mediaPaths={mediaPaths}
@@ -59,6 +67,7 @@ export default class ControlPane extends React.Component {
             onRemoveInsertedMedia={onRemoveInsertedMedia}
             onValidate={onValidate}
             processControlRef={this.processControlRef}
+            __experimental={__experimental}
           />
         )}
       </div>
@@ -79,4 +88,5 @@ ControlPane.propTypes = {
   onChange: PropTypes.func.isRequired,
   onValidate: PropTypes.func.isRequired,
   onRemoveInsertedMedia: PropTypes.func.isRequired,
+  featureFlags: ImmutablePropTypes.map.isRequired,
 };

--- a/src/components/Editor/EditorControlPane/Widget.js
+++ b/src/components/Editor/EditorControlPane/Widget.js
@@ -182,6 +182,7 @@ export default class Widget extends Component {
       setInactiveStyle,
       hasActiveStyle,
       editorControl,
+      __experimental,
     } = this.props;
     return React.createElement(controlComponent, {
       field,
@@ -205,6 +206,7 @@ export default class Widget extends Component {
       setInactiveStyle,
       hasActiveStyle,
       editorControl,
+      __experimental,
     });
   }
 }

--- a/src/components/Editor/EditorInterface.js
+++ b/src/components/Editor/EditorInterface.js
@@ -81,6 +81,7 @@ class EditorInterface extends Component {
       isModification,
       currentStatus,
       onLogoutClick,
+      featureFlags,
     } = this.props;
 
     const { previewVisible, scrollSyncEnabled, showEventBlocker } = this.state;
@@ -102,6 +103,7 @@ class EditorInterface extends Component {
           onOpenMediaLibrary={onOpenMediaLibrary}
           onAddAsset={onAddAsset}
           onRemoveInsertedMedia={onRemoveInsertedMedia}
+          featureFlags={featureFlags}
           ref={c => this.controlPaneRef = c} // eslint-disable-line
         />
       </div>
@@ -219,6 +221,7 @@ EditorInterface.propTypes = {
   isModification: PropTypes.bool,
   currentStatus: PropTypes.string,
   onLogoutClick: PropTypes.func.isRequired,
+  featureFlags: ImmutablePropTypes.map.isRequired,
 };
 
 export default EditorInterface;

--- a/src/components/EditorWidgets/String/StringControl.js
+++ b/src/components/EditorWidgets/String/StringControl.js
@@ -18,7 +18,7 @@ export default class StringControl extends React.Component {
       onChange,
       classNameWrapper,
       setActiveStyle,
-      setInactiveStyle
+      setInactiveStyle,
     } = this.props;
 
     return (

--- a/src/constants/featureFlags.js
+++ b/src/constants/featureFlags.js
@@ -1,0 +1,1 @@
+export const WIDGET_ENTRY_DATA = 'widget_entry_data';


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines;
https://github.com/netlify/netlify-cms/blob/master/CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first three fields are mandatory:
-->

**- Summary**

<!--
Explain the **motivation** for making this change.
What existing problem does the pull request solve?
-->

Now that Netlify CMS is 1.0, we need a way to introduce non-final changes for public testing. This is especially critical as we develop the CMS extension surfaces, such as the props provided to custom widgets.

This PR introduces basic feature flag functionality driven by a simple object in the config file, and an initial flagged feature: providing all current entry field values to widgets. This is provided through an additional convention, an `__experimental` prop, so that its clear to developers that their opting into non-standard functionality that may completely change or break at any time.

**- Test plan**

<!--
Demonstrate the code is solid.
Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.
-->

Toggled on the widget entry data feature flag by adding the following to the example project config:

```
feature_flags:
  widget_entry_data: true
```

When the flag is on, an `entryData` map is provided within the `__experimental` prop (also a map). When the flag is off, the `__experimental` prop has an empty map.

**- Description for the changelog**

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Should not be included in changelog.

