### PR TITLE
add dev task that writes output to disk

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,9 @@
   "description": "Netlify CMS lets content editors work on structured content stored in git",
   "main": "dist/cms.js",
   "scripts": {
-    "start": "webpack-dev-server -d --config webpack.dev.js",
+    "start": "npm run dev",
+    "dev": "webpack-dev-server -d --config webpack.dev.js",
+    "dev:write": "webpack-dev-server -d --config webpack.dev-write.js",
     "test": "jest --coverage",
     "test:watch": "jest --watch",
     "build": "cross-env NODE_ENV=production webpack --config webpack.prod.js --display-error-details",
@@ -123,7 +125,8 @@
     "webpack": "^3.6.0",
     "webpack-dev-server": "^2.9.1",
     "webpack-merge": "^4.1.0",
-    "webpack-postcss-tools": "^1.1.1"
+    "webpack-postcss-tools": "^1.1.1",
+    "write-file-webpack-plugin": "^4.2.0"
   },
   "dependencies": {
     "classnames": "^2.2.5",

--- a/webpack.dev-write.js
+++ b/webpack.dev-write.js
@@ -1,0 +1,9 @@
+/* global require */
+const merge = require('webpack-merge');
+const WriteFilePlugin = require('write-file-webpack-plugin');
+
+module.exports = merge.smart(require('./webpack.dev.js'), {
+  plugins: [
+    new WriteFilePlugin(),
+  ],
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -3164,6 +3164,10 @@ fileset@^2.0.2:
     glob "^7.0.3"
     minimatch "^3.0.3"
 
+filesize@^3.2.1:
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/filesize/-/filesize-3.6.0.tgz#22d079615624bb6fd3c04026120628a41b3f4efa"
+
 fill-range@^2.1.0:
   version "2.2.3"
   resolved "https://registry.yarnpkg.com/fill-range/-/fill-range-2.2.3.tgz#50b77dfd7e469bc7492470963699fe7a8485a723"
@@ -9581,6 +9585,17 @@ write-file-atomic@^2.0.0, write-file-atomic@^2.1.0:
 write-file-stdout@0.0.2:
   version "0.0.2"
   resolved "https://registry.yarnpkg.com/write-file-stdout/-/write-file-stdout-0.0.2.tgz#c252d7c7c5b1b402897630e3453c7bfe690d9ca1"
+
+write-file-webpack-plugin@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/write-file-webpack-plugin/-/write-file-webpack-plugin-4.2.0.tgz#7bd18547eaa0ea0b23992fb1e0322e5431d339ef"
+  dependencies:
+    chalk "^1.1.1"
+    debug "^2.6.8"
+    filesize "^3.2.1"
+    lodash "^4.5.1"
+    mkdirp "^0.5.1"
+    moment "^2.11.2"
 
 write@^0.2.1:
   version "0.2.1"


### PR DESCRIPTION
This is necessary for local development in many scenarios, e.g. developing on the CMS and Gatsby sources simultaneously with a local test project. Been using it privately for months, tired of restoring it from stash every time I need it.