### PR TITLE
accept CSS string in registerPreviewStyle

### DIFF
--- a/src/components/Editor/EditorPreviewPane/EditorPreviewPane.js
+++ b/src/components/Editor/EditorPreviewPane/EditorPreviewPane.js
@@ -138,7 +138,12 @@ export default class PreviewPane extends React.Component {
     };
 
     const styleEls = getPreviewStyles()
-       .map((style, i) => <link key={i} href={style} type="text/css" rel="stylesheet" />);
+      .map((style, i) => {
+        if (style.raw) {
+          return <style key={i}>{style.value}</style>
+        }
+        return <link key={i} href={style.value} type="text/css" rel="stylesheet" />;
+      });
 
     if (!collection) {
       return <Frame className="nc-previewPane-frame" head={styleEls} />;

--- a/src/lib/registry.js
+++ b/src/lib/registry.js
@@ -32,9 +32,12 @@ export default {
 
 /**
  * Preview Styles
+ *
+ * Valid options:
+ *  - raw {boolean} if `true`, `style` value is expected to be a CSS string
  */
-export function registerPreviewStyle(style) {
-  registry.previewStyles.push(style);
+export function registerPreviewStyle(style, opts) {
+  registry.previewStyles.push({ ...opts, value: style });
 };
 export function getPreviewStyles() {
   return registry.previewStyles;

--- a/website/site/content/docs/beta-features.md
+++ b/website/site/content/docs/beta-features.md
@@ -44,3 +44,18 @@ init({
 // The registry works as expected, and can be used before or after init.
 registry.registerPreviewTemplate(...);
 ```
+
+## Raw CSS in `registerPreviewStyle`
+`registerPreviewStyle` can now accept a CSS string, in addition to accepting a url. The feature is activated by passing in an object as the second argument, with `raw` set to a truthy value.This is critical for integrating with modern build tooling. Here's an example using webpack:
+
+```js
+/**
+ * Assumes a webpack project with `sass-loader` and `css-loader` installed.
+ * Takes advantage of the `toString` method in the return value of `css-loader`.
+ */
+import CMS from 'netlify-cms';
+import styles from '!css-loader!sass-loader!../main.scss'
+
+CMS.registerPreviewStyle(styles.toString(), { raw: true })
+```
+


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines;
https://github.com/netlify/netlify-cms/blob/master/CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first three fields are mandatory:
-->

**- Summary**

<!--
Explain the **motivation** for making this change.
What existing problem does the pull request solve?
-->

Raw styles can't currently be injected into the preview pane, which is a challenge for projects using modern build tooling. For example, I'd like to import styles from a specific file using inline webpack loaders and pass the result to `registerPreviewStyle`, rather than doing something hacky to get Webpack to emit files, which is next to impossible if the webpack config is shared, as in systems like Gatsby.

Adding this as a beta feature only to avoid commitment to the exact API being introduced.


**- Description for the changelog**

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Accept CSS strings in registerPreviewStyle

**- Docs**

## Raw CSS in `registerPreviewStyle`
`registerPreviewStyle` can now accept a CSS string, in addition to accepting a url. The feature is activated by passing in an object as the second argument, with `raw` set to a truthy value.This is critical for integrating with modern build tooling. Here's an example using webpack:
 
```js
/**
 * Assumes a webpack project with `sass-loader` and `css-loader` installed.
 * Takes advantage of the `toString` method in the return value of `css-loader`.
 */
import CMS from 'netlify-cms';
import styles from '!css-loader!sass-loader!../main.scss'
 
CMS.registerPreviewStyle(styles.toString(), { raw: true })
```