### PR TITLE
chore: checkout last 5 commits

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,3 +16,5 @@ before_script:
   - yarn add codecov --dev
 after_script:
   - codecov
+git:
+  depth: 5


### PR DESCRIPTION
By default Travis CI clones the last 50 commits. 5 are sufficient and often faster.

https://docs.travis-ci.com/user/customizing-the-build#Git-Clone-Depth