### PR TITLE
Allow for single bundle init without losing automatic loading

### DIFF
--- a/src/bootstrap.js
+++ b/src/bootstrap.js
@@ -13,17 +13,9 @@ import 'EditorWidgets';
 import 'MarkdownPlugins';
 import './index.css';
 
-const ROOT_ID = 'nc-root';
+export const ROOT_ID = 'nc-root';
 
 function bootstrap(opts = {}) {
-  /**
-   * Error and return if this function was already called.
-   */
-  if (document.getElementById(ROOT_ID)) {
-    console.error('Bootstrap attempted, but Netlify CMS is already initialized!');
-    return;
-  }
-
   const { config } = opts;
 
   /**
@@ -34,9 +26,12 @@ function bootstrap(opts = {}) {
   /**
    * Create mount element dynamically.
    */
-  const el = document.createElement('div');
-  el.id = 'nc-root';
-  document.body.appendChild(el);
+  let el = document.getElementById(ROOT_ID);
+  if (!el) {
+    el = document.createElement('div');
+    el.id = ROOT_ID;
+    document.body.appendChild(el);
+  }
 
   /**
    * Configure Redux store.

--- a/src/index.js
+++ b/src/index.js
@@ -3,23 +3,47 @@
  * the `window` object.
  */
 import React from 'react';
-import bootstrap from './bootstrap';
+import bootstrap, { ROOT_ID } from './bootstrap';
 import registry from 'Lib/registry';
 import createReactClass from 'create-react-class';
 
+let initialized = false;
+
+/**
+ * Allow init of the CMS.
+ */
+function init(opts = {}) {
+  if (initialized) {
+    console.error('Bootstrap attempted, but Netlify CMS is already initialized!');
+    return;
+  }
+  initialized = bootstrap(opts);
+  return initialized;
+}
+
+/**
+ * Allow reset of the CMS to allow render after unmount
+ */
+function reset() {
+  initialized = false;
+}
+
 const CMS = (function startApp() {
   /**
-   * Load the app, bail if bootstrapping fails. This will most likely occur
-   * if both automatic and manual initialization are attempted.
+   * Load the app, bail if root element exists or no-auto element.
+   * Use <div id="no-auto" /> in your app if you are not persisting the root element.
+   *  (in example: as a React Route)
    */
-  if (!bootstrap()) {
-    return;
+  if (document.getElementById('no-auto') || document.getElementById(ROOT_ID)) {
+    console.log('CMS is running in manual mode. [using init() to initialize]');
+  } else {
+    init();
   }
 
   /**
    * Add extension hooks to global scope.
    */
-  const api = { ...registry };
+  const api = { init, reset, ...registry };
   if (typeof window !== 'undefined') {
     window.CMS = api;
     window.createClass = window.createClass || createReactClass;
@@ -32,3 +56,8 @@ const CMS = (function startApp() {
  * Export the registry for projects that import the CMS.
  */
 export default CMS;
+
+/**
+ * Export the init, reset and registry standalone. (optional)
+ */
+export { init, reset, registry };


### PR DESCRIPTION
**- Summary**

Here is the proposed changes to allow for single bundle today!

**- Features**

- looks for both element id `nc-root` or `no-auto` because we need to persist the element in the case `nc-root` will be a route component, that gets unmounted
-  Ability to `import CMS from 'netlify-cms'` from the bundle ( CMS.init(), CMS.reset() added )
- reset() method added to allow a reset when unmounting the cms from the dom and need to re-init
- Allow for the `import { init, reset, registry } from 'netlify-cms'` but not sure it is needed in this solution (optional)

**- Test plan**

`yarn build`
consume the assets in a project and make sure it is working :smile:

**- Description for the changelog**

see parent description

**- A picture of a cute animal (not mandatory but encouraged)**
🐧