### PR TITLE
WIP - Cursor API

### DIFF
--- a/src/actions/entries.js
+++ b/src/actions/entries.js
@@ -2,8 +2,7 @@ import { List } from 'immutable';
 import { actions as notifActions } from 'redux-notifications';
 import { serializeValues } from 'Lib/serializeEntryValues';
 import { currentBackend } from 'Backends/backend';
-import { getIntegrationProvider } from 'Integrations';
-import { getAsset, selectIntegration } from 'Reducers';
+import { getAsset } from 'Reducers';
 import { selectFields } from 'Reducers/collections';
 import { collectionEntriesCursorKey } from 'Reducers/cursors';
 import { validateCursor, invalidCursorError } from 'ValueObjects/Cursor';
@@ -251,10 +250,9 @@ export function loadEntries(collection, page = 0) {
     }
     const state = getState();
     const backend = currentBackend(state.config);
-    const integration = selectIntegration(state, collection.get('name'), 'listEntries');
-    const provider = integration ? getIntegrationProvider(state.integrations, backend.getToken, integration) : backend;
     dispatch(entriesLoading(collection));
-    provider.listEntries(collection, page)
+
+    backend.listEntries(collection, page)
     // Validate the cursor if it exists to ensure it has the correct
     // structure.
     .then(response => ((!response.cursor) || validateCursor(response.cursor)

--- a/src/actions/search.js
+++ b/src/actions/search.js
@@ -1,10 +1,4 @@
-import fuzzy from 'fuzzy';
 import { currentBackend } from 'Backends/backend';
-import { getIntegrationProvider } from 'Integrations';
-import { selectIntegration, selectEntries } from 'Reducers';
-import { selectInferedField } from 'Reducers/collections';
-import { WAIT_UNTIL_ACTION } from 'Redux/middleware/waitUntilAction';
-import { loadEntries, ENTRIES_SUCCESS } from './entries';
 
 /*
  * Contant Declarations
@@ -106,120 +100,28 @@ export function clearSearch() {
 export function searchEntries(searchTerm, page = 0) {
   return (dispatch, getState) => {
     const state = getState();
-    const allCollections = state.collections.keySeq().toArray();
-    const collections = allCollections.filter(collection => selectIntegration(state, collection, 'search'));
-    const integration = selectIntegration(state, collections[0], 'search');
-    if (!integration) {
-      localSearch(searchTerm, getState, dispatch);
-    } else {
-      const provider = getIntegrationProvider(state.integrations, currentBackend(state.config).getToken, integration);
-      dispatch(searchingEntries(searchTerm));
-      provider.search(collections, searchTerm, page).then(
-        response => dispatch(searchSuccess(searchTerm, response.entries, response.pagination)),
-        error => dispatch(searchFailure(searchTerm, error))
-      );
-    }
+    dispatch(searchingEntries(searchTerm));
+    const backend = currentBackend(state.config);
+    const collections = state.collections.valueSeq().toArray();
+    return backend.search(collections, searchTerm, page).then(
+      response => dispatch(searchSuccess(searchTerm, response.entries, response.pagination)),
+      error => dispatch(searchFailure(searchTerm, error))
+    );
   };
 }
 
 // Instead of searching for complete entries, query will search for specific fields
 // in specific collections and return raw data (no entries).
-export function query(namespace, collection, searchFields, searchTerm) {
+export function query(namespace, collectionName, searchFields, searchTerm) {
   return (dispatch, getState) => {
     const state = getState();
-    const integration = selectIntegration(state, collection, 'search');
-    dispatch(querying(namespace, collection, searchFields, searchTerm));
-    if (!integration) {
-      localQuery(namespace, collection, searchFields, searchTerm, state, dispatch);
-    } else {
-      const provider = getIntegrationProvider(state.integrations, currentBackend(state.config).getToken, integration);
-      provider.searchBy(searchFields.map(f => `data.${ f }`), collection, searchTerm).then(
-        response => dispatch(querySuccess(namespace, collection, searchFields, searchTerm, response)),
-        error => dispatch(queryFailure(namespace, collection, searchFields, searchTerm, error))
-      );
-    }
+    dispatch(querying(namespace, collectionName, searchFields, searchTerm));
+    const backend = currentBackend(state.config);
+    const collection = state.collections.find(collection => collection.get('name') === collectionName);
+    return backend.query(collection, searchFields, searchTerm)
+      .then(
+      response => dispatch(querySuccess(namespace, collection, searchFields, searchTerm, response)),
+      error => dispatch(queryFailure(namespace, collection, searchFields, searchTerm, error)),
+    );
   };
-}
-
-// Local Query & Search functions
-
-function localSearch(searchTerm, getState, dispatch) {
-  return (function acc(localResults = { entries: [] }) {
-    function processCollection(collection, collectionKey) {
-      const state = getState();
-      if (state.entries.hasIn(['pages', collectionKey, 'ids'])) {
-        const searchFields = [
-          selectInferedField(collection, 'title'),
-          selectInferedField(collection, 'shortTitle'),
-          selectInferedField(collection, 'author'),
-        ];
-        const collectionEntries = selectEntries(state, collectionKey).toJS();
-        const filteredEntries = fuzzy.filter(searchTerm, collectionEntries, {
-          extract: entry => searchFields.reduce((acc, field) => {
-            const f = entry.data[field];
-            return f ? `${ acc } ${ f }` : acc;
-          }, ""),
-        }).filter(entry => entry.score > 5);
-        localResults[collectionKey] = true;
-        localResults.entries = localResults.entries.concat(filteredEntries);
-        
-        const returnedKeys = Object.keys(localResults);
-        const allCollections = state.collections.keySeq().toArray();
-        if (allCollections.every(v => returnedKeys.indexOf(v) !== -1)) {
-          const sortedResults = localResults.entries.sort((a, b) => {
-            if (a.score > b.score) return -1;
-            if (a.score < b.score) return 1;
-            return 0;
-          }).map(f => f.original);
-          if (allCollections.size > 3 || localResults.entries.length > 30) {
-            console.warn('The Netlify CMS is currently using a Built-in search.' +
-            '\nWhile this works great for small sites, bigger projects might benefit from a separate search integration.' + 
-            '\nPlease refer to the documentation for more information');
-          }
-          dispatch(searchSuccess(searchTerm, sortedResults, 0));
-        }
-      } else {
-        // Collection entries aren't loaded yet.
-        // Dispatch loadEntries and wait before redispatching this action again.
-        dispatch({
-          type: WAIT_UNTIL_ACTION,
-          predicate: action => (action.type === ENTRIES_SUCCESS && action.payload.collection === collectionKey),
-          run: () => processCollection(collection, collectionKey),
-        });
-        dispatch(loadEntries(collection));
-      }
-    }
-    getState().collections.forEach(processCollection);
-  }());
-}
-
-
-function localQuery(namespace, collection, searchFields, searchTerm, state, dispatch) {
-  // Check if entries in this collection were already loaded
-  if (state.entries.hasIn(['pages', collection, 'ids'])) {
-    const entries = selectEntries(state, collection).toJS();
-    const filteredEntries = fuzzy.filter(searchTerm, entries, {
-      extract: entry => searchFields.reduce((acc, field) => {
-        const f = entry.data[field];
-        return f ? `${ acc } ${ f }` : acc;
-      }, ""),
-    }).filter(entry => entry.score > 5);
-
-    const resultObj = {
-      query: searchTerm,
-      hits: [],
-    };
-
-    resultObj.hits = filteredEntries.map(f => f.original);
-    dispatch(querySuccess(namespace, collection, searchFields, searchTerm, resultObj));
-  } else {
-    // Collection entries aren't loaded yet.
-    // Dispatch loadEntries and wait before redispatching this action again.
-    dispatch({
-      type: WAIT_UNTIL_ACTION,
-      predicate: action => (action.type === ENTRIES_SUCCESS && action.payload.collection === collection),
-      run: dispatch => dispatch(query(namespace, collection, searchFields, searchTerm)),
-    });
-    dispatch(loadEntries(state.collections.get(collection)));
-  }
 }

--- a/src/components/Collection/Entries/Entries.js
+++ b/src/components/Collection/Entries/Entries.js
@@ -11,13 +11,19 @@ const Entries = ({
   page,
   onPaginate,
   isFetching,
-  viewStyle
+  viewStyle,
+  cursorActions,
+  cursorMeta,
 }) => {
   const loadingMessages = [
     'Loading Entries',
     'Caching Entries',
     'This might take several minutes',
   ];
+
+  if (isFetching) {
+    return <Loader active>{loadingMessages}</Loader>;
+  }
 
   if (entries) {
     return (
@@ -28,12 +34,10 @@ const Entries = ({
         page={page}
         onPaginate={onPaginate}
         viewStyle={viewStyle}
+        cursorActions={cursorActions}
+        cursorMeta={cursorMeta}
       />
     );
-  }
-
-  if (isFetching) {
-    return <Loader active>{loadingMessages}</Loader>;
   }
 
   return <div className="nc-collectionPage-noEntries">No Entries</div>;

--- a/src/components/Collection/Entries/EntryListing.css
+++ b/src/components/Collection/Entries/EntryListing.css
@@ -7,3 +7,36 @@
 .nc-entryListing-cardsList {
   margin-left: -12px;
 }
+
+.nc-entryListing-pagination {
+  display: flex;
+  justify-content: space-between;
+  flex-basis: var(--topCardWidth);
+  align-items: center;
+  margin-left: 12px;
+}
+
+.nc-entryListing-paginationElement {
+  flex-grow: 1;
+  flex-basis: 0;
+}
+
+.nc-entryListing-paginationElement {
+  text-align: left;
+  flex-grow: 1;
+  flex-basis: 0;
+}
+
+.nc-entryListing-paginationMeta {
+  text-align: center;
+}
+
+.nc-entryListing-paginationButton {
+  @apply(--button);
+  @apply(--buttonDefault);
+  @apply(--buttonGray);
+}
+
+.nc-entryListing-paginationElementRight {
+  text-align: right;
+}

--- a/src/components/Collection/Entries/EntryListing.js
+++ b/src/components/Collection/Entries/EntryListing.js
@@ -53,7 +53,14 @@ export default class EntryListing extends React.Component {
   };
 
   render() {
-    const { collections, entries, publicFolder } = this.props;
+    const { collections, entries, publicFolder, cursorActions, cursorMeta } = this.props;
+    const { first, next, last, prev } = (cursorActions || {});
+    const { index: rawIndex, pageCount: rawPageCount } = (cursorMeta || {});
+    const index = rawIndex + 1;
+    const pageCount = rawPageCount + 1;
+    const pageString = index
+      ? `Page ${ index }${ pageCount ? ` of ${ pageCount }` : "" }`
+      : "";
 
     return (
       <div>
@@ -63,8 +70,26 @@ export default class EntryListing extends React.Component {
               ? this.renderCardsForSingleCollection()
               : this.renderCardsForMultipleCollections()
           }
-          <Waypoint onEnter={this.handleLoadMore} />
-        </div>
+          {cursorActions && Object.keys(cursorActions).length > 0
+            ? <div className="nc-entryListing-pagination">
+              <div className="nc-entryListing-paginationElement">
+                {first ? <button className="nc-entryListing-paginationButton" onClick={first}>{"<<<"}</button> : ""}
+              </div>
+              <div className="nc-entryListing-paginationElement">
+                {prev ? <button className="nc-entryListing-paginationButton" onClick={prev}>{"<"}</button> : ""}
+              </div>
+              <div className="nc-entryListing-paginationElement nc-entryListing-paginationMeta">
+                {pageString}
+              </div>
+              <div className="nc-entryListing-paginationElement nc-entryListing-paginationElementRight">
+                {next ? <button className="nc-entryListing-paginationButton" onClick={next}>{">"}</button> : ""}
+              </div>
+              <div className="nc-entryListing-paginationElement nc-entryListing-paginationElementRight">
+                {last ? <button className="nc-entryListing-paginationButton" onClick={last}>{">>>"}</button> : ""}
+              </div>
+            </div>
+           : ""}
+          </div>
       </div>
     );
   }

--- a/src/reducers/cursors.js
+++ b/src/reducers/cursors.js
@@ -1,0 +1,27 @@
+import { Map } from 'immutable';
+import {
+  ENTRIES_SUCCESS,
+} from 'Actions/entries';
+
+// Since pagination can be used for a variety of views (collections
+// and searches are the most common examples), we namespace cursors by
+// their type before storing them in the state.
+export const collectionEntriesCursorKey = collectionName => `collectionEntries.${ collectionName }`;
+
+const cursors = (state = Map(), action) => {
+  switch (action.type) {
+    case ENTRIES_SUCCESS: {
+      const collection = action.payload.collection;
+      const cursor = action.payload.cursor;
+      if (cursor) {
+        return state.set(collectionEntriesCursorKey(collection), cursor);
+      }
+      return state;
+    }
+
+    default:
+      return state;
+  }
+};
+
+export default cursors;

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -2,6 +2,7 @@ import auth from './auth';
 import config from './config';
 import integrations, * as fromIntegrations from './integrations';
 import entries, * as fromEntries from './entries';
+import cursors from './cursors';
 import editorialWorkflow, * as fromEditorialWorkflow from './editorialWorkflow';
 import entryDraft from './entryDraft';
 import collections from './collections';
@@ -17,6 +18,7 @@ const reducers = {
   search,
   integrations,
   entries,
+  cursors,
   editorialWorkflow,
   entryDraft,
   mediaLibrary,

--- a/src/reducers/search.js
+++ b/src/reducers/search.js
@@ -38,7 +38,7 @@ const entries = (state = defaultState, action) => {
         map.set('isFetching', false);
         map.set('page', page);
         map.set('term', searchTerm);
-        map.set('entryIds', page === 0 ? entryIds : map.get('entryIds', List()).concat(entryIds));
+        map.set('entryIds', (!page || page === 0) ? entryIds : map.get('entryIds', List()).concat(entryIds));
       });
 
     case QUERY_REQUEST:

--- a/src/valueObjects/Cursor.js
+++ b/src/valueObjects/Cursor.js
@@ -43,3 +43,10 @@ export const validateCursor = cursor =>
   (!cursor.meta || validKeys({ optional: ["index", "count", "pageSize", "pageCount"] }, cursor.meta));
 
 export const invalidCursorError = cursor => new Error("Invalid cursor returned!");
+
+// This is a temporary hack to allow cursors to be added to the
+// interface between backend.js and backends without modifying old
+// backends at all. This should be removed in favor of wrapping old
+// backends with a compatibility layer, as part of the backend API
+// refactor.
+export const CURSOR_COMPATIBILITY_SYMBOL = Symbol("cursor key for compatibility with old backends");

--- a/src/valueObjects/Cursor.js
+++ b/src/valueObjects/Cursor.js
@@ -1,0 +1,45 @@
+import isArray from "lodash/isArray";
+import isEqual from "lodash/isEqual";
+
+/*
+  Cursors are POJOs with a few requirements:
+
+  - They _must_ have an `actions` list. (It may be empty, but it must
+    be present).
+
+  - They _may_ include a `meta` key, which _is_ usable by the core
+    code. This may contain `index` and `pageSize`, which should both
+    be numbers.
+
+    `meta` is for user-visible information that is _not_ guaranteed to
+    exist. It should not be required or used to implement pagination
+    functionality, only for optional display. It _may_ be used by the
+    core code, but an empty or absent `meta` object _must not_ prevent
+    pagination actions from working.
+
+  - They _may_ include a value at the `data` key, which _must_ be
+    serializable using JSON.stringify and JSON.parse (we may want to
+    allow other types that we know how to serialize, such as
+    Immutable.js `Map`s, in the future)
+
+    `data` is for data used by the backend to implement pagination. It
+    _must not_ be used directly by code receiving the cursor, and
+    should be considered opaque by any code except the backend that
+    created it.
+
+  - They _must not_ include any further keys.
+*/
+
+const isSerializable = v => isEqual(v, JSON.parse(JSON.stringify(v)));
+const validKeys = ({ required=[], optional=[] }, obj) =>
+  obj &&
+  required.every(key => !!obj[key]) &&
+  Object.keys(obj).every(key => required.includes(key) || optional.includes(key));
+
+export const validateCursor = cursor =>
+  isSerializable(cursor) &&
+  validKeys({ required: ["actions"], optional: ["data", "meta"] }, cursor) &&
+  isArray(cursor.actions) &&
+  (!cursor.meta || validKeys({ optional: ["index", "count", "pageSize", "pageCount"] }, cursor.meta));
+
+export const invalidCursorError = cursor => new Error("Invalid cursor returned!");


### PR DESCRIPTION
**Summary**

Implements a new cursor API that allows backends to implement pagination of folder-based collections for listing and search, without changing the code or behavior of existing backends (except `test-repo`, which has been modified to use the cursor API).

Moves the code that bypasses backend methods when integrations are present for search and entries listing to `backend.js`. Now the only part of the integrations API exposed to code outside of `backend.js` is the media library.

Adds pagination UI - infinite scroll as used by the existing pagination system (only used for the Algolia integration) is still possible, but not yet implemented for cursor-based backends due to debugging and performance reasons (we need a solid method of avoiding having thousands of React components in the entries list if you scroll through the whole collection, and it's not immediately clear how `last` or `first` would be implemented. (**Note: the current infinite scroll UI doesn't work, as I still need to improve the UI code to detect when it needs to use the cursor function props or the old `onLoadMore` prop - this will be fixed before merge.**)

Todo before merge:

- [ ] See if `listAllEntries` performance can be improved by improving caching or allowing backends to implement it specifically and using different request strategies when listing everything as opposed to a single page.
- [ ] Move Algolia integration to cursors and remove old `pagination` code, making all pagination use the same functions. (The UI issue described above will be solved by this.)
- [ ] Write tests for cursor API to ensure functionality hasn't regressed.

**Test plan**

The `test-repo` backend has been modified to use cursors, as well as the GitLab PR (the PR hasn't yet been updated, but the branch implementing GitLab with cursors is at https://github.com/netlify/netlify-cms/tree/gitlab-benaiah-rebased-onto-cursor-api. Manual testing has been done on both of those, and some automated Redux tests will follow. (The planned development of a backend test suite that can run on any backend will improve the refactoring and new-backend-development experiences, but I expect this to be merged before that's done.)

**Description for the changelog**

Implement cursor API supporting arbitrary backend pagination implementations.

**- A picture of a cute animal (not mandatory but encouraged)**

![image](https://user-images.githubusercontent.com/1425133/39074938-493e511e-44a8-11e8-9d93-1b95211af6a7.png)