### PR TITLE
improvement: remove button background color styling for editorial status labels

### DIFF
--- a/packages/netlify-cms-core/src/components/Editor/EditorToolbar.js
+++ b/packages/netlify-cms-core/src/components/Editor/EditorToolbar.js
@@ -342,9 +342,9 @@ export default class EditorToolbar extends React.Component {
               Writing in <strong>{collection.get('label')}</strong> collection
             </BackCollection>
             {hasChanged ? (
-              <BackStatusChanged>Unsaved Changes</BackStatusChanged>
+              <BackStatusChanged>UNSAVED CHANGES</BackStatusChanged>
             ) : (
-              <BackStatusUnchanged>Changes saved</BackStatusUnchanged>
+              <BackStatusUnchanged>CHANGES SAVED</BackStatusUnchanged>
             )}
           </div>
         </ToolbarSectionBackLink>

--- a/packages/netlify-cms-core/src/components/Editor/EditorToolbar.js
+++ b/packages/netlify-cms-core/src/components/Editor/EditorToolbar.js
@@ -342,9 +342,9 @@ export default class EditorToolbar extends React.Component {
               Writing in <strong>{collection.get('label')}</strong> collection
             </BackCollection>
             {hasChanged ? (
-              <BackStatusChanged>UNSAVED CHANGES</BackStatusChanged>
+              <BackStatusChanged>Unsaved Changes</BackStatusChanged>
             ) : (
-              <BackStatusUnchanged>CHANGES SAVED</BackStatusUnchanged>
+              <BackStatusUnchanged>Changes saved</BackStatusUnchanged>
             )}
           </div>
         </ToolbarSectionBackLink>

--- a/packages/netlify-cms-ui-default/src/styles.js
+++ b/packages/netlify-cms-ui-default/src/styles.js
@@ -113,13 +113,24 @@ const shadows = {
   `,
 };
 
-const textBadge = css`
-  font-size: 13px;
+const badge = css`
+    font-size: 13px;
+    line-height: 1;
+  `;
+
+const backgroundBadge = css`
+  ${badge};
+  display: block;
   border-radius: ${lengths.borderRadius};
   padding: 4px 10px;
   text-align: center;
+`;
+
+const textBadge = css`
+  ${badge};
   display: inline-block;
-  line-height: 1;
+  font-weight: 700;
+  text-transform: uppercase;
 `;
 
 const card = css`
@@ -133,7 +144,6 @@ const buttons = {
     border: 0;
     border-radius: ${lengths.borderRadius};
     cursor: pointer;
-    background-color: ${colorsRaw.blueLight};
   `,
   default: css`
     height: 36px;
@@ -202,6 +212,21 @@ const components = {
     border-top: 6px solid currentColor;
     border-radius: 2px;
   `,
+  badge: css`
+    ${backgroundBadge};
+    color: ${colors.infoText};
+    background-color: ${colors.infoBackground};
+  `,
+  badgeSuccess: css`
+    ${backgroundBadge};
+    color: ${colors.successText};
+    background-color: ${colors.successBackground};
+  `,
+  badgeDanger: css`
+    ${backgroundBadge};
+    color: ${colorsRaw.red};
+    background-color: #fbe0d7;
+  `,
   textBadge: css`
     ${textBadge};
     color: ${colors.infoText};
@@ -209,12 +234,10 @@ const components = {
   textBadgeSuccess: css`
     ${textBadge};
     color: ${colors.successText};
-    font-weight: bold;
   `,
   textBadgeDanger: css`
     ${textBadge};
     color: ${colorsRaw.red};
-    font-weight: bold;
   `,
   loaderSize: css`
     width: 2.28571429rem;

--- a/packages/netlify-cms-ui-default/src/styles.js
+++ b/packages/netlify-cms-ui-default/src/styles.js
@@ -133,6 +133,7 @@ const buttons = {
     border: 0;
     border-radius: ${lengths.borderRadius};
     cursor: pointer;
+    background-color: ${colorsRaw.blueLight};
   `,
   default: css`
     height: 36px;
@@ -204,17 +205,14 @@ const components = {
   textBadge: css`
     ${textBadge};
     color: ${colors.infoText};
-    background-color: ${colors.infoBackground};
   `,
   textBadgeSuccess: css`
     ${textBadge};
     color: ${colors.successText};
-    background-color: ${colors.successBackground};
   `,
   textBadgeDanger: css`
     ${textBadge};
     color: ${colorsRaw.red};
-    background-color: #fbe0d7;
   `,
   loaderSize: css`
     width: 2.28571429rem;

--- a/packages/netlify-cms-ui-default/src/styles.js
+++ b/packages/netlify-cms-ui-default/src/styles.js
@@ -209,10 +209,12 @@ const components = {
   textBadgeSuccess: css`
     ${textBadge};
     color: ${colors.successText};
+    font-weight: bold;
   `,
   textBadgeDanger: css`
     ${textBadge};
     color: ${colorsRaw.red};
+    font-weight: bold;
   `,
   loaderSize: css`
     width: 2.28571429rem;

--- a/packages/netlify-cms-ui-default/src/styles.js
+++ b/packages/netlify-cms-ui-default/src/styles.js
@@ -114,9 +114,9 @@ const shadows = {
 };
 
 const badge = css`
-    font-size: 13px;
-    line-height: 1;
-  `;
+  font-size: 13px;
+  line-height: 1;
+`;
 
 const backgroundBadge = css`
   ${badge};

--- a/packages/netlify-cms-widget-file/src/withFileControl.js
+++ b/packages/netlify-cms-widget-file/src/withFileControl.js
@@ -45,6 +45,7 @@ const FileWidgetButton = styled.button`
 const FileWidgetButtonRemove = styled.button`
   ${buttons.button};
   ${components.textBadgeDanger};
+  ${buttons.lightRed};
   display: block;
 `;
 

--- a/packages/netlify-cms-widget-file/src/withFileControl.js
+++ b/packages/netlify-cms-widget-file/src/withFileControl.js
@@ -38,15 +38,12 @@ const FileName = styled.span`
 
 const FileWidgetButton = styled.button`
   ${buttons.button};
-  ${components.textBadge};
-  display: block;
+  ${components.badge};
 `;
 
 const FileWidgetButtonRemove = styled.button`
   ${buttons.button};
-  ${components.textBadgeDanger};
-  ${buttons.lightRed};
-  display: block;
+  ${components.badgeDanger};
 `;
 
 export default function withFileControl({ forImage } = {}) {


### PR DESCRIPTION
This PR addresses the edit entry page status labels look like a button. This issue was detailed here https://github.com/netlify/netlify-cms/issues/1031

I removed the background color in the success and danger text badges. I then set the default button light blue color at the button level instead of the textBadge css class level. And the status labels have been capitalized and set to bold.

<img width="711" alt="entry-saved-changes" src="https://user-images.githubusercontent.com/137077/41418142-fd1b0882-6fa3-11e8-9cc9-5283fcf0bbcd.png">

<img width="757" alt="entry-unsaved-changes" src="https://user-images.githubusercontent.com/137077/41418184-1537132a-6fa4-11e8-8457-e763da6f1942.png">


Closes #1031.