### PR TITLE
Pre-sanitize slug portions individually

### DIFF
--- a/src/backends/backend.js
+++ b/src/backends/backend.js
@@ -59,7 +59,7 @@ const slugFormatter = (template = "{{slug}}", entryData, slugConfig) => {
     return identifier;
   };
 
-  const slug = template.replace(/\{\{([^\}]+)\}\}/g, (_, field) => {
+  const getFieldValue = (field) => {
     switch (field) {
       case "year":
         return date.getFullYear();
@@ -78,12 +78,17 @@ const slugFormatter = (template = "{{slug}}", entryData, slugConfig) => {
       default:
         return entryData.get(field, "").trim();
     }
-  })
-  // Convert slug to lower-case
-  .toLocaleLowerCase()
+  };
 
-  // Replace periods with dashes.
-  .replace(/[.]/g, '-');
+  const slug = template.replace(/\{\{([^\}]+)\}\}/g, (_, field) => {
+    return getFieldValue(field)
+
+    // Convert slug to lower-case
+    .toLocaleLowerCase()
+
+    // Replace periods with dashes.
+    .replace(/[.]/g, '-');
+  });
 
   return sanitizeSlug(slug, slugConfig);
 };


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines;
https://github.com/netlify/netlify-cms/blob/master/CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first three fields are mandatory:
-->

**- Summary**
Closes #1254.

Filename sanitation, in particular replacing periods with hifens and lowercasing, is applied to the whole slug. It should only be applied to the variable parts, such as {{slug}} or {{name-of-field}}.

If I explicitly add a period to the slug, I absolutely expect it to appear in the resulting filename, regardless of any encoding or sanitation preferences: title-of-my-article.en.md

Basically I would expect any value I hardcode in those slugs to take precedence over anything else.

cc @tech4him1 because you've worked on slug sanitation (#640)

<!--
Explain the **motivation** for making this change.
What existing problem does the pull request solve?
-->

**- Test plan**
Create a collection with something like {{title}}.{{i18nlanguage}}, where "title" and "i18nlanguage" are content fields, and ensure the resulting filename is be something like title-of-my-article.en.md.

<!--
Demonstrate the code is solid.
Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.
-->

**- Description for the changelog**
Keep periods and lettercase of explicitly defined file slugs
(risk of being a breaking change if site generators are relying on current pre-sanitation behavior with custom slugs)

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->