### PR TITLE
Only use label_singular when one item is rendered in the listControl

### DIFF
--- a/src/components/EditorWidgets/List/ListControl.js
+++ b/src/components/EditorWidgets/List/ListControl.js
@@ -262,14 +262,15 @@ export default class ListControl extends Component {
     const { value, forID, field, classNameWrapper } = this.props;
     const { itemsCollapsed } = this.state;
     const items = value || List();
-    const label = field.get('label_singular') || field.get('label');
+    const label = field.get('label');
+    const labelSingular = field.get('label_singular') || field.get('label');
 
     return (
       <div id={forID} className={c(classNameWrapper, 'nc-listControl')}>
         <TopBar
           allowAdd={field.get('allow_add', true)}
           onAdd={this.handleAdd}
-          listLabel={label.toLowerCase()}
+          listLabel={items.size === 1 ? labelSingular.toLowerCase() : label.toLowerCase()}
           onCollapseAllToggle={this.handleCollapseAllToggle}
           allItemsCollapsed={itemsCollapsed.every(val => val === true)}
           itemsCount={items.size}


### PR DESCRIPTION
Fixes #1397.
Check the size of the item list and set the listLabel based on that.
If no label_singular is set, fall back to the normal label

**- Summary**

The list control always used the singular name as label if one is specified, even when the list contains 0 or > 1 items. It's now based on the amount of items thats provided.

**- Test plan**
Tested with the existing authors settings in the example CMS.

With 2 authors:
![image](https://user-images.githubusercontent.com/5166612/41238484-527c9562-6d96-11e8-8e7e-636abd925753.png)

With 1 author:
![image](https://user-images.githubusercontent.com/5166612/41238516-5fd64cd0-6d96-11e8-9e26-d9fe177c829e.png)

With 0 authors:
![image](https://user-images.githubusercontent.com/5166612/41238654-c188e8a2-6d96-11e8-9e45-81e0fd245bec.png)


**- Description for the changelog**
Base the listLabel on the size of the list provided.

**- A picture of a cute animal (not mandatory but encouraged)**
![image](https://user-images.githubusercontent.com/5166612/41238575-893b999a-6d96-11e8-9976-ab0c3c15ef9d.png)
