### PR TITLE
Fix negative CSS variables

### DIFF
--- a/src/components/EditorWidgets/Markdown/MarkdownControl/RawEditor/index.css
+++ b/src/components/EditorWidgets/Markdown/MarkdownControl/RawEditor/index.css
@@ -11,5 +11,5 @@
   border-top-left-radius: 0;
   border-top-right-radius: 0;
   border-top: 0;
-  margin-top: -var(--stickyDistanceBottom);
+  margin-top: calc(-1 * var(--stickyDistanceBottom));
 }

--- a/src/components/EditorWidgets/Markdown/MarkdownControl/VisualEditor/Shortcode.css
+++ b/src/components/EditorWidgets/Markdown/MarkdownControl/VisualEditor/Shortcode.css
@@ -7,7 +7,7 @@
 
 .nc-visualEditor-shortcode-topBar {
   background-color: var(--textFieldBorderColor);
-  margin: -var(--widgetNestDistance) -var(--widgetNestDistance) 0;
+  margin: calc(-1 * var(--widgetNestDistance)) calc(-1 * var(--widgetNestDistance)) 0;
   border-radius: 0;
 }
 

--- a/src/components/EditorWidgets/Markdown/MarkdownControl/VisualEditor/index.css
+++ b/src/components/EditorWidgets/Markdown/MarkdownControl/VisualEditor/index.css
@@ -24,7 +24,7 @@
   border-top-left-radius: 0;
   border-top-right-radius: 0;
   border-top: 0;
-  margin-top: -var(--stickyDistanceBottom);
+  margin-top: calc(-1 * var(--stickyDistanceBottom));
 }
 
 .nc-visualEditor-editor h1 {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines;
https://github.com/netlify/netlify-cms/blob/master/CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first three fields are mandatory:
-->

**- Summary**

<!--
Explain the **motivation** for making this change.
What existing problem does the pull request solve?
-->

Dependency updates caused postcss to stop preprocessing css variables (due to sufficient browser support), and the following unsupported syntax stopped working:

```css
margin: -var(--value);
```

The syntax used to produce the variable preceded with a hyphen. Instead the supported way to negate a css variable is:

```css
margin: calc(-1 * var(--value));
```

**- Description for the changelog**

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Fix markdown widget styling