### PR TITLE
Updating add-to-your-site.md to include Nuxt

### DIFF
--- a/website/site/content/docs/add-to-your-site.md
+++ b/website/site/content/docs/add-to-your-site.md
@@ -15,7 +15,7 @@ All Netlify CMS files are contained in a static `admin` folder, stored at the ro
 | These generators ... | store static files in |
 | -------------------- | --------------------- |
 | Jekyll, GitBook      | `/` (project root)    |
-| Hugo, Gatsby         | `/static`             |
+| Hugo, Gatsby, Nuxt   | `/static`             |
 | Hexo, Middleman      | `/source`             |
 | Spike                | `/views`              |
 | Wyam                 | `/input`              |


### PR DESCRIPTION
Added Nuxt to list of generators that use the "static" folder for static files where the Netlify CMS admin can live.

<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines;
https://github.com/netlify/netlify-cms/blob/master/CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first three fields are mandatory:
-->

**- Summary**
Netlify CMS can be added to a Nuxt project by placing the required files in the "/static" folder.
<!--
Explain the **motivation** for making this change.
What existing problem does the pull request solve?
-->

**- Test plan**

<!--
Demonstrate the code is solid.
Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.
-->

**- Description for the changelog**
Added Nuxt to list of generators that use the "static" folder for installing the Netlify CMS admin.
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

**- A picture of a cute animal (not mandatory but encouraged)**
![dckuwt8v0aay2gz](https://user-images.githubusercontent.com/6036273/39876801-23cc5152-5442-11e8-95c0-db7b8ae63eb8.jpg)
