### PR TITLE
fix deploy preview links

### DIFF
--- a/website/site/config.yaml
+++ b/website/site/config.yaml
@@ -1,4 +1,4 @@
-baseurl: "https://www.netlifycms.org/"
+baseurl: "/"
 languageCode: "en-us"
 title: "Netlify CMS | Open-Source Content Management System"
 disable404: true


### PR DESCRIPTION
Use a relative url for Hugo base path so that links to don't always lead to the production site.