### PR TITLE
nudge the contributor count up

### DIFF
--- a/website/site/data/landing.yaml
+++ b/website/site/data/landing.yaml
@@ -37,7 +37,7 @@ community:
     - feature: "Support when you need it"
       description: "Get up and running with comprehensive [documentation](/docs) and templates or work through difficult problems with help from the community on [Gitter](https://gitter.im/netlify/NetlifyCMS)."
     - feature: "A community-driven project you can help evolve"
-      description: "Netlify CMS is built by a community of 60+ contributors — and you can help. Join our [bi-weekly planning sessions](/community) or read the [contributing guide](/docs/contributor-guide) to join in."
+      description: "Netlify CMS is built by a community of more than 100 contributors — and you can help. Join our [bi-weekly planning sessions](/community) or read the [contributing guide](/docs/contributor-guide) to join in."
   contributors: "Made possible by awesome contributors"
 
 ---


### PR DESCRIPTION
**- Summary**

The contributor count has increased quite a bit. No linger 60+ as advertised, now over 100 contributors. This PR also rephrases this sentence a little to make it scan a little better.

**- Test plan**

This is a simple content change made purely in the data file as intended for simplified content abstraction. Locally the revised copy rendered suitably:

<img width="687" alt="screen shot 2018-04-24 at 23 13 33" src="https://user-images.githubusercontent.com/5865/39216840-34337e50-4815-11e8-97a2-042ec22ad6ff.png">

**- Description for the changelog**

1. Single copy change in the landing.yaml data file

**- A picture of a cute animal (not mandatory but encouraged)**

![Wut? Just merge me!](https://user-images.githubusercontent.com/5865/39216999-ed41ba7e-4815-11e8-86a3-e46a406e613f.jpg)
