### PR TITLE
And training forward slash to example URI for GitLab

### DIFF
--- a/website/site/content/docs/authentication-backends.md
+++ b/website/site/content/docs/authentication-backends.md
@@ -86,7 +86,7 @@ To enable it:
 
 With GitLab's Implicit Grant, users can authenticate with GitLab directly from the client. To do this:
 
-1. Follow the [GitLab docs](https://docs.gitlab.com/ee/integration/oauth_provider.html#adding-an-application-through-the-profile) to add your Netlify CMS instance as an OAuth application. For the **Redirect URI**, enter the address where you access Netlify CMS, for example, `https://www.mysite.com/admin`. For scope, select `api`.
+1. Follow the [GitLab docs](https://docs.gitlab.com/ee/integration/oauth_provider.html#adding-an-application-through-the-profile) to add your Netlify CMS instance as an OAuth application. For the **Redirect URI**, enter the address where you access Netlify CMS, for example, `https://www.mysite.com/admin/`. For scope, select `api`.
 2. GitLab will give you an **Application ID**. Copy this and enter it in your Netlify CMS `config.yml` file, along with the following settings:
 
     ```yaml


### PR DESCRIPTION
**- Summary**

The example URI for creating an application in GitLab does not contain a trailing `/` but the Netlify CMS admin oauth implicit grant request to GitLab does include a trailing `/`.  This results in a failure with GitLab not matching the URI and returning an error. 

Following the example explicitly as most will do with copy-paste,  `https://example.com/app/admin` will be entered. Then the Netlify admin login will send `https://example.com/app/admin` and the URI will not match and GitLab will show an error indicating the URI is invalid.

The easy fix for the user is just to put the trailing `/` ... `https://example.com/app/admin/`.

I updated that example string in the hopes that users will not have to figure this out on their own in the future.

**- Test plan**

Doc change. Just run normal test suite.

**- Description for the changelog**

Fix GitLab oauth documentation to include correct URI format.

