### PR TITLE
fix workflow top panel styling

### DIFF
--- a/src/components/Workflow/Workflow.css
+++ b/src/components/Workflow/Workflow.css
@@ -2,8 +2,7 @@
 @import "./WorkflowCard.css";
 
 .nc-workflow {
-  padding: var(--pageMargin);
-  padding-bottom: 0;
+  padding: var(--pageMargin) 0;
   height: 100vh;
 }
 


### PR DESCRIPTION
Fixes styling break from recent dependencies update. Native CSS variables combined with PostCSS output optimizations converted this:

```css
.nc-workflow {
  padding: var(--pageMargin);
  padding-bottom: 0;
}
```

to this:

```css
.nc-workflow {
  padding: var(--pageMargin) var(--pageMargin) 0;
}
```

PostCSS static analysis counted the vars as single values, but the variable equates to `84px 18px`, leading to an output of `84px 18px 84px 18px 0`, which fails in the browser.

Fixed by not declaring the bottom padding subsequent to general padding declaration, but we should consider changing or dropping related optimizations if these kinds of issues prove common.

Bug demo: https://5b084974c965920b4c7644e3--cms-demo.netlify.com/#/workflow

Fix demo: https://deploy-preview-1398--cms-demo.netlify.com/#/workflow