### PR TITLE
Fix beta feature document

### DIFF
--- a/website/site/content/docs/beta-features.md
+++ b/website/site/content/docs/beta-features.md
@@ -36,8 +36,10 @@ init()
  */
 
 init({
-  backend: {
-    name: 'git-gateway',
+  config: {
+    backend: {
+      name: 'git-gateway',
+    },
   },
 })
 


### PR DESCRIPTION
**- Summary**

Fix beta feature document
The `init()` method requires an object with a property name `config` and the value to be the configuration

**- A picture of a cute animal (not mandatory but encouraged)**
🐧