### PR TITLE
Fix missing line breaks in code example in Custom Widgets documentation

### DIFF
--- a/website/site/content/docs/custom-widgets.md
+++ b/website/site/content/docs/custom-widgets.md
@@ -20,7 +20,12 @@ However, although possible, it may be cumbersome or even impractical to add a Re
 Register a custom widget.
 
 ```js
-// Using global window objectCMS.registerWidget(name, control, [preview])// Using npm module importimport CMS from 'netlify-cms'CMS.registerWidget(name, control, [preview])
+// Using global window object
+CMS.registerWidget(name, control, [preview])
+
+// Using npm module import
+import CMS from 'netlify-cms'
+CMS.registerWidget(name, control, [preview])
 ```
 
 **Params:**


### PR DESCRIPTION
**- Summary**

The [Custom Widgets docs page](https://www.netlifycms.org/docs/custom-widgets/) has a code example missing line breaks, making it hard to read.

**- Description for the changelog**

Fix missing line breaks in Custom Widgets docs page.
