### PR TITLE
enable editorial workflow for test backend

### DIFF
--- a/example/config.yml
+++ b/example/config.yml
@@ -4,6 +4,8 @@ backend:
 display_url: https://example.com
 media_folder: "assets/uploads"
 
+publish_mode: editorial_workflow # optional, enables publishing workflow
+
 collections: # A list of collections the CMS should be able to edit
   - name: "posts" # Used in routes, ie.: /admin/collections/:slug/edit
     label: "Posts" # Used in the UI

--- a/src/backends/test-repo/implementation.js
+++ b/src/backends/test-repo/implementation.js
@@ -1,8 +1,11 @@
 import { remove, attempt, isError } from 'lodash';
 import uuid from 'uuid/v4';
+import { EDITORIAL_WORKFLOW, status } from 'Constants/publishModes';
+import { EditorialWorkflowError } from 'ValueObjects/errors';
 import AuthenticationPage from './AuthenticationPage';
 
 window.repoFiles = window.repoFiles || {};
+window.repoFilesUnpublished = window.repoFilesUnpublished || [];
 
 function getFile(path) {
   const segments = path.split('/');
@@ -78,20 +81,89 @@ export default class TestRepo {
     });
   }
 
-  persistEntry(entry, mediaFiles = [], options) {
+  unpublishedEntries() {
+    return Promise.resolve(window.repoFilesUnpublished);
+  }
+
+  unpublishedEntry(collection, slug) {
+    const entry = window.repoFilesUnpublished.find(e => (
+      e.metaData.collection === collection.get('name') && e.slug === slug
+    ));
+    if (!entry) {
+      return Promise.reject(new EditorialWorkflowError('content is not under editorial workflow', true));
+    }
+    return Promise.resolve(entry);
+  }
+
+  deleteUnpublishedEntry(collection, slug) {
+    const unpubStore = window.repoFilesUnpublished;
+    const existingEntryIndex = unpubStore.findIndex(e => (
+      e.metaData.collection === collection && e.slug === slug
+    ));
+    unpubStore.splice(existingEntryIndex, 1);
+    return Promise.resolve()
+  }
+
+  persistEntry({ path, raw, slug }, mediaFiles = [], options = {}) {
+    if (options.mode === EDITORIAL_WORKFLOW) {
+      const unpubStore = window.repoFilesUnpublished;
+      const existingEntryIndex = unpubStore.findIndex(e => e.file.path === path);
+      if (existingEntryIndex >= 0) {
+        const unpubEntry = { ...unpubStore[existingEntryIndex], data: raw };
+        unpubEntry.title = options.parsedData && options.parsedData.title;
+        unpubEntry.description = options.parsedData && options.parsedData.description;
+        unpubStore.splice(existingEntryIndex, 1, unpubEntry);
+      } else {
+        const unpubEntry = {
+          data: raw,
+          file: {
+            path,
+          },
+          metaData: {
+            collection: options.collectionName,
+            status: status.first(),
+            title: options.parsedData && options.parsedData.title,
+            description: options.parsedData && options.parsedData.description,
+          },
+          slug,
+        };
+        unpubStore.push(unpubEntry);
+      }
+      return Promise.resolve();
+    }
+
     const newEntry = options.newEntry || false;
-    const folder = entry.path.substring(0, entry.path.lastIndexOf('/'));
-    const fileName = entry.path.substring(entry.path.lastIndexOf('/') + 1);
+    const folder = path.substring(0, path.lastIndexOf('/'));
+    const fileName = path.substring(path.lastIndexOf('/') + 1);
     window.repoFiles[folder] = window.repoFiles[folder] || {};
     window.repoFiles[folder][fileName] = window.repoFiles[folder][fileName] || {};
     if (newEntry) {
-      window.repoFiles[folder][fileName] = { content: entry.raw };
+      window.repoFiles[folder][fileName] = { content: raw };
     } else {
-      window.repoFiles[folder][fileName].content = entry.raw;
+      window.repoFiles[folder][fileName].content = raw;
     }
     return Promise.resolve();
   }
 
+  updateUnpublishedEntryStatus(collection, slug, newStatus) {
+    const unpubStore = window.repoFilesUnpublished;
+    const entryIndex = unpubStore.findIndex(e => (
+      e.metaData.collection === collection && e.slug === slug
+    ));
+    unpubStore[entryIndex].metaData.status = newStatus;
+    return Promise.resolve();
+  }
+
+  publishUnpublishedEntry(collection, slug) {
+    const unpubStore = window.repoFilesUnpublished;
+    const unpubEntryIndex = unpubStore.findIndex(e => (
+      e.metaData.collection === collection && e.slug === slug
+    ));
+    const unpubEntry = unpubStore[unpubEntryIndex];
+    const entry = { raw: unpubEntry.data, slug: unpubEntry.slug, path: unpubEntry.file.path };
+    unpubStore.splice(unpubEntryIndex, 1);
+    return this.persistEntry(entry);
+  }
   getMedia() {
     return Promise.resolve(this.assets);
   }


### PR DESCRIPTION
Provides simple, in-memory editorial workflow support for the test backend.

Fixes #267.