### PR TITLE
Support displayFields in the Relation widget

### DIFF
--- a/example/config.yml
+++ b/example/config.yml
@@ -74,6 +74,7 @@ collections: # A list of collections the CMS should be able to edit
         name: "post"
         widget: "relationKitchenSinkPost"
         collection: "posts"
+        dispalyFields: ["title", "date"]
         searchFields: ["title", "body"]
         valueField: "title"
       - {label: "Title", name: "title", widget: "string"}

--- a/example/config.yml
+++ b/example/config.yml
@@ -74,7 +74,7 @@ collections: # A list of collections the CMS should be able to edit
         name: "post"
         widget: "relationKitchenSinkPost"
         collection: "posts"
-        dispalyFields: ["title", "date"]
+        displayFields: ["title", "date"]
         searchFields: ["title", "body"]
         valueField: "title"
       - {label: "Title", name: "title", widget: "string"}

--- a/src/components/EditorWidgets/Relation/RelationControl.js
+++ b/src/components/EditorWidgets/Relation/RelationControl.js
@@ -94,11 +94,11 @@ class RelationControl extends Component {
     if (List.isList(valueField)) {
       return (
         <span>
-          {valueField.toJS().map(key => <span key={key}>{suggestion.data[key]}{' '}</span>)}
+          {valueField.toJS().map(key => <span key={key}>{new String(suggestion.data[key])}{' '}</span>)}
         </span>
       );
     }
-    return <span>{suggestion.data[valueField]}</span>;
+    return <span>{new String(suggestion.data[valueField])}</span>;
   };
 
   render() {

--- a/src/components/EditorWidgets/Relation/RelationControl.js
+++ b/src/components/EditorWidgets/Relation/RelationControl.js
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import Autosuggest from 'react-autosuggest';
 import uuid from 'uuid/v4';
-import { Map } from 'immutable';
+import { List, Map } from 'immutable';
 import { connect } from 'react-redux';
 import { debounce } from 'lodash';
 import { query, clearSearch } from 'Actions/search';
@@ -90,7 +90,14 @@ class RelationControl extends Component {
 
   renderSuggestion = (suggestion) => {
     const { field } = this.props;
-    const valueField = field.get('valueField');
+    const valueField = field.get('displayFields') || field.get('valueField');
+    if (List.isList(valueField)) {
+      return (
+        <span>
+          {valueField.toJS().map(key => <span key={key}>{suggestion.data[key]}{' '}</span>)}
+        </span>
+      );
+    }
     return <span>{suggestion.data[valueField]}</span>;
   };
 

--- a/website/site/content/docs/widgets/relation.md
+++ b/website/site/content/docs/widgets/relation.md
@@ -13,6 +13,7 @@ The relation widget allows you to reference items from another collection. It pr
 - **Options:**
   - `default`: accepts any widget data type; defaults to an empty string
   - `collection`: (**required**) name of the collection being referenced (string)
+  - `displayFields`: list of one or more names of fields in the referenced collection that will render in the autocomplete menu of the control. The value field is used by default.
   - `searchFields`: (**required**) list of one or more names of fields in the referenced collection to search for the typed value
   - `valueField`: (**required**) name of the field from the referenced collection whose value will be stored for the relation
 - **Example** (assuming a separate "authors" collection with "name" and "twitterHandle" fields):
@@ -22,7 +23,8 @@ The relation widget allows you to reference items from another collection. It pr
     name: "author"
     widget: "relation"
     collection: "authors"
+    displayFields: ["twitterHandle", "followerCount"]
     searchFields: ["name", "twitterHandle"]
     valueField: "name"
   ```
-  The generated UI input will search the authors collection by name and twitterHandle as the user types. On selection, the author name will be saved for the field.
+  The generated UI input will search the authors collection by name and twitterHandle as the user types. Each collection will be represented by the author's handle and follower count. On selection, the author name will be saved for the field.

--- a/website/site/content/docs/widgets/relation.md
+++ b/website/site/content/docs/widgets/relation.md
@@ -13,7 +13,7 @@ The relation widget allows you to reference items from another collection. It pr
 - **Options:**
   - `default`: accepts any widget data type; defaults to an empty string
   - `collection`: (**required**) name of the collection being referenced (string)
-  - `displayFields`: list of one or more names of fields in the referenced collection that will render in the autocomplete menu of the control. The value field is used by default.
+  - `displayFields`: list of one or more names of fields in the referenced collection that will render in the autocomplete menu of the control. Defaults to `valueField`.
   - `searchFields`: (**required**) list of one or more names of fields in the referenced collection to search for the typed value
   - `valueField`: (**required**) name of the field from the referenced collection whose value will be stored for the relation
 - **Example** (assuming a separate "authors" collection with "name" and "twitterHandle" fields):
@@ -23,8 +23,8 @@ The relation widget allows you to reference items from another collection. It pr
     name: "author"
     widget: "relation"
     collection: "authors"
-    displayFields: ["twitterHandle", "followerCount"]
     searchFields: ["name", "twitterHandle"]
     valueField: "name"
+    displayFields: ["twitterHandle", "followerCount"]
   ```
-  The generated UI input will search the authors collection by name and twitterHandle as the user types. Each collection will be represented by the author's handle and follower count. On selection, the author name will be saved for the field.
+  The generated UI input will search the authors collection by name and twitterHandle, and display each author's handle and follower count. On selection, the author name will be saved for the field.


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines;
https://github.com/netlify/netlify-cms/blob/master/CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first three fields are mandatory:
-->

**- Summary**

Some relation objects I have are stored by an `id` field to guarantee each object has a unique value. My `id`s are random hashes though and they are not very informative, especially looking through the autocomplete options. 

By adding the `displayFields` option, we can render information of the object that is more useful to the user. In my case I can display the title and author, which helps distinguish posts with the same title.

**- Test plan**

Manual testing works
The test suite passes using `yarn test`

**- Description for the changelog**

The relation widget now supports custom display fields
