### PR TITLE
Allow typing in date widget

### DIFF
--- a/src/components/EditorWidgets/Date/DateControl.js
+++ b/src/components/EditorWidgets/Date/DateControl.js
@@ -34,13 +34,29 @@ export default class DateControl extends React.Component {
     }
   }
 
+  // Date is valid if datetime is a moment or Date object otherwise it's a string.
+  // Handle the empty case, if the user wants to empty the field.
+  isValid = datetime => (moment.isMoment(datetime) || datetime instanceof Date || datetime === '');
+
   handleChange = datetime => {
     const { onChange } = this.props;
-    // Set the date if the format is valid (moment or Date object otherwise datetime is a string).
-    if (moment.isMoment(datetime) || datetime instanceof Date) {
+
+    // Set the date only if the format is valid
+    if (this.isValid(datetime)) {
       const formattedValue = moment(datetime).format(this.format);
       onChange(formattedValue);
     }
+  };
+
+  onBlur = datetime => {
+    const { setInactiveStyle } = this.props;
+
+    // Warn the user if the date is invalid
+    if (!this.isValid(datetime)) {
+      window.alert('The date you entered is invalid.');
+    }
+
+    setInactiveStyle();
   };
 
   render() {
@@ -52,7 +68,7 @@ export default class DateControl extends React.Component {
         value={moment(value, format)}
         onChange={this.handleChange}
         onFocus={setActiveStyle}
-        onBlur={setInactiveStyle}
+        onBlur={this.onBlur}
         inputProps={{ className: classNameWrapper }}
       />
     );

--- a/src/components/EditorWidgets/Date/DateControl.js
+++ b/src/components/EditorWidgets/Date/DateControl.js
@@ -36,9 +36,8 @@ export default class DateControl extends React.Component {
 
   handleChange = datetime => {
     const { onChange } = this.props;
-    if (!this.format || datetime === '') {
-      onChange(datetime);
-    } else {
+    // Set the date if the format is valid (moment or Date object otherwise datetime is a string).
+    if (moment.isMoment(datetime) || datetime instanceof Date) {
       const formattedValue = moment(datetime).format(this.format);
       onChange(formattedValue);
     }

--- a/src/components/EditorWidgets/Date/DateControl.js
+++ b/src/components/EditorWidgets/Date/DateControl.js
@@ -49,11 +49,15 @@ export default class DateControl extends React.Component {
   };
 
   onBlur = datetime => {
-    const { setInactiveStyle } = this.props;
+    const { setInactiveStyle, onChange } = this.props;
 
-    // Warn the user if the date is invalid
     if (!this.isValid(datetime)) {
-      window.alert('The date you entered is invalid.');
+      const parsedDate = moment(datetime);
+
+      if (parsedDate.isValid()) {
+        const formattedValue = parsedDate.format(this.format);
+        onChange(formattedValue);
+      }
     }
 
     setInactiveStyle();

--- a/src/components/EditorWidgets/Date/DateControl.js
+++ b/src/components/EditorWidgets/Date/DateControl.js
@@ -57,6 +57,8 @@ export default class DateControl extends React.Component {
       if (parsedDate.isValid()) {
         const formattedValue = parsedDate.format(this.format);
         onChange(formattedValue);
+      } else {
+        window.alert('The date you entered is invalid.');
       }
     }
 

--- a/src/components/EditorWidgets/Date/DateControl.js
+++ b/src/components/EditorWidgets/Date/DateControl.js
@@ -36,13 +36,13 @@ export default class DateControl extends React.Component {
 
   // Date is valid if datetime is a moment or Date object otherwise it's a string.
   // Handle the empty case, if the user wants to empty the field.
-  isValid = datetime => (moment.isMoment(datetime) || datetime instanceof Date || datetime === '');
+  isValidDate = datetime => (moment.isMoment(datetime) || datetime instanceof Date || datetime === '');
 
   handleChange = datetime => {
     const { onChange } = this.props;
 
     // Set the date only if the format is valid
-    if (this.isValid(datetime)) {
+    if (this.isValidDate(datetime)) {
       const formattedValue = moment(datetime).format(this.format);
       onChange(formattedValue);
     }
@@ -51,7 +51,7 @@ export default class DateControl extends React.Component {
   onBlur = datetime => {
     const { setInactiveStyle, onChange } = this.props;
 
-    if (!this.isValid(datetime)) {
+    if (!this.isValidDate(datetime)) {
       const parsedDate = moment(datetime);
 
       if (parsedDate.isValid()) {


### PR DESCRIPTION
Fixes #1178 : Allow typing in date widget

**- Summary**

Allow typing in date widget by setting the date only if the format is valid

**- Test plan**

Test date widget behavior is ok

**- Description for the changelog**

Allow typing in date widget