### PR TITLE
Display public_folder path in Media Library

### DIFF
--- a/src/components/MediaLibrary/MediaLibrary.js
+++ b/src/components/MediaLibrary/MediaLibrary.js
@@ -223,6 +223,7 @@ class MediaLibrary extends React.Component {
       page,
       isPaginating,
       privateUpload,
+      publicFolder,
     } = this.props;
     const { query, selectedFile } = this.state;
     const filteredFiles = forImage ? this.filterImages(files) : files;
@@ -320,7 +321,7 @@ class MediaLibrary extends React.Component {
                         : <div className="nc-mediaLibrary-cardImage"/>
                     }
                   </div>
-                  <p className="nc-mediaLibrary-cardText">{file.name}</p>
+                  <p className="nc-mediaLibrary-cardText">{publicFolder && `${publicFolder}/`}{file.name}</p>
                 </div>
               )
             }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines;
https://github.com/netlify/netlify-cms/blob/master/CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first three fields are mandatory:
-->

**- Summary**

It can be useful for content editors to see the path to uploaded media / files. I have added on the `public_folder` to the displayed filename.

This may not be desired for all users, maybe we can add an option in the config? 

<!--
Explain the **motivation** for making this change.
What existing problem does the pull request solve?
-->

**- Test plan**

Visual confirmation:

<img width="983" alt="screen shot 2018-04-18 at 9 22 26 am" src="https://user-images.githubusercontent.com/3147296/38904557-6b2a74f8-42ee-11e8-88c4-e98396fc5905.png">

<!--
Demonstrate the code is solid.
Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.
-->

**- Description for the changelog**

Display public_folder path in Media Library

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

**- A picture of a cute animal (not mandatory but encouraged)**

![wallaby-joey](https://user-images.githubusercontent.com/3147296/38904688-36655214-42ef-11e8-9943-e9bac1178af5.jpg)

