### PR TITLE
Fixes #1457, int val output in TOML format, adds test

### DIFF
--- a/src/formats/__tests__/frontmatter.spec.js
+++ b/src/formats/__tests__/frontmatter.spec.js
@@ -192,7 +192,7 @@ describe('Frontmatter', () => {
     );
   });
 
-  it('should stringify YAML with --- delimiters when it is explicitly set as the format without a custom delimiter',
+  it('should stringify YAML with --- delimiters when it is explicitly set as the format without a custom delimiter', 
   () => {
     expect(
       frontmatterYAML().toFile({ body: 'Some content\nOn another line', tags: ['front matter', 'yaml'], title: 'YAML' })
@@ -210,7 +210,7 @@ describe('Frontmatter', () => {
       );
   });
 
-  it('should stringify YAML with --- delimiters when it is explicitly set as the format with a custom delimiter',
+  it('should stringify YAML with --- delimiters when it is explicitly set as the format with a custom delimiter', 
   () => {
     expect(
       frontmatterYAML("~~~").toFile({ body: 'Some content\nOn another line', tags: ['front matter', 'yaml'], title: 'YAML' })
@@ -228,7 +228,7 @@ describe('Frontmatter', () => {
       );
   });
 
-  it('should stringify YAML with --- delimiters when it is explicitly set as the format with different custom delimiters',
+  it('should stringify YAML with --- delimiters when it is explicitly set as the format with different custom delimiters', 
   () => {
     expect(
       frontmatterYAML(["~~~", "^^^"]).toFile({ body: 'Some content\nOn another line', tags: ['front matter', 'yaml'], title: 'YAML' })
@@ -278,7 +278,7 @@ describe('Frontmatter', () => {
       );
   });
 
-  it('should stringify JSON with { } delimiters when it is explicitly set as the format without a custom delimiter',
+  it('should stringify JSON with { } delimiters when it is explicitly set as the format without a custom delimiter', 
   () => {
     expect(
       frontmatterJSON().toFile({ body: 'Some content\nOn another line', tags: ['front matter', 'json'], title: 'JSON' })
@@ -297,7 +297,7 @@ describe('Frontmatter', () => {
       );
   });
 
-  it('should stringify JSON with { } delimiters when it is explicitly set as the format with a custom delimiter',
+  it('should stringify JSON with { } delimiters when it is explicitly set as the format with a custom delimiter', 
   () => {
     expect(
       frontmatterJSON("~~~").toFile({ body: 'Some content\nOn another line', tags: ['front matter', 'json'], title: 'JSON' })

--- a/src/formats/__tests__/frontmatter.spec.js
+++ b/src/formats/__tests__/frontmatter.spec.js
@@ -1,5 +1,4 @@
 import { FrontmatterInfer, frontmatterJSON, frontmatterTOML, frontmatterYAML } from '../frontmatter';
-import tomlFormatter from '../toml';
 
 jest.mock("../../valueObjects/AssetProxy.js");
 
@@ -313,20 +312,6 @@ describe('Frontmatter', () => {
         '~~~',
         'Some content',
         'On another line\n',
-      ].join('\n')
-      );
-  });
-});
-
-describe('tomlFormatter', () => {
-  it('should output TOML integer values without decimals', () => {
-    expect(
-      tomlFormatter.toFile({ testFloat: 123.456, testInteger: 789, title: 'TOML' })
-    ).toEqual(
-      [
-        'testFloat = 123.456',
-        'testInteger = 789',
-        'title = "TOML"'
       ].join('\n')
       );
   });

--- a/src/formats/__tests__/frontmatter.spec.js
+++ b/src/formats/__tests__/frontmatter.spec.js
@@ -1,4 +1,5 @@
 import { FrontmatterInfer, frontmatterJSON, frontmatterTOML, frontmatterYAML } from '../frontmatter';
+import tomlFormatter from '../toml';
 
 jest.mock("../../valueObjects/AssetProxy.js");
 
@@ -192,7 +193,7 @@ describe('Frontmatter', () => {
     );
   });
 
-  it('should stringify YAML with --- delimiters when it is explicitly set as the format without a custom delimiter', 
+  it('should stringify YAML with --- delimiters when it is explicitly set as the format without a custom delimiter',
   () => {
     expect(
       frontmatterYAML().toFile({ body: 'Some content\nOn another line', tags: ['front matter', 'yaml'], title: 'YAML' })
@@ -210,7 +211,7 @@ describe('Frontmatter', () => {
       );
   });
 
-  it('should stringify YAML with --- delimiters when it is explicitly set as the format with a custom delimiter', 
+  it('should stringify YAML with --- delimiters when it is explicitly set as the format with a custom delimiter',
   () => {
     expect(
       frontmatterYAML("~~~").toFile({ body: 'Some content\nOn another line', tags: ['front matter', 'yaml'], title: 'YAML' })
@@ -228,7 +229,7 @@ describe('Frontmatter', () => {
       );
   });
 
-  it('should stringify YAML with --- delimiters when it is explicitly set as the format with different custom delimiters', 
+  it('should stringify YAML with --- delimiters when it is explicitly set as the format with different custom delimiters',
   () => {
     expect(
       frontmatterYAML(["~~~", "^^^"]).toFile({ body: 'Some content\nOn another line', tags: ['front matter', 'yaml'], title: 'YAML' })
@@ -278,7 +279,7 @@ describe('Frontmatter', () => {
       );
   });
 
-  it('should stringify JSON with { } delimiters when it is explicitly set as the format without a custom delimiter', 
+  it('should stringify JSON with { } delimiters when it is explicitly set as the format without a custom delimiter',
   () => {
     expect(
       frontmatterJSON().toFile({ body: 'Some content\nOn another line', tags: ['front matter', 'json'], title: 'JSON' })
@@ -297,7 +298,7 @@ describe('Frontmatter', () => {
       );
   });
 
-  it('should stringify JSON with { } delimiters when it is explicitly set as the format with a custom delimiter', 
+  it('should stringify JSON with { } delimiters when it is explicitly set as the format with a custom delimiter',
   () => {
     expect(
       frontmatterJSON("~~~").toFile({ body: 'Some content\nOn another line', tags: ['front matter', 'json'], title: 'JSON' })
@@ -312,6 +313,20 @@ describe('Frontmatter', () => {
         '~~~',
         'Some content',
         'On another line\n',
+      ].join('\n')
+      );
+  });
+});
+
+describe('tomlFormatter', () => {
+  it('should output TOML integer values without decimals', () => {
+    expect(
+      tomlFormatter.toFile({ testFloat: 123.456, testInteger: 789, title: 'TOML' })
+    ).toEqual(
+      [
+        'testFloat = 123.456',
+        'testInteger = 789',
+        'title = "TOML"'
       ].join('\n')
       );
   });

--- a/src/formats/__tests__/tomlFormatter.spec.js
+++ b/src/formats/__tests__/tomlFormatter.spec.js
@@ -1,0 +1,15 @@
+import tomlFormatter from '../toml';
+
+describe('tomlFormatter', () => {
+  it('should output TOML integer values without decimals', () => {
+    expect(
+      tomlFormatter.toFile({ testFloat: 123.456, testInteger: 789, title: 'TOML' })
+    ).toEqual(
+      [
+        'testFloat = 123.456',
+        'testInteger = 789',
+        'title = "TOML"'
+      ].join('\n')
+      );
+  });
+});

--- a/src/formats/toml.js
+++ b/src/formats/toml.js
@@ -4,12 +4,18 @@ import moment from 'moment';
 import AssetProxy from 'ValueObjects/AssetProxy';
 import { sortKeys } from './helpers';
 
+// IE polyfill for Number.isInteger
+Number.isInteger = Number.isInteger || (value => typeof value === "number" && isFinite(value) && Math.floor(value) === value);
+
 const outputReplacer = (key, value) => {
   if (moment.isMoment(value)) {
     return value.format(value._f);
   }
   if (value instanceof AssetProxy) {
     return `${ value.path }`;
+  }
+  if (Number.isInteger(value)) {
+    return `${ value }`;
   }
   // Return `false` to use default (`undefined` would delete key).
   return false;

--- a/src/formats/toml.js
+++ b/src/formats/toml.js
@@ -12,6 +12,7 @@ const outputReplacer = (key, value) => {
     return `${ value.path }`;
   }
   if (Number.isInteger(value)) {
+    // Return the string representation of integers so tomlify won't render with tenths (".0")
     return value.toString();
   }
   // Return `false` to use default (`undefined` would delete key).

--- a/src/formats/toml.js
+++ b/src/formats/toml.js
@@ -4,9 +4,6 @@ import moment from 'moment';
 import AssetProxy from 'ValueObjects/AssetProxy';
 import { sortKeys } from './helpers';
 
-// IE polyfill for Number.isInteger
-Number.isInteger = Number.isInteger || (value => typeof value === "number" && isFinite(value) && Math.floor(value) === value);
-
 const outputReplacer = (key, value) => {
   if (moment.isMoment(value)) {
     return value.format(value._f);

--- a/src/formats/toml.js
+++ b/src/formats/toml.js
@@ -15,7 +15,7 @@ const outputReplacer = (key, value) => {
     return `${ value.path }`;
   }
   if (Number.isInteger(value)) {
-    return `${ value }`;
+    return value.toString();
   }
   // Return `false` to use default (`undefined` would delete key).
   return false;


### PR DESCRIPTION
**- Summary**
Fixes #1457, int val output in TOML format, adds test

**- Test plan**
Test added and passing for int and float

**- Description for the changelog**
Fix int val output in TOML format file
