### PR TITLE
Allow for un-captured route of config.yml

### DIFF
--- a/src/actions/config.js
+++ b/src/actions/config.js
@@ -122,7 +122,13 @@ export function loadConfig() {
         throw new Error(`Failed to load config.yml (${ response.status })`);
       }
 
-      const loadedConfig = parseConfig(requestSuccess ? await response.text() : '');
+      let loadedConfig = '';
+      const contentType = response.headers.get('Content-Type');
+      if (contentType.indexOf('text/html') !== -1) {
+        console.log('No config.yml found. (Content-Type: text/html)');
+      } else {
+        loadedConfig = parseConfig(requestSuccess ? await response.text() : '');
+      }
 
       /**
        * Merge any existing configuration so the result can be validated.

--- a/src/actions/config.js
+++ b/src/actions/config.js
@@ -86,7 +86,6 @@ async function getConfig(file, isPreloaded) {
   if (!isYaml) {
     console.log(`Response for ${ file } was not yaml. (Content-Type: ${ contentType })`);
     if (isPreloaded) return parseConfig('');
-    throw new Error('Failed to load configuration.');
   }
   return parseConfig(await response.text());
 }


### PR DESCRIPTION
This fixes if there was an invalid route to the `config.yml` because it did not exist and it was handled without a 404.

Delete this branch when merged.