### PR TITLE
Fix regression in list relation previews

### DIFF
--- a/src/components/EditorWidgets/List/ListControl.js
+++ b/src/components/EditorWidgets/List/ListControl.js
@@ -158,11 +158,12 @@ export default class ListControl extends Component {
 
   handleChangeFor(index) {
     return (fieldName, newValue, newMetadata) => {
-      const { value, metadata, onChange, forID } = this.props;
+      const { value, metadata, onChange, field } = this.props;
+      const collectionName = field.get('name');
       const newObjectValue = this.getObjectValue(index).set(fieldName, newValue);
       const parsedValue = (this.valueType === valueTypes.SINGLE) ? newObjectValue.first() : newObjectValue;
       const parsedMetadata = {
-        [forID]: Object.assign(metadata ? metadata.toJS() : {}, newMetadata ? newMetadata[forID] : {}),
+        [collectionName]: Object.assign(metadata ? metadata.toJS() : {}, newMetadata ? newMetadata[collectionName] : {}),
       };
       onChange(value.set(index, parsedValue), parsedMetadata);
     };
@@ -171,8 +172,9 @@ export default class ListControl extends Component {
   handleRemove = (index, event) => {
     event.preventDefault();
     const { itemsCollapsed } = this.state;
-    const { value, metadata, onChange, forID } = this.props;
-    const parsedMetadata = metadata && { [forID]: metadata.removeIn(value.get(index).valueSeq()) };
+    const { value, metadata, onChange, field } = this.props;
+    const collectionName = field.get('name');
+    const parsedMetadata = metadata && { [collectionName]: metadata.removeIn(value.get(index).valueSeq()) };
 
     this.setState({ itemsCollapsed: itemsCollapsed.delete(index) });
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines;
https://github.com/netlify/netlify-cms/blob/master/CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first three fields are mandatory:
-->

**- Summary**
Closes #1198 - regression fix: PR #1087 broke relation lists preview.

<!--
Explain the **motivation** for making this change.
What existing problem does the pull request solve?
-->

**- Test plan**
This is hard, I haven't found any example in the demo that shows this. The *ListControl* component was using the `forID` property to check for metadata that has a structure like 
```
{ "collection_name": { ... } }
```
but the changes to ensure `forID` uniqueness breaks this of course as the metadata doesn't have that unique string in the object's property names.

This fix ensures that *ListControl* uses the collection name without any unique string attached when checking for metadata.

<!--
Demonstrate the code is solid.
Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.
-->

**- Description for the changelog**
(Fix regression) previews for relation lists broken by #1087 

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
