### PR TITLE
Fixes website CTA spacing on desktop

### DIFF
--- a/website/src/css/imports/cta.css
+++ b/website/src/css/imports/cta.css
@@ -28,6 +28,7 @@
       font-size: 18px;
       line-height: 25px;
       color: $lightishGrey;
+      margin: 0;
 
       .hook {
         font-weight: $bold;


### PR DESCRIPTION
On the website, there is a wrong bottom margin below the CTA text on desktop. This removes it.