### PR TITLE
Fix multi branch github deployes by appending branch name for cms pul…

### DIFF
--- a/packages/netlify-cms-backend-github/src/API.js
+++ b/packages/netlify-cms-backend-github/src/API.js
@@ -9,12 +9,12 @@ export default class API {
     this.api_root = config.api_root || 'https://api.github.com';
     this.token = config.token || false;
     this.branch = config.branch || 'master';
-    let branch_prefix = config.branch_prefix || 'cms';
-    if (!/\/$/.test(branch_prefix)) {
+    let workflow_branch_prefix = config.workflow_branch_prefix || 'cms';
+    if (!/\/$/.test(workflow_branch_prefix)) {
       // Make sure we always have a trailing /
-      branch_prefix += '/';
+      workflow_branch_prefix += '/';
     }
-    this.branch_prefix = branch_prefix;
+    this.workflow_branch_prefix = workflow_branch_prefix;
     this.repo = config.repo || '';
     this.repoURL = `/repos/${this.repo}`;
     this.merge_method = config.squash_merges ? 'squash' : 'merge';
@@ -95,7 +95,7 @@ export default class API {
   }
 
   generateBranchName(basename) {
-    return `${this.branch_prefix}${basename}`;
+    return `${this.workflow_branch_prefix}${basename}`;
   }
 
   checkMetadataRef() {
@@ -654,7 +654,7 @@ export default class API {
   }
 
   assertCmsBranch(branchName) {
-    return branchName.startsWith(this.branch_prefix);
+    return branchName.startsWith(this.workflow_branch_prefix);
   }
 
   patchBranch(branchName, sha, opts = {}) {

--- a/packages/netlify-cms-backend-github/src/API.js
+++ b/packages/netlify-cms-backend-github/src/API.js
@@ -4,13 +4,17 @@ import { uniq, initial, last, get, find, hasIn, partial, result } from 'lodash';
 import { filterPromises, resolvePromiseProperties } from 'netlify-cms-lib-util';
 import { APIError, EditorialWorkflowError } from 'netlify-cms-lib-util';
 
-const CMS_BRANCH_PREFIX = 'cms/';
-
 export default class API {
   constructor(config) {
     this.api_root = config.api_root || 'https://api.github.com';
     this.token = config.token || false;
     this.branch = config.branch || 'master';
+    let branch_prefix = config.branch_prefix || 'cms';
+    if (!/\/$/.test(branch_prefix)) {
+      // Make sure we always have a trailing /
+      branch_prefix += '/';
+    }
+    this.branch_prefix = branch_prefix;
     this.repo = config.repo || '';
     this.repoURL = `/repos/${this.repo}`;
     this.merge_method = config.squash_merges ? 'squash' : 'merge';
@@ -91,7 +95,7 @@ export default class API {
   }
 
   generateBranchName(basename) {
-    return `${CMS_BRANCH_PREFIX}${basename}`;
+    return `${this.branch_prefix}${basename}`;
   }
 
   checkMetadataRef() {
@@ -650,7 +654,7 @@ export default class API {
   }
 
   assertCmsBranch(branchName) {
-    return branchName.startsWith(CMS_BRANCH_PREFIX);
+    return branchName.startsWith(this.branch_prefix);
   }
 
   patchBranch(branchName, sha, opts = {}) {

--- a/packages/netlify-cms-backend-github/src/API.js
+++ b/packages/netlify-cms-backend-github/src/API.js
@@ -9,12 +9,7 @@ export default class API {
     this.api_root = config.api_root || 'https://api.github.com';
     this.token = config.token || false;
     this.branch = config.branch || 'master';
-    let workflow_branch_prefix = config.workflow_branch_prefix || 'cms';
-    if (!/\/$/.test(workflow_branch_prefix)) {
-      // Make sure we always have a trailing /
-      workflow_branch_prefix += '/';
-    }
-    this.workflow_branch_prefix = workflow_branch_prefix;
+    this.workflow_branch_prefix = config.workflow_branch_prefix;
     this.repo = config.repo || '';
     this.repoURL = `/repos/${this.repo}`;
     this.merge_method = config.squash_merges ? 'squash' : 'merge';
@@ -95,7 +90,7 @@ export default class API {
   }
 
   generateBranchName(basename) {
-    return `${this.workflow_branch_prefix}${basename}`;
+    return `${this.workflow_branch_prefix}/${basename}`;
   }
 
   checkMetadataRef() {
@@ -654,7 +649,7 @@ export default class API {
   }
 
   assertCmsBranch(branchName) {
-    return branchName.startsWith(this.workflow_branch_prefix);
+    return branchName.startsWith(`${this.workflow_branch_prefix}/`);
   }
 
   patchBranch(branchName, sha, opts = {}) {

--- a/packages/netlify-cms-backend-github/src/implementation.js
+++ b/packages/netlify-cms-backend-github/src/implementation.js
@@ -22,6 +22,7 @@ export default class GitHub {
 
     this.repo = config.getIn(['backend', 'repo'], '');
     this.branch = config.getIn(['backend', 'branch'], 'master').trim();
+    this.branch_prefix = config.getIn(['backend', 'branch_prefix'], 'cms').trim();
     this.api_root = config.getIn(['backend', 'api_root'], 'https://api.github.com');
     this.token = '';
     this.squash_merges = config.getIn(['backend', 'squash_merges']);
@@ -40,6 +41,7 @@ export default class GitHub {
     this.api = new API({
       token: this.token,
       branch: this.branch,
+      branch_prefix: this.branch_prefix,
       repo: this.repo,
       api_root: this.api_root,
       squash_merges: this.squash_merges,
@@ -158,7 +160,7 @@ export default class GitHub {
         branches.map(branch => {
           promises.push(
             new Promise(resolve => {
-              const slug = branch.ref.split('refs/heads/cms/').pop();
+              const slug = branch.ref.split(`refs/heads/${this.branch_prefix}/`).pop();
               return sem.take(() =>
                 this.api
                   .readUnpublishedBranchFile(slug)

--- a/packages/netlify-cms-backend-github/src/implementation.js
+++ b/packages/netlify-cms-backend-github/src/implementation.js
@@ -1,4 +1,4 @@
-import trimStart from 'lodash/trimStart';
+import { trim, trimStart } from 'lodash';
 import semaphore from 'semaphore';
 import AuthenticationPage from './AuthenticationPage';
 import API from './API';
@@ -22,7 +22,8 @@ export default class GitHub {
 
     this.repo = config.getIn(['backend', 'repo'], '');
     this.branch = config.getIn(['backend', 'branch'], 'master').trim();
-    this.branch_prefix = config.getIn(['backend', 'branch_prefix'], 'cms').trim();
+    this.workflow_branch_prefix =
+      trim(config.getIn(['backend', 'workflow_branch_prefix'], '/ ')) || 'cms';
     this.api_root = config.getIn(['backend', 'api_root'], 'https://api.github.com');
     this.token = '';
     this.squash_merges = config.getIn(['backend', 'squash_merges']);
@@ -41,7 +42,7 @@ export default class GitHub {
     this.api = new API({
       token: this.token,
       branch: this.branch,
-      branch_prefix: this.branch_prefix,
+      workflow_branch_prefix: this.workflow_branch_prefix,
       repo: this.repo,
       api_root: this.api_root,
       squash_merges: this.squash_merges,
@@ -160,7 +161,7 @@ export default class GitHub {
         branches.map(branch => {
           promises.push(
             new Promise(resolve => {
-              const slug = branch.ref.split(`refs/heads/${this.branch_prefix}/`).pop();
+              const slug = branch.ref.split(`refs/heads/${this.workflow_branch_prefix}/`).pop();
               return sem.take(() =>
                 this.api
                   .readUnpublishedBranchFile(slug)

--- a/packages/netlify-cms-backend-github/src/implementation.js
+++ b/packages/netlify-cms-backend-github/src/implementation.js
@@ -23,7 +23,7 @@ export default class GitHub {
     this.repo = config.getIn(['backend', 'repo'], '');
     this.branch = config.getIn(['backend', 'branch'], 'master').trim();
     this.workflow_branch_prefix =
-      trim(config.getIn(['backend', 'workflow_branch_prefix'], '/ ')) || 'cms';
+      trim(config.getIn(['backend', 'workflow_branch_prefix'], ''), '/ ') || 'cms';
     this.api_root = config.getIn(['backend', 'api_root'], 'https://api.github.com');
     this.token = '';
     this.squash_merges = config.getIn(['backend', 'squash_merges']);

--- a/website/content/docs/beta-features.md
+++ b/website/content/docs/beta-features.md
@@ -120,3 +120,25 @@ Template tags produce the following output:
 - `{{collection}}`: the name of the collection containing the entry changed
 
 - `{{path}}`: the full path to the file changed
+
+## Custom CMS Preview Branches
+
+By default the CMS will use "cms/"" as the prefix for preview branches. For example when updating a content file
+you might see a branch called ```cms/2018-06-25-this-is-a-slug``` to contain changes applied and not published.
+This is essentially a draft inside of the workflow panel.
+
+If you need to have multiple deployments against different branches and their own CMS then using the same "cms/"
+prefix will cause unpublished files to show up as unpublished files on both CMS instances, but publishing one
+of them will pull it into the branch configued inside of that site's config.yml backend.branch branch.
+To allow this you can configure a custom branch_prefix for the workflow on each site by specifying
+```backend.branch_prefix```. If this value is not configured then it will automatically default to "cms/".
+
+Example:
+
+```yaml
+backend:
+  branch_prefix: cms-dev
+  branch: dev
+```
+
+The default for this value is "cms"

--- a/website/content/docs/beta-features.md
+++ b/website/content/docs/beta-features.md
@@ -121,23 +121,27 @@ Template tags produce the following output:
 
 - `{{path}}`: the full path to the file changed
 
-## Custom CMS Preview Branches
+## Custom Editorial Workflow branch name prefixes
 
-By default the CMS will use "cms/"" as the prefix for preview branches. For example when updating a content file
-you might see a branch called ```cms/2018-06-25-this-is-a-slug``` to contain changes applied and not published.
-This is essentially a draft inside of the workflow panel.
+When using [editorial workflow](), a branch is created for each entry. By default the branch name
+follows this template:
 
-If you need to have multiple deployments against different branches and their own CMS then using the same "cms/"
-prefix will cause unpublished files to show up as unpublished files on both CMS instances, but publishing one
-of them will pull it into the branch configued inside of that site's config.yml backend.branch branch.
-To allow this you can configure a custom workflow_branch_prefix for the workflow on each site by specifying ```backend.workflow_branch_prefix```. If this value is not configured then it will automatically default to "cms/".
+```
+cms/{{slug}}
+```
 
-Example:
+You can customize the `cms` portion by setting `workflow_branch_prefix` under `backend` in your
+`config.yml`:
 
 ```yaml
 backend:
-  workflow_branch_prefix: cms-dev
+  name: some-backend
   branch: dev
+  workflow_branch_prefix: cms-dev
 ```
 
-The default for this value is "cms"
+The above configuration would change the branch name template to:
+
+```
+cms-dev/{{slug}}
+```

--- a/website/content/docs/beta-features.md
+++ b/website/content/docs/beta-features.md
@@ -130,14 +130,13 @@ This is essentially a draft inside of the workflow panel.
 If you need to have multiple deployments against different branches and their own CMS then using the same "cms/"
 prefix will cause unpublished files to show up as unpublished files on both CMS instances, but publishing one
 of them will pull it into the branch configued inside of that site's config.yml backend.branch branch.
-To allow this you can configure a custom branch_prefix for the workflow on each site by specifying
-```backend.branch_prefix```. If this value is not configured then it will automatically default to "cms/".
+To allow this you can configure a custom workflow_branch_prefix for the workflow on each site by specifying ```backend.workflow_branch_prefix```. If this value is not configured then it will automatically default to "cms/".
 
 Example:
 
 ```yaml
 backend:
-  branch_prefix: cms-dev
+  workflow_branch_prefix: cms-dev
   branch: dev
 ```
 


### PR DESCRIPTION
Added support to name space the CMS_BRANCH_PREFIX by including the branch name for non-master branches. This allows multiple deployments to each user their own branch and their own pull requests.
