### PR TITLE
Fix default value support in editor components

### DIFF
--- a/src/actions/entries.js
+++ b/src/actions/entries.js
@@ -346,7 +346,11 @@ export function createEmptyDraft(collection) {
   return (dispatch) => {
     const dataFields = {};
     collection.get('fields', List()).forEach((field) => {
-      dataFields[field.get('name')] = field.get('default');
+      let defaultValue = field.get('default');
+      if (typeof defaultValue === 'function') {
+        defaultValue = defaultValue(collection);
+      }
+      dataFields[field.get('name')] = defaultValue;
     });
     const newEntry = createEntry(collection.get('name'), '', '', { data: dataFields });
     dispatch(emptyDraftCreated(newEntry));

--- a/src/components/EditorWidgets/Markdown/MarkdownControl/VisualEditor/index.js
+++ b/src/components/EditorWidgets/Markdown/MarkdownControl/VisualEditor/index.js
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types';
 import ImmutablePropTypes from 'react-immutable-proptypes';
 import React, { Component } from 'react';
 import { get, isEmpty, debounce } from 'lodash';
-import { Map } from 'immutable';
+import { Map, List } from 'immutable';
 import { Value, Document, Block, Text } from 'slate';
 import { Editor as Slate } from 'slate-react';
 import { slateToMarkdown, markdownToSlate, htmlToSlate } from 'EditorWidgets/Markdown/serializers';
@@ -141,13 +141,20 @@ export default class Editor extends Component {
   handlePluginAdd = pluginId => {
     const { value } = this.state;
     const nodes = [Text.create('')];
+    const pluginDefinition = getEditorComponents().get(pluginId);
+
+    const defaultValues = {};
+    pluginDefinition.get('fields', List()).forEach((field) => {
+      let defaultValue = field.get('default');
+      defaultValues[field.get('name')] = defaultValue;
+    });
     const block = {
       kind: 'block',
       type: 'shortcode',
       data: {
         shortcode: pluginId,
         shortcodeNew: true,
-        shortcodeData: Map(),
+        shortcodeData: new Map(defaultValues)
       },
       isVoid: true,
       nodes

--- a/src/components/EditorWidgets/Markdown/MarkdownControl/VisualEditor/index.js
+++ b/src/components/EditorWidgets/Markdown/MarkdownControl/VisualEditor/index.js
@@ -146,6 +146,9 @@ export default class Editor extends Component {
     const defaultValues = {};
     pluginDefinition.get('fields', List()).forEach((field) => {
       let defaultValue = field.get('default');
+      if (typeof defaultValue === 'function') {
+        defaultValue = defaultValue(pluginDefinition);
+      }
       defaultValues[field.get('name')] = defaultValue;
     });
     const block = {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines;
https://github.com/netlify/netlify-cms/blob/master/CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first three fields are mandatory:
-->

**- Summary**

<!--
Explain the **motivation** for making this change.
What existing problem does the pull request solve?
-->

Fix #1406 -- see the description in the issue.

Also includes a simple implementation of #1407 that's at least compatible with custom components (but there's no way to achieve dynamic default values via config.yml). I needed this myself to get my automatically issued uuids to work, but feel free to ignore that commit if a solution for https://github.com/netlify/netlify-cms/issues/1409 is required to be a part of that feature.

**- Test plan**

<!--
Demonstrate the code is solid.
Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.
-->

I've tested it manually in my own application and found that the default values work with various widgets, including `hidden`.

**- Description for the changelog**

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Editor components: Fix support for default field values 