### PR TITLE
fix github auth button icon alignment

### DIFF
--- a/src/backends/github/AuthenticationPage.css
+++ b/src/backends/github/AuthenticationPage.css
@@ -19,12 +19,11 @@
 
   padding: 0 30px;
   margin-top: -80px;
-  display: block;
+  display: flex;
+  align-items: center;
   position: relative;
 
   & .nc-icon {
-    display: flex;
-    align-items: center;
     margin-right: 18px;
   }
 }


### PR DESCRIPTION
Partial revert of #1227.

Fixes GitHub icon misalignment, regression from #1227.