### PR TITLE
Register Internal and Custom backend API's

### DIFF
--- a/src/backends/backend.js
+++ b/src/backends/backend.js
@@ -14,6 +14,7 @@ import { sanitizeSlug } from "Lib/urlHelper";
 import TestRepoBackend from "./test-repo/implementation";
 import GitHubBackend from "./github/implementation";
 import GitGatewayBackend from "./git-gateway/implementation";
+import { getBackend } from 'Lib/registry';
 
 class LocalStorageAuthStore {
   storageKey = "netlify-cms-user";
@@ -338,6 +339,10 @@ export function resolveBackend(config) {
   }
 
   const authStore = new LocalStorageAuthStore();
+
+  if (getBackend && getBackend().name === name) {
+    return new Backend(getBackend().init(config), name, authStore);
+  }
 
   switch (name) {
     case "test-repo":

--- a/src/backends/backend.js
+++ b/src/backends/backend.js
@@ -14,7 +14,15 @@ import { sanitizeSlug } from "Lib/urlHelper";
 import TestRepoBackend from "./test-repo/implementation";
 import GitHubBackend from "./github/implementation";
 import GitGatewayBackend from "./git-gateway/implementation";
-import { getBackend } from 'Lib/registry';
+import { registerBackends, getBackend } from 'Lib/registry';
+
+/**
+ * Register internal backends
+ */
+registerBackends('git-gateway', GitGatewayBackend);
+registerBackends('github', GitHubBackend);
+registerBackends('test-repo', TestRepoBackend);
+
 
 class LocalStorageAuthStore {
   storageKey = "netlify-cms-user";
@@ -340,19 +348,10 @@ export function resolveBackend(config) {
 
   const authStore = new LocalStorageAuthStore();
 
-  if (getBackend && getBackend().name === name) {
-    return new Backend(getBackend().init(config), name, authStore);
-  }
-
-  switch (name) {
-    case "test-repo":
-      return new Backend(new TestRepoBackend(config), name, authStore);
-    case "github":
-      return new Backend(new GitHubBackend(config), name, authStore);
-    case "git-gateway":
-      return new Backend(new GitGatewayBackend(config), name, authStore);
-    default:
-      throw new Error(`Backend not found: ${ name }`);
+  if (!getBackend(name)) {
+    throw new Error(`Backend not found: ${ name }`);
+  } else {
+    return new Backend(getBackend(name).init(config), name, authStore);
   }
 }
 

--- a/src/backends/backend.js
+++ b/src/backends/backend.js
@@ -14,14 +14,14 @@ import { sanitizeSlug } from "Lib/urlHelper";
 import TestRepoBackend from "./test-repo/implementation";
 import GitHubBackend from "./github/implementation";
 import GitGatewayBackend from "./git-gateway/implementation";
-import { registerBackends, getBackend } from 'Lib/registry';
+import { registerBackend, getBackend } from 'Lib/registry';
 
 /**
  * Register internal backends
  */
-registerBackends('git-gateway', GitGatewayBackend);
-registerBackends('github', GitHubBackend);
-registerBackends('test-repo', TestRepoBackend);
+registerBackend('git-gateway', GitGatewayBackend);
+registerBackend('github', GitHubBackend);
+registerBackend('test-repo', TestRepoBackend);
 
 
 class LocalStorageAuthStore {

--- a/src/lib/registry.js
+++ b/src/lib/registry.js
@@ -5,6 +5,7 @@ import { newEditorPlugin } from 'EditorWidgets/Markdown/MarkdownControl/plugins'
  * Global Registry Object
  */
 const registry = {
+  backend: { },
   templates: {},
   previewStyles: [],
   widgets: {},
@@ -24,6 +25,8 @@ export default {
   getEditorComponents,
   registerWidgetValueSerializer,
   getWidgetValueSerializer,
+  registerBackend,
+  getBackend,
 };
 
 
@@ -87,3 +90,18 @@ export function registerWidgetValueSerializer(widgetName, serializer) {
 export function getWidgetValueSerializer(widgetName) {
   return registry.widgetValueSerializers[widgetName];
 };
+
+/**
+ * Backend API
+ */
+export function registerBackend(name, BackendClass) {
+  registry.backend = {
+    name,
+    init: config => new BackendClass(config),
+  };
+}
+
+export function getBackend() {
+  return registry.backend;
+}
+

--- a/src/lib/registry.js
+++ b/src/lib/registry.js
@@ -5,7 +5,7 @@ import { newEditorPlugin } from 'EditorWidgets/Markdown/MarkdownControl/plugins'
  * Global Registry Object
  */
 const registry = {
-  backend: { },
+  backends: { },
   templates: {},
   previewStyles: [],
   widgets: {},
@@ -25,7 +25,7 @@ export default {
   getEditorComponents,
   registerWidgetValueSerializer,
   getWidgetValueSerializer,
-  registerBackend,
+  registerBackends,
   getBackend,
 };
 
@@ -94,14 +94,19 @@ export function getWidgetValueSerializer(widgetName) {
 /**
  * Backend API
  */
-export function registerBackend(name, BackendClass) {
-  registry.backend = {
-    name,
-    init: config => new BackendClass(config),
-  };
+export function registerBackends(name, BackendClass) {
+  if (!name || !BackendClass) {
+    console.error("Backend parameters invalid. example: CMS.registerBackends('myBackend', BackendClass)");
+  } else if (registry.backends[name]) {
+      console.error(`Backend [${ name }] already registered. Please choose a different name.`);
+  } else {
+    registry.backends[name] = {
+      init: config => new BackendClass(config),
+    };
+  }
 }
 
-export function getBackend() {
-  return registry.backend;
+export function getBackend(name) {
+  return registry.backends[name];
 }
 

--- a/src/lib/registry.js
+++ b/src/lib/registry.js
@@ -25,7 +25,7 @@ export default {
   getEditorComponents,
   registerWidgetValueSerializer,
   getWidgetValueSerializer,
-  registerBackends,
+  registerBackend,
   getBackend,
 };
 
@@ -94,9 +94,9 @@ export function getWidgetValueSerializer(widgetName) {
 /**
  * Backend API
  */
-export function registerBackends(name, BackendClass) {
+export function registerBackend(name, BackendClass) {
   if (!name || !BackendClass) {
-    console.error("Backend parameters invalid. example: CMS.registerBackends('myBackend', BackendClass)");
+    console.error("Backend parameters invalid. example: CMS.registerBackend('myBackend', BackendClass)");
   } else if (registry.backends[name]) {
       console.error(`Backend [${ name }] already registered. Please choose a different name.`);
   } else {


### PR DESCRIPTION
**- Summary**

A solution to register a custom backend API while also registering the internal API's so there is no overwriting of names.

The backends internally target `github` and the `git-gateway` without any changes to the CMS itself. This solution is a non breaking solution for the current CMS without having to change the internal backend's.

**- Test plan**

Make sure the CMS works as is using all current internal backends.
Test a custom created backend by registering the new backend `CMS.registerBackends("my-custom-backend", MyCustomBackendClass)`
Created an example [backend library here][1] (might look familiar to some of you)

**- Description for the changelog**

Register Internal and Custom backend API's

**- A picture of a cute animal (not mandatory but encouraged)**
🐶


  [1]: https://github.com/talves/netlify-cms-backend-offline