### PR TITLE
Check for title/slug field on config load.

### DIFF
--- a/src/actions/__tests__/config.spec.js
+++ b/src/actions/__tests__/config.spec.js
@@ -58,7 +58,17 @@ describe('config', () => {
 
   describe('validateConfig', () => {
     it('should return the config if no errors', () => {
-      const config = fromJS({ foo: 'bar', backend: { name: 'bar' }, media_folder: 'baz', collections: [{}] });
+      const collections = [{
+        name: 'posts',
+        folder: '_posts',
+        fields: [{ name: 'title', label: 'title' }],
+      }];
+      const config = fromJS({
+        foo: 'bar',
+        backend: { name: 'bar' },
+        media_folder: 'baz',
+        collections,
+      });
       expect(
         validateConfig(config)
       ).toEqual(config);

--- a/src/actions/config.js
+++ b/src/actions/config.js
@@ -68,7 +68,7 @@ function validateCollection(collection) {
     // Cannot set custom delimiter without explicit and proper frontmatter format declaration
     throw new Error(`Please set a proper frontmatter format for collection "${name}" to use a custom delimiter. Supported frontmatter formats are yaml-frontmatter, toml-frontmatter, and json-frontmatter.`);
   }
-  if (!!folder && !selectIdentifier(collection)) {
+  if (folder && !selectIdentifier(collection)) {
     // Verify that folder-type collections have an identifier field for slug creation.
     throw new Error(`Collection "${name}" must have a field that is a valid entry identifier. Supported fields are ${IDENTIFIER_FIELDS.join(', ')}.`);
   }

--- a/src/actions/config.js
+++ b/src/actions/config.js
@@ -2,6 +2,9 @@ import yaml from "js-yaml";
 import { Map, List, fromJS } from "immutable";
 import { trimStart, flow, isBoolean, get } from "lodash";
 import { authenticateUser } from "Actions/auth";
+import { formatByExtension, supportedFormats, frontmatterFormats } from "Formats/formats";
+import { selectIdentifier } from "Reducers/collections";
+import { IDENTIFIER_FIELDS } from "Constants/fieldInference";
 import * as publishModes from "Constants/publishModes";
 
 export const CONFIG_REQUEST = "CONFIG_REQUEST";
@@ -40,6 +43,38 @@ export function applyDefaults(config) {
     });
 }
 
+function validateCollection(collection) {
+  const {
+    name,
+    folder,
+    files,
+    format,
+    extension,
+    frontmatter_delimiter: delimiter,
+    fields,
+  } = collection.toJS();
+
+  if (!folder && !files) {
+    throw new Error(`Unknown collection type for collection "${name}". Collections can be either Folder based or File based.`);
+  }
+  if (format && !supportedFormats.includes(format)) {
+    throw new Error(`Unknown collection format for collection "${name}". Supported formats are ${supportedFormats.join(',')}`);
+  }
+  if (!format && extension && !formatByExtension(extension)) {
+    // Cannot infer format from extension.
+    throw new Error(`Please set a format for collection "${name}". Supported formats are ${supportedFormats.join(',')}`);
+  }
+  if (delimiter && !frontmatterFormats.includes(format)) {
+    // Cannot set custom delimiter without explicit and proper frontmatter format declaration
+    throw new Error(`Please set a proper frontmatter format for collection "${name}" to use a custom delimiter. Supported frontmatter formats are yaml-frontmatter, toml-frontmatter, and json-frontmatter.`);
+  }
+  if (!!folder && !selectIdentifier(collection)) {
+    // Verify that folder-type collections have an identifier field for slug creation.
+    throw new Error(`Collection "${name}" must have a field that is a valid entry identifier. Supported fields are ${IDENTIFIER_FIELDS.join(', ')}.`);
+  }
+}
+
+
 export function validateConfig(config) {
   if (!config.get('backend')) {
     throw new Error("Error in configuration file: A `backend` wasn't found. Check your config.yml file.");
@@ -70,6 +105,12 @@ export function validateConfig(config) {
   if (!List.isList(collections) || collections.isEmpty() || !collections.first()) {
     throw new Error("Error in configuration file: Your `collections` must be an array with at least one element. Check your config.yml file.");
   }
+
+  /**
+   * Validate Collections
+   */
+  config.get('collections').forEach(validateCollection);
+
   return config;
 }
 

--- a/src/backends/backend.js
+++ b/src/backends/backend.js
@@ -46,13 +46,13 @@ const slugFormatter = (template = "{{slug}}", entryData, slugConfig) => {
   const date = new Date();
 
   const getIdentifier = (entryData) => {
-    const identifier = selectIdentifier(entryData.keys());
+    const identifier = selectIdentifier(entryData.keySeq());
 
     if (identifier === undefined) {
       throw new Error("Collection must have a field name that is a valid entry identifier");
     }
 
-    return identifier;
+    return entryData.get(identifier);
   };
 
   const slug = template.replace(/\{\{([^\}]+)\}\}/g, (_, field) => {

--- a/src/backends/backend.js
+++ b/src/backends/backend.js
@@ -2,6 +2,7 @@ import { attempt, isError } from 'lodash';
 import { resolveFormat } from "Formats/formats";
 import { selectIntegration } from 'Reducers/integrations';
 import {
+  selectIdentifier,
   selectListMethod,
   selectEntrySlug,
   selectEntryPath,
@@ -45,15 +46,10 @@ const slugFormatter = (template = "{{slug}}", entryData, slugConfig) => {
   const date = new Date();
 
   const getIdentifier = (entryData) => {
-    const validIdentifierFields = ["title", "path"];
-    const identifiers = validIdentifierFields.map((field) =>
-      entryData.find((_, key) => key.toLowerCase().trim() === field)
-    );
-
-    const identifier = identifiers.find(ident => ident !== undefined);
+    const identifier = selectIdentifier(entryData.keys());
 
     if (identifier === undefined) {
-      throw new Error(`Collection must have a field name that is a valid entry identifier. Please add one of these fields: ${ validIdentifierFields }`);
+      throw new Error("Collection must have a field name that is a valid entry identifier");
     }
 
     return identifier;

--- a/src/backends/backend.js
+++ b/src/backends/backend.js
@@ -53,7 +53,7 @@ const slugFormatter = (template = "{{slug}}", entryData, slugConfig) => {
     const identifier = identifiers.find(ident => ident !== undefined);
 
     if (identifier === undefined) {
-      throw new Error("Collection must have a field name that is a valid entry identifier");
+      throw new Error(`Collection must have a field name that is a valid entry identifier. Please add one of these fields: ${ validIdentifierFields }`);
     }
 
     return identifier;

--- a/src/backends/backend.js
+++ b/src/backends/backend.js
@@ -47,7 +47,7 @@ const slugFormatter = (collection, entryData, slugConfig) => {
   const date = new Date();
 
   const identifier = entryData.get(selectIdentifier(collection));
-  if (identifier === undefined) {
+  if (!identifier) {
     throw new Error("Collection must have a field name that is a valid entry identifier");
   }
 

--- a/src/constants/fieldInference.js
+++ b/src/constants/fieldInference.js
@@ -1,6 +1,8 @@
 import React from 'react';
 
 /* eslint-disable */
+export const IDENTIFIER_FIELDS = ['title', 'path'];
+
 export const INFERABLE_FIELDS = {
   title: {
     type: 'string',

--- a/src/reducers/collections.js
+++ b/src/reducers/collections.js
@@ -34,7 +34,8 @@ function validateCollection(configCollection) {
     files,
     format,
     extension,
-    frontmatter_delimiter: delimiter
+    frontmatter_delimiter: delimiter,
+    fields,
   } = configCollection.toJS();
 
   if (!folder && !files) {
@@ -51,7 +52,21 @@ function validateCollection(configCollection) {
     // Cannot set custom delimiter without explicit and proper frontmatter format declaration
     throw new Error(`Please set a proper frontmatter format for collection "${name}" to use a custom delimiter. Supported frontmatter formats are yaml-frontmatter, toml-frontmatter, and json-frontmatter.`);
   }
+  if (selectIdentifier(fields.map(f => f.name)) === undefined) {
+    // Verify that the collection has a slug field.
+    // TODO: Verify only for folder-type collections.
+    throw new Error(`Collection "${name}" must have a field that is a valid entry identifier. Supported fields are ${validIdentifierFields.join(',')}`);
+  }
 }
+
+const validIdentifierFields = ["title", "path"];
+export const selectIdentifier = (entryData, collectionName) => {
+  const identifiers = validIdentifierFields.map((field) =>
+    entryData.find(key => key.toLowerCase().trim() === field)
+  );
+
+  return identifiers.find(ident => ident !== undefined);
+};
 
 const selectors = {
   [FOLDER]: {

--- a/src/reducers/collections.js
+++ b/src/reducers/collections.js
@@ -52,15 +52,14 @@ function validateCollection(configCollection) {
     // Cannot set custom delimiter without explicit and proper frontmatter format declaration
     throw new Error(`Please set a proper frontmatter format for collection "${name}" to use a custom delimiter. Supported frontmatter formats are yaml-frontmatter, toml-frontmatter, and json-frontmatter.`);
   }
-  if (selectIdentifier(fields.map(f => f.name)) === undefined) {
-    // Verify that the collection has a slug field.
-    // TODO: Verify only for folder-type collections.
+  if ((!!folder) && (selectIdentifier(fields.map(f => f.name)) === undefined)) {
+    // Verify that folder-type collections have a "slug"-type field.
     throw new Error(`Collection "${name}" must have a field that is a valid entry identifier. Supported fields are ${validIdentifierFields.join(',')}`);
   }
 }
 
 const validIdentifierFields = ["title", "path"];
-export const selectIdentifier = (entryData, collectionName) => {
+export const selectIdentifier = (entryData) => {
   const identifiers = validIdentifierFields.map((field) =>
     entryData.find(key => key.toLowerCase().trim() === field)
   );


### PR DESCRIPTION
This PR fixes #690 by verifying that folder-type collections have a valid title ("slug"-able) field at CMS load time, instead of when the user tries to save an entry. It also explains how to fix the error.