### PR TITLE
Fixes field config usage with List widget.

### DIFF
--- a/packages/netlify-cms-core/src/components/Editor/EditorPreviewPane/EditorPreviewPane.js
+++ b/packages/netlify-cms-core/src/components/Editor/EditorPreviewPane/EditorPreviewPane.js
@@ -22,17 +22,18 @@ const PreviewPaneFrame = styled(Frame)`
 `;
 
 export default class PreviewPane extends React.Component {
-  getWidget = (field, value, props) => {
+  getWidget = (field, value, props, idx = null) => {
     const { fieldsMetaData, getAsset, entry } = props;
     const widget = resolveWidget(field.get('widget'));
-
+    const key = idx ? field.get('name') + '_' + idx : field.get('name');
+    
     /**
      * Use an HOC to provide conditional updates for all previews.
      */
     return !widget.preview ? null : (
       <PreviewHOC
         previewComponent={widget.preview}
-        key={field.get('name')}
+        key={key}
         field={field}
         getAsset={getAsset}
         value={value && Map.isMap(value) ? value.get(field.get('name')) : value}
@@ -68,9 +69,14 @@ export default class PreviewPane extends React.Component {
     let field = fields && fields.find(f => f.get('name') === name);
     let value = values && values.get(field.get('name'));
     let nestedFields = field.get('fields');
+    let singleField = field.get('field');
 
     if (nestedFields) {
       field = field.set('fields', this.getNestedWidgets(nestedFields, value));
+    }
+
+    if (singleField) {
+      field = field.set('field', this.getSingleNested(singleField, value));
     }
 
     const labelledWidgets = ['string', 'text', 'number'];
@@ -101,6 +107,13 @@ export default class PreviewPane extends React.Component {
     }
     // Fields nested within an object field will be paired with a single Map of values.
     return this.widgetsForNestedFields(fields, values);
+  };
+
+  getSingleNested = (field, values) => {
+    if (List.isList(values)) {
+      return values.map((value, idx) => this.getWidget(field, value, this.props, idx))
+    }
+    return this.getWidget(field, values, this.props);
   };
 
   /**

--- a/packages/netlify-cms-core/src/components/Editor/EditorPreviewPane/EditorPreviewPane.js
+++ b/packages/netlify-cms-core/src/components/Editor/EditorPreviewPane/EditorPreviewPane.js
@@ -26,7 +26,7 @@ export default class PreviewPane extends React.Component {
     const { fieldsMetaData, getAsset, entry } = props;
     const widget = resolveWidget(field.get('widget'));
     const key = idx ? field.get('name') + '_' + idx : field.get('name');
-    
+
     /**
      * Use an HOC to provide conditional updates for all previews.
      */
@@ -111,7 +111,7 @@ export default class PreviewPane extends React.Component {
 
   getSingleNested = (field, values) => {
     if (List.isList(values)) {
-      return values.map((value, idx) => this.getWidget(field, value, this.props, idx))
+      return values.map((value, idx) => this.getWidget(field, value, this.props, idx));
     }
     return this.getWidget(field, values, this.props);
   };

--- a/packages/netlify-cms-ui-default/src/ListItemTopBar.js
+++ b/packages/netlify-cms-ui-default/src/ListItemTopBar.js
@@ -36,27 +36,23 @@ const DragIconContainer = styled(TopBarButtonSpan)`
 const ListItemTopBar = ({ className, collapsed, onCollapseToggle, onRemove, dragHandleHOC }) => {
   const DragHandle = dragHandleHOC(() => (
     <DragIconContainer>
-      <Icon type="drag-handle" size="small"/>
+      <Icon type="drag-handle" size="small" />
     </DragIconContainer>
   ));
 
   return (
     <TopBar className={className}>
-      {
-        onCollapseToggle
-          ? <TopBarButton onClick={onCollapseToggle}>
-              <Icon type="chevron" size="small" direction={collapsed ? 'right' : 'down'}/>
-            </TopBarButton>
-          : null
-      }
-      { dragHandleHOC ? <DragHandle dragHandleHOC={dragHandleHOC}/> : null }
-      {
-        onRemove
-          ? <TopBarButton onClick={onRemove}>
-              <Icon type="close" size="small"/>
-            </TopBarButton>
-          : null
-      }
+      {onCollapseToggle ? (
+        <TopBarButton onClick={onCollapseToggle}>
+          <Icon type="chevron" size="small" direction={collapsed ? 'right' : 'down'} />
+        </TopBarButton>
+      ) : null}
+      {dragHandleHOC ? <DragHandle dragHandleHOC={dragHandleHOC} /> : null}
+      {onRemove ? (
+        <TopBarButton onClick={onRemove}>
+          <Icon type="close" size="small" />
+        </TopBarButton>
+      ) : null}
     </TopBar>
   );
 };

--- a/packages/netlify-cms-ui-default/src/ListItemTopBar.js
+++ b/packages/netlify-cms-ui-default/src/ListItemTopBar.js
@@ -28,30 +28,38 @@ const TopBarButton = styled.button`
 
 const TopBarButtonSpan = TopBarButton.withComponent('span');
 
-const DragIcon = styled(TopBarButtonSpan)`
+const DragIconContainer = styled(TopBarButtonSpan)`
   width: 100%;
   cursor: move;
 `;
 
-const ListItemTopBar = ({ className, collapsed, onCollapseToggle, onRemove, dragHandleHOC }) => (
-  <TopBar className={className}>
-    {onCollapseToggle ? (
-      <TopBarButton onClick={onCollapseToggle}>
-        <Icon type="chevron" size="small" direction={collapsed ? 'right' : 'down'} />
-      </TopBarButton>
-    ) : null}
-    {dragHandleHOC ? (
-      <DragIcon>
-        <Icon type="drag-handle" size="small" />
-      </DragIcon>
-    ) : null}
-    {onRemove ? (
-      <TopBarButton onClick={onRemove}>
-        <Icon type="close" size="small" />
-      </TopBarButton>
-    ) : null}
-  </TopBar>
-);
+const ListItemTopBar = ({ className, collapsed, onCollapseToggle, onRemove, dragHandleHOC }) => {
+  const DragHandle = dragHandleHOC(() => (
+    <DragIconContainer>
+      <Icon type="drag-handle" size="small"/>
+    </DragIconContainer>
+  ));
+
+  return (
+    <TopBar className={className}>
+      {
+        onCollapseToggle
+          ? <TopBarButton onClick={onCollapseToggle}>
+              <Icon type="chevron" size="small" direction={collapsed ? 'right' : 'down'}/>
+            </TopBarButton>
+          : null
+      }
+      { dragHandleHOC ? <DragHandle dragHandleHOC={dragHandleHOC}/> : null }
+      {
+        onRemove
+          ? <TopBarButton onClick={onRemove}>
+              <Icon type="close" size="small"/>
+            </TopBarButton>
+          : null
+      }
+    </TopBar>
+  );
+};
 
 const StyledListItemTopBar = styled(ListItemTopBar)`
   display: flex;

--- a/packages/netlify-cms-widget-list/src/ListControl.js
+++ b/packages/netlify-cms-widget-list/src/ListControl.js
@@ -177,9 +177,10 @@ export default class ListControl extends React.Component {
     const { itemsCollapsed } = this.state;
     const { value, metadata, onChange, field } = this.props;
     const collectionName = field.get('name');
-    const singleMetadata = metadata && (this.valueType === valueTypes.SINGLE) && { [collectionName]: metadata.removeIn(value.get(index)) }; 
-    const multiMetadata = metadata && (this.valueType === valueTypes.MULTIPLE) && { [collectionName]: metadata.removeIn(value.get(index).valueSeq()) };
-    const parsedMetadata = singleMetadata || multiMetadata;
+    const isSingleField = this.valueType === valueTypes.SINGLE;
+
+    const metadataRemovePath = isSingleField ? value.get(index) : value.get(index).valueSeq();
+    const parsedMetadata = metadata && { [collectionName]: metadata.removeIn(metadataRemovePath) };
 
     this.setState({ itemsCollapsed: itemsCollapsed.delete(index) });
 

--- a/packages/netlify-cms-widget-list/src/ListControl.js
+++ b/packages/netlify-cms-widget-list/src/ListControl.js
@@ -159,16 +159,16 @@ export default class ListControl extends React.Component {
     return (fieldName, newValue, newMetadata) => {
       const { value, metadata, onChange, field } = this.props;
       const collectionName = field.get('name');
-      const newObjectValue = this.getObjectValue(index).set(fieldName, newValue);
-      const parsedValue =
-        this.getValueType() === valueTypes.SINGLE ? newObjectValue.first() : newObjectValue;
+      const newObjectValue = (this.getValueType() === valueTypes.MULTIPLE)
+        ? this.getObjectValue(index).set(fieldName, newValue)
+        : newValue;
       const parsedMetadata = {
         [collectionName]: Object.assign(
           metadata ? metadata.toJS() : {},
           newMetadata ? newMetadata[collectionName] : {},
         ),
       };
-      onChange(value.set(index, parsedValue), parsedMetadata);
+      onChange(value.set(index, newObjectValue), parsedMetadata);
     };
   }
 
@@ -177,9 +177,9 @@ export default class ListControl extends React.Component {
     const { itemsCollapsed } = this.state;
     const { value, metadata, onChange, field } = this.props;
     const collectionName = field.get('name');
-    const parsedMetadata = metadata && {
-      [collectionName]: metadata.removeIn(value.get(index).valueSeq()),
-    };
+    const singleMetadata = metadata && (this.valueType === valueTypes.SINGLE) && { [collectionName]: metadata.removeIn(value.get(index)) }; 
+    const multiMetadata = metadata && (this.valueType === valueTypes.MULTIPLE) && { [collectionName]: metadata.removeIn(value.get(index).valueSeq()) };
+    const parsedMetadata = singleMetadata || multiMetadata;
 
     this.setState({ itemsCollapsed: itemsCollapsed.delete(index) });
 

--- a/packages/netlify-cms-widget-list/src/ListControl.js
+++ b/packages/netlify-cms-widget-list/src/ListControl.js
@@ -159,9 +159,10 @@ export default class ListControl extends React.Component {
     return (fieldName, newValue, newMetadata) => {
       const { value, metadata, onChange, field } = this.props;
       const collectionName = field.get('name');
-      const newObjectValue = (this.getValueType() === valueTypes.MULTIPLE)
-        ? this.getObjectValue(index).set(fieldName, newValue)
-        : newValue;
+      const newObjectValue =
+        this.getValueType() === valueTypes.MULTIPLE
+          ? this.getObjectValue(index).set(fieldName, newValue)
+          : newValue;
       const parsedMetadata = {
         [collectionName]: Object.assign(
           metadata ? metadata.toJS() : {},

--- a/packages/netlify-cms-widget-object/src/ObjectControl.js
+++ b/packages/netlify-cms-widget-object/src/ObjectControl.js
@@ -62,31 +62,32 @@ export default class ObjectControl extends Component {
     this.setState({ collapsed: !this.state.collapsed });
   };
 
+  renderFields = (multiFields, singleField) => {
+    if (multiFields) {
+      return multiFields.map((f, idx) => this.controlFor(f, idx))
+    }
+    return this.controlFor(singleField)
+  }
+
   render() {
     const { field, forID, classNameWrapper, forList } = this.props;
     const { collapsed } = this.state;
     const multiFields = field.get('fields');
     const singleField = field.get('field');
 
-    if (multiFields) {
+    if (multiFields || singleField) {
       return (
-        <div
-          id={forID}
-          className={cx(classNameWrapper, components.objectWidgetTopBarContainer, {
-            [styles.nestedObjectControl]: forList,
-          })}
-        >
-          {forList ? null : (
-            <ObjectWidgetTopBar
-              collapsed={collapsed}
-              onCollapseToggle={this.handleCollapseToggle}
-            />
-          )}
-          {collapsed ? null : multiFields.map((f, idx) => this.controlFor(f, idx))}
+        <div id={forID} className={cx(
+          classNameWrapper,
+          components.objectWidgetTopBarContainer,
+          { [styles.nestedObjectControl]: forList },
+        )}>
+          {forList ? null :
+            <ObjectWidgetTopBar collapsed={collapsed} onCollapseToggle={this.handleCollapseToggle} />
+          }
+          {collapsed ? null : this.renderFields(multiFields, singleField)}
         </div>
       );
-    } else if (singleField) {
-      return this.controlFor(singleField);
     }
 
     return <h3>No field(s) defined for this widget</h3>;

--- a/packages/netlify-cms-widget-object/src/ObjectControl.js
+++ b/packages/netlify-cms-widget-object/src/ObjectControl.js
@@ -64,10 +64,10 @@ export default class ObjectControl extends Component {
 
   renderFields = (multiFields, singleField) => {
     if (multiFields) {
-      return multiFields.map((f, idx) => this.controlFor(f, idx))
+      return multiFields.map((f, idx) => this.controlFor(f, idx));
     }
-    return this.controlFor(singleField)
-  }
+    return this.controlFor(singleField);
+  };
 
   render() {
     const { field, forID, classNameWrapper, forList } = this.props;
@@ -77,14 +77,18 @@ export default class ObjectControl extends Component {
 
     if (multiFields || singleField) {
       return (
-        <div id={forID} className={cx(
-          classNameWrapper,
-          components.objectWidgetTopBarContainer,
-          { [styles.nestedObjectControl]: forList },
-        )}>
-          {forList ? null :
-            <ObjectWidgetTopBar collapsed={collapsed} onCollapseToggle={this.handleCollapseToggle} />
-          }
+        <div
+          id={forID}
+          className={cx(classNameWrapper, components.objectWidgetTopBarContainer, {
+            [styles.nestedObjectControl]: forList,
+          })}
+        >
+          {forList ? null : (
+            <ObjectWidgetTopBar
+              collapsed={collapsed}
+              onCollapseToggle={this.handleCollapseToggle}
+            />
+          )}
           {collapsed ? null : this.renderFields(multiFields, singleField)}
         </div>
       );

--- a/packages/netlify-cms-widget-object/src/ObjectPreview.js
+++ b/packages/netlify-cms-widget-object/src/ObjectPreview.js
@@ -3,7 +3,9 @@ import PropTypes from 'prop-types';
 import { WidgetPreviewContainer } from 'netlify-cms-ui-default';
 
 const ObjectPreview = ({ field }) => (
-  <WidgetPreviewContainer>{(field && field.get('fields')) || null}</WidgetPreviewContainer>
+  <WidgetPreviewContainer>
+    {(field && field.get('fields')) || field.get('field') || null}
+  </WidgetPreviewContainer>
 );
 
 ObjectPreview.propTypes = {


### PR DESCRIPTION
Closes #1139. The original issue had two problems that I have found. The first was how the config.yml responds to `field`.

When adding in `fields` for a `list` widget as demonstrated under the label `List`, it renders correctly.

<img width="518" alt="screen shot 2018-05-30 at 9 38 07 am" src="https://user-images.githubusercontent.com/23248886/40723580-33e73a88-63ed-11e8-8014-365e2d4c3b25.png">

<img width="378" alt="screen shot 2018-05-30 at 9 36 55 am" src="https://user-images.githubusercontent.com/23248886/40723613-44fcab1e-63ed-11e8-9232-640d8a97f592.png">

But when we use `field` instead, and indent with a dash, as we would with `fields`, 


<img width="731" alt="screen shot 2018-05-30 at 11 58 52 am" src="https://user-images.githubusercontent.com/23248886/40732236-e09d49bc-6400-11e8-98fe-b5c0d4b0d555.png">

this happens:
<img width="383" alt="screen shot 2018-05-30 at 9 42 12 am" src="https://user-images.githubusercontent.com/23248886/40723887-d5b267e8-63ed-11e8-9871-5b4693c567e0.png">

It doesn't render the select properly, and we get a whole console full of errors.

<img width="681" alt="screen shot 2018-05-30 at 9 43 33 am" src="https://user-images.githubusercontent.com/23248886/40723976-fed3a376-63ed-11e8-9f65-d7dc4a389cab.png">

This error pointed to `handleChangeFor`.

```
  handleChangeFor(index) {
    return (fieldName, newValue, newMetadata) => {
      const { value, metadata, onChange, field } = this.props;
      const collectionName = field.get('name');
      const newObjectValue = this.getObjectValue(index).set(fieldName, newValue);
      const parsedValue = (this.valueType === valueTypes.SINGLE) ? newObjectValue.first() : newObjectValue;
      const parsedMetadata = {
        [collectionName]: Object.assign(metadata ? metadata.toJS() : {}, newMetadata ? newMetadata[collectionName] : {}),
      };
      onChange(value.set(index, parsedValue), parsedMetadata);
    };
  }
```
The handling of `newObjectValue` kept throwing because `getObjectValue` wasn't returning a `Map` like it was expecting, it was returning a `string` from the `select` widget. The `parsedValue` step was also expecting a `List`, but it was no longer becoming a `List`.

Having `newObjectValue` check first if it was `valueTypes.MULTIPLE` before using `getObjectValue`, and if it was a `valueTypes.SINGLE` then redirecting it to `newValue`, solved this problem. I removed the `parsedValue` step, since `newObjectValue` is no longer a `List`, and passed it to on change where the newValue was stored in a list.

That and using `field`'s object in `config` on the same line made the difference.

<img width="762" alt="screen shot 2018-05-30 at 12 05 40 pm" src="https://user-images.githubusercontent.com/23248886/40732730-ece0b3ac-6401-11e8-9aa5-f63ad4b1b88c.png">

<img width="383" alt="screen shot 2018-05-30 at 12 05 17 pm" src="https://user-images.githubusercontent.com/23248886/40732737-f00d24fc-6401-11e8-9ec0-446f900dae33.png">

The preview pane issue required special parsing for `field` which I added in.
