### PR TITLE
Fix workflow silent fail

### DIFF
--- a/src/actions/editorialWorkflow.js
+++ b/src/actions/editorialWorkflow.js
@@ -243,10 +243,17 @@ export function loadUnpublishedEntries(collections) {
     if (state.config.get('publish_mode') !== EDITORIAL_WORKFLOW) return;
     const backend = currentBackend(state.config);
     dispatch(unpublishedEntriesLoading());
-    backend.unpublishedEntries(collections).then(
-      response => dispatch(unpublishedEntriesLoaded(response.entries, response.pagination)),
-      error => dispatch(unpublishedEntriesFailed(error))
-    );
+    backend.unpublishedEntries(collections)
+      .then(response => dispatch(unpublishedEntriesLoaded(response.entries, response.pagination)))
+      .catch(error => {
+        dispatch(notifSend({
+          message: `Error loading entries: ${ error }`,
+          kind: 'danger',
+          dismissAfter: 8000,
+        }));
+        dispatch(unpublishedEntriesFailed(error));
+        Promise.reject(error)
+      });
   };
 }
 

--- a/src/backends/backend.js
+++ b/src/backends/backend.js
@@ -201,10 +201,13 @@ class Backend {
     ))
     .then(entries => ({
       pagination: 0,
-      entries: entries.map(entry => {
+      entries: entries.reduce((acc, entry) => {
         const collection = collections.get(entry.collection);
-        return this.entryWithFormat(collection)(entry);
-      }),
+        if (collection) {
+          acc.push(this.entryWithFormat(collection)(entry));
+        }
+        return acc;
+      }, []),
     }));
   }
 


### PR DESCRIPTION
This addresses two issues:

1. `loadUnpublishedEntries` swallows errors, hiding them in both the console and the UI.
2. Unpublished entries from unknown collections crashes the editorial workflow on load. This can happen when different branches use different configurations.