### PR TITLE
Add property key in EditorToolbar

### DIFF
--- a/src/components/Editor/EditorToolbar.js
+++ b/src/components/Editor/EditorToolbar.js
@@ -93,6 +93,7 @@ export default class EditorToolbar extends React.Component {
 
     return [
         <button
+          key="save-button"
           className="nc-entryEditor-toolbar-saveButton"
           onClick={() => hasChanged && onPersist()}
         >
@@ -100,6 +101,7 @@ export default class EditorToolbar extends React.Component {
         </button>,
         isNewEntry || !deleteLabel ? null
             : <button
+                key="delete-button"
                 className="nc-entryEditor-toolbar-deleteButton"
                 onClick={hasUnpublishedChanges ? onDeleteUnpublishedChanges : onDelete}
               >


### PR DESCRIPTION
**- Summary**

It simply remove this warning :
![image](https://user-images.githubusercontent.com/3051737/38755468-17424586-3f66-11e8-9c88-38ac6793cbe5.png)

**- Description for the changelog**

Add property key in EditorToolbar
