### PR TITLE
Allow existing nc-root element

### DIFF
--- a/src/bootstrap.js
+++ b/src/bootstrap.js
@@ -25,9 +25,12 @@ function bootstrap(opts = {}) {
   /**
    * Create mount element dynamically.
    */
-  const el = document.createElement('div');
-  el.id = 'nc-root';
-  document.body.appendChild(el);
+  const el = document.getElementById('nc-root');
+  if (!el) {
+    document.createElement('div');
+    el.id = 'nc-root';
+    document.body.appendChild(el);
+  }
 
   /**
    * Configure Redux store.

--- a/src/bootstrap.js
+++ b/src/bootstrap.js
@@ -27,7 +27,7 @@ function bootstrap(opts = {}) {
    */
   const el = document.getElementById('nc-root');
   if (!el) {
-    document.createElement('div');
+    el = document.createElement('div');
     el.id = 'nc-root';
     document.body.appendChild(el);
   }

--- a/src/bootstrap.js
+++ b/src/bootstrap.js
@@ -25,7 +25,7 @@ function bootstrap(opts = {}) {
   /**
    * Create mount element dynamically.
    */
-  const el = document.getElementById('nc-root');
+  let el = document.getElementById('nc-root');
   if (!el) {
     el = document.createElement('div');
     el.id = 'nc-root';


### PR DESCRIPTION
**- Summary**

Allow for the render of an existing root element for the CMS app.

### Solves:
Will allow a React app to be able to wrap the CMS component with a react component to be able to include as a route.
[Example Test Repo based on create-react-app](https://github.com/talves/react-netlify-cms)

**- Test plan**

- `yarn build`
- use the `dist` assets in your app

**- Description for the changelog**

Allow existing root element `nc-root` 

**- A picture of a cute animal (not mandatory but encouraged)**
🦈