### PR TITLE
Add Gitter Sidecar widget to docs site

### DIFF
--- a/website/site/layouts/partials/footer.html
+++ b/website/site/layouts/partials/footer.html
@@ -34,5 +34,13 @@ debug: false // Set debug to true if you want to inspect the dropdown
   <script src="/widgets.js"></script>
 {{- end -}}
 <script async defer src="https://buttons.github.io/buttons.js"></script>
+{{ if or (eq .Section "docs") (eq .Title "Docs") (eq .Title "Community") }}
+<script>
+  ((window.gitter = {}).chat = {}).options = {
+    room: 'netlify/NetlifyCMS'
+  };
+</script>
+<script src="https://sidecar.gitter.im/dist/sidecar.v1.js" async defer></script>
+{{ end }}
 </body>
 </html>

--- a/website/src/css/imports/gitter.css
+++ b/website/src/css/imports/gitter.css
@@ -1,0 +1,17 @@
+.gitter-open-chat-button {
+  &,
+  &:visited {
+    padding: $tiny $small;
+    font-family: $roboto;
+    font-size: $tiny;
+    letter-spacing: 0.5px;
+    color: $grey;
+    background-color: $green;
+    box-shadow: 0 2px 16px 0 rgba(68,74,87,0.15), 0 1px 4px 0 rgba(68,74,87,0.30);
+  }
+
+  &:hover {
+    background-color: $lightGreen;
+    box-shadow: 0 2px 16px 0 rgba(68,74,87,0.25), 0 1px 4px 0 rgba(68,74,87,0.50);
+  }
+}

--- a/website/src/css/imports/gitter.css
+++ b/website/src/css/imports/gitter.css
@@ -14,4 +14,9 @@
     background-color: $lightGreen;
     box-shadow: 0 2px 16px 0 rgba(68,74,87,0.25), 0 1px 4px 0 rgba(68,74,87,0.50);
   }
+
+  &:focus {
+    box-shadow: 0 0 6px 3px rgba(62,160,127,.6);
+    transition: none;
+  }
 }

--- a/website/src/css/imports/gitter.css
+++ b/website/src/css/imports/gitter.css
@@ -19,4 +19,8 @@
     box-shadow: 0 0 6px 3px rgba(62,160,127,.6);
     transition: none;
   }
+
+  &:active {
+    color: $lightGrey;
+  }
 }

--- a/website/src/css/main.css
+++ b/website/src/css/main.css
@@ -10,3 +10,4 @@
 @import "imports/docs.css";
 @import "imports/widgets.css";
 @import "imports/footer.css";
+@import "imports/gitter.css";


### PR DESCRIPTION
### Summary

Closes #1323

Adds an “Open Chat” button to Netlify CMS site, excluding the home page, using [Gitter Sidecar](https://sidecar.gitter.im/).

![Screenshot showing a page from the Netlify CMS docs featuring Sidecar button](https://user-images.githubusercontent.com/357379/39457967-a4f9ea44-4cf1-11e8-9b6c-5cfaee921e53.png)


### Description for the changelog

Add Gitter Sidecar widget to docs site
