### PR TITLE
Fix list items crashing for first fields other than strings.

### DIFF
--- a/src/components/EditorWidgets/List/ListControl.js
+++ b/src/components/EditorWidgets/List/ListControl.js
@@ -194,7 +194,7 @@ export default class ListControl extends Component {
     const singleField = field.get('field');
     const labelField = (multiFields && multiFields.first()) || singleField;
     const value = multiFields ? item.get(multiFields.first().get('name')) : singleField.get('label');
-    return value || `No ${ labelField.get('name') }`;
+    return (value || `No ${ labelField.get('name') }`).toString();
   }
 
   onSortEnd = ({ oldIndex, newIndex }) => {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines;
https://github.com/netlify/netlify-cms/blob/master/CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first three fields are mandatory:
-->

**- Summary**

If the first field in a list widget didn't return a string (or React component), the CMS would crash. This was because the CMS was trying to render the value of the first widget when a list item was collapsed, as explained in the related issue.

Fixes #1113.
<!--
Explain the **motivation** for making this change.
What existing problem does the pull request solve?
-->

**- Test plan**

Manually tested with date widget.
<!--
Demonstrate the code is solid.
Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.
-->

**- Description for the changelog**

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

**- A picture of a cute animal (not mandatory but encouraged)**
