### PR TITLE
exclude time from default date widget format

### DIFF
--- a/src/components/EditorWidgets/Date/DateControl.js
+++ b/src/components/EditorWidgets/Date/DateControl.js
@@ -3,6 +3,9 @@ import PropTypes from 'prop-types';
 import DateTime from 'react-datetime';
 import moment from 'moment';
 
+const DEFAULT_DATE_FORMAT = 'YYYY-MM-DD';
+const DEFAULT_DATETIME_FORMAT = moment.defaultFormat;
+
 export default class DateControl extends React.Component {
   static propTypes = {
     field: PropTypes.object.isRequired,
@@ -42,7 +45,7 @@ export default class DateControl extends React.Component {
 
   render() {
     const { includeTime, value, classNameWrapper, setActiveStyle, setInactiveStyle } = this.props;
-    const format = this.format || moment.defaultFormat;
+    const format = this.format || (includeTime ? DEFAULT_DATETIME_FORMAT : DEFAULT_DATE_FORMAT);
     return (
       <DateTime
         timeFormat={!!includeTime}

--- a/src/components/EditorWidgets/Date/DateControl.js
+++ b/src/components/EditorWidgets/Date/DateControl.js
@@ -21,8 +21,8 @@ export default class DateControl extends React.Component {
   };
 
   componentDidMount() {
-    const { value, field, onChange } = this.props;
-    this.format = field.get('format');
+    const { includeTime, value, field, onChange } = this.props;
+    this.format = field.get('format') || (includeTime ? DEFAULT_DATETIME_FORMAT : DEFAULT_DATE_FORMAT);
 
     /**
      * Set the current date as default value if no default value is provided. An
@@ -45,7 +45,7 @@ export default class DateControl extends React.Component {
 
   render() {
     const { includeTime, value, classNameWrapper, setActiveStyle, setInactiveStyle } = this.props;
-    const format = this.format || (includeTime ? DEFAULT_DATETIME_FORMAT : DEFAULT_DATE_FORMAT);
+    const format = this.format;
     return (
       <DateTime
         timeFormat={!!includeTime}


### PR DESCRIPTION
Sets correct and documented format for Date widget (YYYY-MM-DD).

Closes #1119. 