### PR TITLE
Prevent Overwriting Files with Same Slug Names

### DIFF
--- a/src/backends/backend.js
+++ b/src/backends/backend.js
@@ -23,8 +23,6 @@ registerBackend('git-gateway', GitGatewayBackend);
 registerBackend('github', GitHubBackend);
 registerBackend('test-repo', TestRepoBackend);
 
-const overWriteError = new Error("Oops! Duplicate filename found. Please choose a unique name.")
-
 class LocalStorageAuthStore {
   storageKey = "netlify-cms-user";
 
@@ -235,17 +233,17 @@ class Backend {
     .then(this.entryWithFormat(collection, slug));
   }
 
-  checkOverwrite(collection, slug, path, entryDraft) {
+  async checkOverwrite(collection, slug, path, entryDraft) {
+    const errorMessage = "Oops, duplicate filename found. Please choose a unique name."
     const existingEntry = window.repoFilesUnpublished.find(e => {
       return e.metaData.collection === collection.get('name') && e.slug === slug;
     })
-    if (existingEntry) throw overWriteError;
-    return this.implementation.getEntry(collection, slug, path)
+    if (existingEntry) throw (new Error(errorMessage));
+    return await this.implementation.getEntry(collection, slug, path)
       .then(result => {
-        if (result.data !== undefined) throw overWriteError;
-        return {path, slug, raw: this.entryToRaw(collection, entryDraft.get("entry"))};
-      })
-      .catch(console.error);
+        if (result.data !== undefined) throw (new Error(errorMessage));
+        else return {path, slug, raw: this.entryToRaw(collection, entryDraft.get("entry"))};
+      });
   }
 
   async persistEntry(config, collection, entryDraft, MediaFiles, integrations, options = {}) {

--- a/src/backends/backend.js
+++ b/src/backends/backend.js
@@ -240,9 +240,9 @@ class Backend {
       return e.metaData.collection === collection.get('name') && e.slug === slug;
     })
     if (existingEntry) throw overWriteError;
-    return this.getEntry(collection, slug)
+    return this.implementation.getEntry(collection, slug, path)
       .then(result => {
-        if (result.data.title) throw overWriteError;
+        if (result.data !== undefined) throw overWriteError;
         return {path, slug, raw: this.entryToRaw(collection, entryDraft.get("entry"))};
       })
       .catch(console.error);

--- a/src/backends/backend.js
+++ b/src/backends/backend.js
@@ -240,12 +240,17 @@ class Backend {
       (error instanceof EditorialWorkflowError && error.notUnderEditorialWorkflow) ?
       Promise.resolve(false) : 
       Promise.reject(error)));
+
     if (existingEntry) throw (new Error(errorMessage));
-    return await this.implentation.getEntry(collection, slug, path)
+
+    const publishedEntry = await this.implementation.getEntry(collection, slug, path)
       .then(result => {
-        if (result.data !== undefined) throw (new Error(errorMessage));
-        else return {path, slug, raw: this.entryToRaw(collection, entryDraft.get("entry"))};
+        return result.data;
       });
+      
+    if (publishedEntry) throw (new Error(errorMessage));
+
+    return {path, slug, raw: this.entryToRaw(collection, entryDraft.get("entry"))};
   }
 
   async persistEntry(config, collection, entryDraft, MediaFiles, integrations, options = {}) {

--- a/src/backends/backend.js
+++ b/src/backends/backend.js
@@ -49,7 +49,7 @@ const getIdentifierKey = entryData => {
       return key.toLowerCase().trim() === field;
     });
   });
-  return keys.find(key => entryData.get(key) !== undefined);
+  return keys.find(key => key !== undefined);
 };
 
 const getIdentifier = entryData => {


### PR DESCRIPTION
Closes #1164.

Previously, when a file was added with the same title as an existing one and the slug equals title, the existing file is overwritten.

**- Summary**

This checks in `src/backends/backend.js` before the `entryObj` is created in `persistEntry` if there's an existing file with the same name. Throws an Error if there is. 

First, for `editorialWorkflow` mode, it checks in `window.repoFilesUnpublished` for preexisting entry. Next, it uses `this.implementation.getEntry`, checking if there's already a published entry in danger of being overwritten.

**- Test plan**
I created a file called `test`
<img width="869" alt="screen shot 2018-04-09 at 1 26 30 pm" src="https://user-images.githubusercontent.com/23248886/38512615-ac9eee06-3bf9-11e8-8517-1dd75d1194be.png">

Saved the file successfully, and checked that it was in workflow.
<img width="289" alt="screen shot 2018-04-09 at 1 27 32 pm" src="https://user-images.githubusercontent.com/23248886/38512661-d4d6fe86-3bf9-11e8-9068-56e0f12b8017.png">

Then created a new file, also called `test`, tried to save it, and--
<img width="813" alt="screen shot 2018-04-09 at 1 28 55 pm" src="https://user-images.githubusercontent.com/23248886/38512714-009ed958-3bfa-11e8-8b83-a5680c012455.png">

Then instead, saved it as `Test 2`. 
<img width="793" alt="screen shot 2018-04-09 at 1 30 00 pm" src="https://user-images.githubusercontent.com/23248886/38512809-409763c2-3bfa-11e8-9633-4618bbc16fba.png">

Then published it.
<img width="625" alt="screen shot 2018-04-09 at 1 30 19 pm" src="https://user-images.githubusercontent.com/23248886/38512843-58e350c6-3bfa-11e8-8a31-fe0b301cbe87.png">

Then created a new file, also called `Test 2`, and tried to save it, and --
<img width="833" alt="screen shot 2018-04-09 at 1 30 34 pm" src="https://user-images.githubusercontent.com/23248886/38512857-65fb4912-3bfa-11e8-94ad-466687fc726d.png">

Error stopped it. All files are safe.

<img width="619" alt="screen shot 2018-04-09 at 1 33 35 pm" src="https://user-images.githubusercontent.com/23248886/38512988-dfc0f486-3bfa-11e8-885f-707772233ca1.png">
<img width="284" alt="screen shot 2018-04-09 at 1 33 41 pm" src="https://user-images.githubusercontent.com/23248886/38512993-e2519f66-3bfa-11e8-8040-d6b01bb5a43a.png">





**- Description for the changelog**

Prevents file overwrite when encountering slug name collisions.

**- A picture of a cute animal (not mandatory but encouraged)**
Behold, a Fennec Fox at rest!
![fennec_fox](https://user-images.githubusercontent.com/23248886/38513190-69f18a3a-3bfb-11e8-91b8-89d16a9642d0.jpg)
