### PR TITLE
Last-minute website tweaks for GitLab release

### DIFF
--- a/website/site/content/docs/add-to-your-site.md
+++ b/website/site/content/docs/add-to-your-site.md
@@ -92,7 +92,7 @@ These lines specify your backend protocol and your publication branch. Git Gatew
 
 ### Editorial Workflow
 
-**Note:** Editorial workflow only works for the GitHub backend (and Git Gateway when used with GitHub). Support for other backends is [coming soon](https://github.com/netlify/netlify-cms/issues/568).
+**Note:** Editorial workflow works with GitHub repositories only. Support for other Git hosts is [coming soon](https://github.com/netlify/netlify-cms/issues/568).
 
 By default, saving a post in the CMS interface will push a commit directly to the publication branch specified in `backend`. However, you also have the option to enable the [Editorial Workflow](https://www.netlifycms.org/docs/configuration-options/#publish-mode), which adds an interface for drafting, reviewing, and approving posts. To do this, add the following line to your Netlify CMS `config.yml`:
 

--- a/website/site/content/docs/configuration-options.md
+++ b/website/site/content/docs/configuration-options.md
@@ -36,6 +36,8 @@ By default, all entries created or edited in the Netlify CMS are committed direc
 
 The `publish_mode` option allows you to enable "Editorial Workflow" mode for more control over the content publishing phases. All unpublished entries will be arranged in a board according to their status, and they can be further reviewed and edited before going live.
 
+**Note:** Editorial workflow works with GitHub repositories only. Support for other Git hosts is [coming soon](https://github.com/netlify/netlify-cms/issues/568).
+
 You can enable the Editorial Workflow with the following line in your Netlify CMS `config.yml` file:
 
 ```yaml

--- a/website/site/data/notifications.yml
+++ b/website/site/data/notifications.yml
@@ -14,3 +14,9 @@ notifications:
     published: false
     title: Gitter shoutout
     url: 'https://gitter.im/netlify/netlifycms'
+  - loud: true
+    message: >-
+      Netlify CMS now supports GitLab!
+    published: true
+    title: GitLab announcement
+    url: '/blog/2018/06/netlify-cms-now-supports-gitlab-as-a-backend/'


### PR DESCRIPTION
**- Summary**

- Adds a note to docs about editorial workflow (supported with GitHub repos only).
- Adds a notification banner to the website, announcing GitLab support

Preview here:
https://website-tweaks-gitlab--netlify-cms-www.netlify.com/docs/configuration-options/#publish-mode