### PR TITLE
Fix indentation in config example

### DIFF
--- a/website/site/content/docs/authentication-backends.md
+++ b/website/site/content/docs/authentication-backends.md
@@ -101,13 +101,13 @@ With GitLab's Implicit Grant, users can authenticate with GitLab directly from t
 
     ```yaml
     backend:
-    name: gitlab
-    repo: owner-name/repo-name # Path to your GitLab repository
-    auth_type: implicit # Required for implicit grant
-    app_id: your-app-id # Application ID from your GitLab settings
-    api_root: https://my-hosted-gitlab-instance.com/api/v4
-    base_url: https://my-hosted-gitlab-instance.com
-    auth_endpoint: oauth/authorize
+      name: gitlab
+      repo: owner-name/repo-name # Path to your GitLab repository
+      auth_type: implicit # Required for implicit grant
+      app_id: your-app-id # Application ID from your GitLab settings
+      api_root: https://my-hosted-gitlab-instance.com/api/v4
+      base_url: https://my-hosted-gitlab-instance.com
+      auth_endpoint: oauth/authorize
     ```
 
 Note that in both cases, GitLab will also provide you with a client secret. You should _never_ store this in your repo or reveal it in the client.


### PR DESCRIPTION
Warning: This is a wild guess. It makes sense for me that theese lines should be indentated, but I havn't tried it yet (I have no self-hosted Gitlab instance) so someone who knows what he is doing should look over this.

**- Summary**

The yaml example in the docs didn't look right. I think it should be indeted.

**- Test plan**

I havn't checked that this yaml is working (I am not in a possition to do so). Someone with knowledge about the config and the gitlab backend should review this before merging

**- Description for the changelog**

I indented the yaml as good as I could. This gets a bit repetitive here.

**- A picture of a cute animal**

![](https://i.redditmedia.com/Nfw1wbU9OCks1AXjvT3eYMsdvjiavKedX8r46L1Urto.jpg?s=28ce5f0d13b0e6cf7b84d1b12ca6c255)