### PR TITLE
Website example reference - www.cupofdata.com

### DIFF
--- a/website/site/content/docs/examples.md
+++ b/website/site/content/docs/examples.md
@@ -13,3 +13,4 @@ Example | Tools | Type | Source | More info |
 [JAMstack Recipes](https://jamstack-cms.netlify.com) | Hugo, Azure | demo | [hlaueriksson/jamstack-cms](https://github.com/hlaueriksson/jamstack-cms) | [blog post](http://conductofcode.io/post/managing-content-for-a-jamstack-site-with-netlify-cms/)
 [The Ragasirtahk Blog](https://www.ragasirtahk.tk/) | Hugo | blog | [ragasirtahk/the-ragasirtahk-blog](https://github.com/ragasirtahk/the-ragasirtahk-blog) | [blog post](https://www.ragasirtahk.tk/2018/01/setting-up-netlify-cms-on-hugo/)
 [Forest Garden Wales](https://www.forestgarden.wales/) | Hugo | blog | [forestgardenwales/forestgarden.wales](https://github.com/forestgardenwales/forestgarden.wales) | [blog post](https://www.forestgarden.wales/blog/now-using-netlify-cms/)
+[Cup of Data](https://www.cupofdata.com/blog) | Gatsby | blog | [cupofdata/cupofdata.com](https://github.com/cupofdata/cupofdata.com) | -


### PR DESCRIPTION
☕️  Reference for [the cupofdata.com](https://cupofdata.com) site which uses the `Netlify CMS` with [Gatsby](https://www.gatsby.org) for various sections using the `git-gateway` backend with Markdown. We were [encouraged to share our site](https://www.netlifycms.org/docs/start-with-a-template/), hence the PR!

