### PR TITLE
Add markdown editor toolbar customization

### DIFF
--- a/src/components/EditorWidgets/Markdown/MarkdownControl/RawEditor/index.js
+++ b/src/components/EditorWidgets/Markdown/MarkdownControl/RawEditor/index.js
@@ -1,4 +1,5 @@
 import PropTypes from 'prop-types';
+import ImmutablePropTypes from 'react-immutable-proptypes';
 import React from 'react';
 import { Editor as Slate } from 'slate-react';
 import Plain from 'slate-plain-serializer';
@@ -50,12 +51,13 @@ export default class RawEditor extends React.Component {
   };
 
   render() {
-    const { className } = this.props;
+    const { className, field } = this.props;
     return (
       <div className="nc-rawEditor-rawWrapper">
         <div className="nc-visualEditor-editorControlBar">
           <Toolbar
             onToggleMode={this.handleToggleMode}
+            buttons={field.get('buttons')}
             className="nc-markdownWidget-toolbarRaw"
             disabled
             rawMode
@@ -77,4 +79,5 @@ RawEditor.propTypes = {
   onMode: PropTypes.func.isRequired,
   className: PropTypes.string.isRequired,
   value: PropTypes.string,
+  field: ImmutablePropTypes.map
 };

--- a/src/components/EditorWidgets/Markdown/MarkdownControl/Toolbar/Toolbar.js
+++ b/src/components/EditorWidgets/Markdown/MarkdownControl/Toolbar/Toolbar.js
@@ -17,6 +17,7 @@ export default class Toolbar extends React.Component {
     getAsset: PropTypes.func,
     disabled: PropTypes.bool,
     className: PropTypes.string,
+    buttons: ImmutablePropTypes.list
   };
 
   constructor(props) {
@@ -26,7 +27,7 @@ export default class Toolbar extends React.Component {
     };
   }
 
-  render() {
+  getToolbarButtonsList() {
     const {
       onMarkClick,
       onBlockClick,
@@ -34,17 +35,63 @@ export default class Toolbar extends React.Component {
       selectionHasMark,
       selectionHasBlock,
       selectionHasLink,
+      disabled,
+      buttons
+    } = this.props;
+
+    const toolbarButtons = [
+      { type: 'bold', label: 'Bold', icon: 'bold', onClick: onMarkClick, isActive: selectionHasMark, disabled },
+      { type: 'italic', label: 'Italic', icon: 'italic', onClick: onMarkClick, isActive: selectionHasMark, disabled },
+      { type: 'code', label: 'Code', icon: 'code', onClick: onMarkClick, isActive: selectionHasMark, disabled },
+      { type: 'link', label: 'Link', icon: 'link', onClick: onLinkClick, isActive: selectionHasLink, disabled },
+      { type: 'heading-one', label: 'Header 1', icon: 'h1', onClick: onBlockClick, isActive: selectionHasBlock, disabled },
+      { type: 'heading-two', label: 'Header 2', icon: 'h2', onClick: onBlockClick, isActive: selectionHasBlock, disabled },
+      { type: 'quote', label: 'Quote', icon: 'quote', onClick: onBlockClick, isActive: selectionHasBlock, disabled },
+      { type: 'code', label: 'Code Block', icon: 'code-block', onClick: onBlockClick, isActive: selectionHasBlock, disabled },
+      { type: 'bulleted-list', label: 'Bulleted List', icon: 'list-bulleted', onClick: onBlockClick, isActive: selectionHasBlock, disabled },
+      { type: 'numbered-list', label: 'Numbered List', icon: 'list-numbered', onClick: onBlockClick, isActive: selectionHasBlock, disabled }
+    ];
+
+    return buttons === undefined ? toolbarButtons : toolbarButtons.filter(button => buttons.includes(button.type));
+  }
+
+  renderToolbarButton(button) {
+    const { type, label, icon, onClick, isActive, disabled } = button;
+    return <ToolbarButton key={label} type={type} label={label} icon={icon} onClick={onClick} isActive={isActive} disabled={disabled}/>;
+  }
+
+  renderToolbarDropdown() {
+    const { plugins, disabled, onSubmit } = this.props;
+
+    return (
+      <div className="nc-toolbar-dropdown">
+        <Dropdown
+          dropdownTopOverlap="36px"
+          button={
+            <ToolbarButton
+              label="Add Component"
+              icon="add-with"
+              onClick={this.handleComponentsMenuToggle}
+              disabled={disabled}
+            />
+          }
+        >
+          {plugins && plugins.toList().map((plugin, idx) => (
+            <DropdownItem key={idx} label={plugin.get('label')} onClick={() => onSubmit(plugin.get('id'))} />
+          ))}
+        </Dropdown>
+      </div>
+    );
+  }
+
+  renderToolbarToggle() {
+    const {
       onToggleMode,
       rawMode,
       plugins,
-      onAddAsset,
-      getAsset,
       disabled,
-      onSubmit,
-      className,
+      className
     } = this.props;
-
-    const { activePlugin } = this.state;
 
     /**
      * Because the toggle labels change font weight for active/inactive state,
@@ -57,132 +104,43 @@ export default class Toolbar extends React.Component {
     const toggleOnLabelWidth = '70px';
 
     return (
-      <div className={c(className, 'nc-toolbar-Toolbar')}>
+      <div className="nc-markdownWidget-toolbar-toggle">
+        <span
+          style={{ width: toggleOffLabelWidth }}
+          className={c(
+            'nc-markdownWidget-toolbar-toggle-label',
+            { 'nc-markdownWidget-toolbar-toggle-label-active': !rawMode },
+          )}
+        >
+          {toggleOffLabel}
+        </span>
+        <Toggle
+          active={rawMode}
+          onChange={onToggleMode}
+          className="nc-markdownWidget-toolbar-toggle"
+          classNameBackground="nc-markdownWidget-toolbar-toggle-background"
+        />
+        <span
+          style={{ width: toggleOnLabelWidth }}
+          className={c(
+            'nc-markdownWidget-toolbar-toggle-label',
+            { 'nc-markdownWidget-toolbar-toggle-label-active': rawMode },
+          )}
+        >
+          {toggleOnLabel}
+        </span>
+      </div>
+    );
+  }
+
+  render() {
+    return (
+      <div className={c(this.props.className, 'nc-toolbar-Toolbar')}>
         <div>
-          <ToolbarButton
-            type="bold"
-            label="Bold"
-            icon="bold"
-            onClick={onMarkClick}
-            isActive={selectionHasMark}
-            disabled={disabled}
-          />
-          <ToolbarButton
-            type="italic"
-            label="Italic"
-            icon="italic"
-            onClick={onMarkClick}
-            isActive={selectionHasMark}
-            disabled={disabled}
-          />
-          <ToolbarButton
-            type="code"
-            label="Code"
-            icon="code"
-            onClick={onMarkClick}
-            isActive={selectionHasMark}
-            disabled={disabled}
-          />
-          <ToolbarButton
-            type="link"
-            label="Link"
-            icon="link"
-            onClick={onLinkClick}
-            isActive={selectionHasLink}
-            disabled={disabled}
-          />
-          <ToolbarButton
-            type="heading-one"
-            label="Header 1"
-            icon="h1"
-            onClick={onBlockClick}
-            isActive={selectionHasBlock}
-            disabled={disabled}
-          />
-          <ToolbarButton
-            type="heading-two"
-            label="Header 2"
-            icon="h2"
-            onClick={onBlockClick}
-            isActive={selectionHasBlock}
-            disabled={disabled}
-          />
-          <ToolbarButton
-            type="quote"
-            label="Quote"
-            icon="quote"
-            onClick={onBlockClick}
-            isActive={selectionHasBlock}
-            disabled={disabled}
-          />
-          <ToolbarButton
-            type="code"
-            label="Code Block"
-            icon="code-block"
-            onClick={onBlockClick}
-            isActive={selectionHasBlock}
-            disabled={disabled}
-          />
-          <ToolbarButton
-            type="bulleted-list"
-            label="Bulleted List"
-            icon="list-bulleted"
-            onClick={onBlockClick}
-            isActive={selectionHasBlock}
-            disabled={disabled}
-          />
-          <ToolbarButton
-            type="numbered-list"
-            label="Numbered List"
-            icon="list-numbered"
-            onClick={onBlockClick}
-            isActive={selectionHasBlock}
-            disabled={disabled}
-          />
-          <div className="nc-toolbar-dropdown">
-            <Dropdown
-              dropdownTopOverlap="36px"
-              button={
-                <ToolbarButton
-                  label="Add Component"
-                  icon="add-with"
-                  onClick={this.handleComponentsMenuToggle}
-                  disabled={disabled}
-                />
-              }
-            >
-              {plugins && plugins.toList().map((plugin, idx) => (
-                <DropdownItem key={idx} label={plugin.get('label')} onClick={() => onSubmit(plugin.get('id'))} />
-              ))}
-            </Dropdown>
-          </div>
+          {this.getToolbarButtonsList().map((toolbarButton) => this.renderToolbarButton(toolbarButton))}
+          {this.renderToolbarDropdown()}
         </div>
-        <div className="nc-markdownWidget-toolbar-toggle">
-          <span
-            style={{ width: toggleOffLabelWidth }}
-            className={c(
-              'nc-markdownWidget-toolbar-toggle-label',
-              { 'nc-markdownWidget-toolbar-toggle-label-active': !rawMode },
-            )}
-          >
-            {toggleOffLabel}
-          </span>
-          <Toggle
-            active={rawMode}
-            onChange={onToggleMode}
-            className="nc-markdownWidget-toolbar-toggle"
-            classNameBackground="nc-markdownWidget-toolbar-toggle-background"
-          />
-          <span
-            style={{ width: toggleOnLabelWidth }}
-            className={c(
-              'nc-markdownWidget-toolbar-toggle-label',
-              { 'nc-markdownWidget-toolbar-toggle-label-active': rawMode },
-            )}
-          >
-            {toggleOnLabel}
-          </span>
-        </div>
+        {this.renderToolbarToggle()}
       </div>
     );
   }

--- a/src/components/EditorWidgets/Markdown/MarkdownControl/Toolbar/Toolbar.js
+++ b/src/components/EditorWidgets/Markdown/MarkdownControl/Toolbar/Toolbar.js
@@ -27,7 +27,12 @@ export default class Toolbar extends React.Component {
     };
   }
 
-  getToolbarButtonsList() {
+  isHidden = button => {
+    const { buttons } = this.props;
+    return List.isList(buttons) ? !buttons.includes(button) : false;
+  }
+
+  render() {
     const {
       onMarkClick,
       onBlockClick,
@@ -35,63 +40,17 @@ export default class Toolbar extends React.Component {
       selectionHasMark,
       selectionHasBlock,
       selectionHasLink,
-      disabled,
-      buttons
-    } = this.props;
-
-    const toolbarButtons = [
-      { type: 'bold', label: 'Bold', icon: 'bold', onClick: onMarkClick, isActive: selectionHasMark, disabled },
-      { type: 'italic', label: 'Italic', icon: 'italic', onClick: onMarkClick, isActive: selectionHasMark, disabled },
-      { type: 'code', label: 'Code', icon: 'code', onClick: onMarkClick, isActive: selectionHasMark, disabled },
-      { type: 'link', label: 'Link', icon: 'link', onClick: onLinkClick, isActive: selectionHasLink, disabled },
-      { type: 'heading-one', label: 'Header 1', icon: 'h1', onClick: onBlockClick, isActive: selectionHasBlock, disabled },
-      { type: 'heading-two', label: 'Header 2', icon: 'h2', onClick: onBlockClick, isActive: selectionHasBlock, disabled },
-      { type: 'quote', label: 'Quote', icon: 'quote', onClick: onBlockClick, isActive: selectionHasBlock, disabled },
-      { type: 'code', label: 'Code Block', icon: 'code-block', onClick: onBlockClick, isActive: selectionHasBlock, disabled },
-      { type: 'bulleted-list', label: 'Bulleted List', icon: 'list-bulleted', onClick: onBlockClick, isActive: selectionHasBlock, disabled },
-      { type: 'numbered-list', label: 'Numbered List', icon: 'list-numbered', onClick: onBlockClick, isActive: selectionHasBlock, disabled }
-    ];
-
-    return buttons === undefined ? toolbarButtons : toolbarButtons.filter(button => buttons.includes(button.type));
-  }
-
-  renderToolbarButton(button) {
-    const { type, label, icon, onClick, isActive, disabled } = button;
-    return <ToolbarButton key={label} type={type} label={label} icon={icon} onClick={onClick} isActive={isActive} disabled={disabled}/>;
-  }
-
-  renderToolbarDropdown() {
-    const { plugins, disabled, onSubmit } = this.props;
-
-    return (
-      <div className="nc-toolbar-dropdown">
-        <Dropdown
-          dropdownTopOverlap="36px"
-          button={
-            <ToolbarButton
-              label="Add Component"
-              icon="add-with"
-              onClick={this.handleComponentsMenuToggle}
-              disabled={disabled}
-            />
-          }
-        >
-          {plugins && plugins.toList().map((plugin, idx) => (
-            <DropdownItem key={idx} label={plugin.get('label')} onClick={() => onSubmit(plugin.get('id'))} />
-          ))}
-        </Dropdown>
-      </div>
-    );
-  }
-
-  renderToolbarToggle() {
-    const {
       onToggleMode,
       rawMode,
       plugins,
+      onAddAsset,
+      getAsset,
       disabled,
-      className
+      onSubmit,
+      className,
     } = this.props;
+
+    const { activePlugin } = this.state;
 
     /**
      * Because the toggle labels change font weight for active/inactive state,
@@ -104,43 +63,142 @@ export default class Toolbar extends React.Component {
     const toggleOnLabelWidth = '70px';
 
     return (
-      <div className="nc-markdownWidget-toolbar-toggle">
-        <span
-          style={{ width: toggleOffLabelWidth }}
-          className={c(
-            'nc-markdownWidget-toolbar-toggle-label',
-            { 'nc-markdownWidget-toolbar-toggle-label-active': !rawMode },
-          )}
-        >
-          {toggleOffLabel}
-        </span>
-        <Toggle
-          active={rawMode}
-          onChange={onToggleMode}
-          className="nc-markdownWidget-toolbar-toggle"
-          classNameBackground="nc-markdownWidget-toolbar-toggle-background"
-        />
-        <span
-          style={{ width: toggleOnLabelWidth }}
-          className={c(
-            'nc-markdownWidget-toolbar-toggle-label',
-            { 'nc-markdownWidget-toolbar-toggle-label-active': rawMode },
-          )}
-        >
-          {toggleOnLabel}
-        </span>
-      </div>
-    );
-  }
-
-  render() {
-    return (
-      <div className={c(this.props.className, 'nc-toolbar-Toolbar')}>
+      <div className={c(className, 'nc-toolbar-Toolbar')}>
         <div>
-          {this.getToolbarButtonsList().map((toolbarButton) => this.renderToolbarButton(toolbarButton))}
-          {this.renderToolbarDropdown()}
+          <ToolbarButton
+            type="bold"
+            label="Bold"
+            icon="bold"
+            onClick={onMarkClick}
+            isActive={selectionHasMark}
+            isHidden={this.isHidden('bold')}
+            disabled={disabled}
+          />
+          <ToolbarButton
+            type="italic"
+            label="Italic"
+            icon="italic"
+            onClick={onMarkClick}
+            isActive={selectionHasMark}
+            isHidden={this.isHidden('italic')}
+            disabled={disabled}
+          />
+          <ToolbarButton
+            type="code"
+            label="Code"
+            icon="code"
+            onClick={onMarkClick}
+            isActive={selectionHasMark}
+            isHidden={this.isHidden('code')}
+            disabled={disabled}
+          />
+          <ToolbarButton
+            type="link"
+            label="Link"
+            icon="link"
+            onClick={onLinkClick}
+            isActive={selectionHasLink}
+            isHidden={this.isHidden('link')}
+            disabled={disabled}
+          />
+          <ToolbarButton
+            type="heading-one"
+            label="Header 1"
+            icon="h1"
+            onClick={onBlockClick}
+            isActive={selectionHasBlock}
+            isHidden={this.isHidden('heading-one')}
+            disabled={disabled}
+          />
+          <ToolbarButton
+            type="heading-two"
+            label="Header 2"
+            icon="h2"
+            onClick={onBlockClick}
+            isActive={selectionHasBlock}
+            isHidden={this.isHidden('heading-two')}
+            disabled={disabled}
+          />
+          <ToolbarButton
+            type="quote"
+            label="Quote"
+            icon="quote"
+            onClick={onBlockClick}
+            isActive={selectionHasBlock}
+            isHidden={this.isHidden('quote')}
+            disabled={disabled}
+          />
+          <ToolbarButton
+            type="code"
+            label="Code Block"
+            icon="code-block"
+            onClick={onBlockClick}
+            isActive={selectionHasBlock}
+            isHidden={this.isHidden('code-block')}
+            disabled={disabled}
+          />
+          <ToolbarButton
+            type="bulleted-list"
+            label="Bulleted List"
+            icon="list-bulleted"
+            onClick={onBlockClick}
+            isActive={selectionHasBlock}
+            isHidden={this.isHidden('bulleted-list')}
+            disabled={disabled}
+          />
+          <ToolbarButton
+            type="numbered-list"
+            label="Numbered List"
+            icon="list-numbered"
+            onClick={onBlockClick}
+            isActive={selectionHasBlock}
+            isHidden={this.isHidden('numbered-list')}
+            disabled={disabled}
+          />
+          <div className="nc-toolbar-dropdown">
+            <Dropdown
+              dropdownTopOverlap="36px"
+              button={
+                <ToolbarButton
+                  label="Add Component"
+                  icon="add-with"
+                  onClick={this.handleComponentsMenuToggle}
+                  disabled={disabled}
+                />
+              }
+            >
+              {plugins && plugins.toList().map((plugin, idx) => (
+                <DropdownItem key={idx} label={plugin.get('label')} onClick={() => onSubmit(plugin.get('id'))} />
+              ))}
+            </Dropdown>
+          </div>
         </div>
-        {this.renderToolbarToggle()}
+        <div className="nc-markdownWidget-toolbar-toggle">
+          <span
+            style={{ width: toggleOffLabelWidth }}
+            className={c(
+              'nc-markdownWidget-toolbar-toggle-label',
+              { 'nc-markdownWidget-toolbar-toggle-label-active': !rawMode },
+            )}
+          >
+            {toggleOffLabel}
+          </span>
+          <Toggle
+            active={rawMode}
+            onChange={onToggleMode}
+            className="nc-markdownWidget-toolbar-toggle"
+            classNameBackground="nc-markdownWidget-toolbar-toggle-background"
+          />
+          <span
+            style={{ width: toggleOnLabelWidth }}
+            className={c(
+              'nc-markdownWidget-toolbar-toggle-label',
+              { 'nc-markdownWidget-toolbar-toggle-label-active': rawMode },
+            )}
+          >
+            {toggleOnLabel}
+          </span>
+        </div>
       </div>
     );
   }

--- a/src/components/EditorWidgets/Markdown/MarkdownControl/Toolbar/ToolbarButton.js
+++ b/src/components/EditorWidgets/Markdown/MarkdownControl/Toolbar/ToolbarButton.js
@@ -3,8 +3,12 @@ import React from 'react';
 import c from 'classnames';
 import { Icon } from 'UI';
 
-const ToolbarButton = ({ type, label, icon, onClick, isActive, disabled }) => {
+const ToolbarButton = ({ type, label, icon, onClick, isActive, isHidden, disabled }) => {
   const active = isActive && type && isActive(type);
+
+  if (isHidden) {
+    return null;
+  }
 
   return (
     <button

--- a/src/components/EditorWidgets/Markdown/MarkdownControl/VisualEditor/index.js
+++ b/src/components/EditorWidgets/Markdown/MarkdownControl/VisualEditor/index.js
@@ -1,4 +1,5 @@
 import PropTypes from 'prop-types';
+import ImmutablePropTypes from 'react-immutable-proptypes';
 import React, { Component } from 'react';
 import { get, isEmpty, debounce } from 'lodash';
 import { Map } from 'immutable';
@@ -33,6 +34,7 @@ export default class Editor extends Component {
     onMode: PropTypes.func.isRequired,
     className: PropTypes.string.isRequired,
     value: PropTypes.string,
+    field: ImmutablePropTypes.map
   };
 
   constructor(props) {
@@ -189,7 +191,7 @@ export default class Editor extends Component {
   }
 
   render() {
-    const { onAddAsset, getAsset, className } = this.props;
+    const { onAddAsset, getAsset, className, field } = this.props;
 
     return (
       <div className="nc-visualEditor-wrapper">
@@ -206,6 +208,7 @@ export default class Editor extends Component {
             onSubmit={this.handlePluginAdd}
             onAddAsset={onAddAsset}
             getAsset={getAsset}
+            buttons={field.get('buttons')}
           />
         </div>
         <Slate

--- a/src/components/EditorWidgets/Markdown/MarkdownControl/index.js
+++ b/src/components/EditorWidgets/Markdown/MarkdownControl/index.js
@@ -45,6 +45,7 @@ export default class MarkdownControl extends React.Component {
       getAsset,
       value,
       classNameWrapper,
+      field
     } = this.props;
 
     const { mode } = this.state;
@@ -57,6 +58,7 @@ export default class MarkdownControl extends React.Component {
           getAsset={getAsset}
           className={classNameWrapper}
           value={value}
+          field={field}
         />
       </div>
     );
@@ -69,6 +71,7 @@ export default class MarkdownControl extends React.Component {
           getAsset={getAsset}
           className={classNameWrapper}
           value={value}
+          field={field}
         />
       </div>
     );

--- a/website/site/content/docs/widgets/markdown.md
+++ b/website/site/content/docs/widgets/markdown.md
@@ -14,7 +14,7 @@ The markdown widget provides a full fledged text editor - which is based on [sla
 - **Data type:** markdown
 - **Options:**
   - `default`: accepts markdown content
-  - `buttons`: a list of string representing the buttons to display ('bold', 'italic', 'code', 'link', 'heading-one', 'heading-two', 'quote', 'code', 'bulleted-list', 'numbered-list'). If this options is missing, all the buttons are display.
+  - `buttons`: a list of string representing the buttons to display ('bold', 'italic', 'code', 'link', 'heading-one', 'heading-two', 'quote', 'code-block', 'bulleted-list', 'numbered-list'). If this options is missing, all the buttons are display.
 - **Example:**
 
   ```yaml

--- a/website/site/content/docs/widgets/markdown.md
+++ b/website/site/content/docs/widgets/markdown.md
@@ -14,6 +14,7 @@ The markdown widget provides a full fledged text editor - which is based on [sla
 - **Data type:** markdown
 - **Options:**
   - `default`: accepts markdown content
+  - `buttons`: a list of string representing the buttons to display ('bold', 'italic', 'code', 'link', 'heading-one', 'heading-two', 'quote', 'code', 'bulleted-list', 'numbered-list'). If this options is missing, all the buttons are display.
 - **Example:**
 
   ```yaml

--- a/website/site/content/docs/widgets/markdown.md
+++ b/website/site/content/docs/widgets/markdown.md
@@ -14,7 +14,7 @@ The markdown widget provides a full fledged text editor - which is based on [sla
 - **Data type:** markdown
 - **Options:**
   - `default`: accepts markdown content
-  - `buttons`: a list of string representing the buttons to display ('bold', 'italic', 'code', 'link', 'heading-one', 'heading-two', 'quote', 'code-block', 'bulleted-list', 'numbered-list'). If this options is missing, all the buttons are display.
+  - `buttons`: an array of strings representing the formatting buttons to display, all buttons shown by default. Buttons include: `bold`, `italic`, `code`, `link`, `heading-one`, `heading-two`, `quote`, `code-block`, `bulleted-list`, and `numbered-list`.
 - **Example:**
 
   ```yaml


### PR DESCRIPTION
# Add markdown editor toolbar customization #1194

**- Summary**

Add markdown toolbar buttons customization, based on conf file : 
```
- ...
- {label: "Markdown", name: "markdown", widget: "markdown", buttons: ["bold", "italic", "link"]}
- ...
```
**- Test plan**

If no `buttons` field is specified we display all the buttons otherwise we display the list.

**- Description for the changelog**

Add markdown editor toolbar customization
