### PR TITLE
Avoid producing invalid markdown when styled text has leading or trailing whitespace

### DIFF
--- a/packages/netlify-cms-widget-markdown/src/serializers/__tests__/slate.spec.js
+++ b/packages/netlify-cms-widget-markdown/src/serializers/__tests__/slate.spec.js
@@ -36,15 +36,16 @@ describe('slate', () => {
 
   it('should not produce invalid markdown when a styled block has trailing whitespace', () => {
     const slateAst = {
-      kind: 'block',
+      object: 'block',
       type: 'root',
       nodes: [
         {
-          kind: 'block',
+          object: 'block',
           type: 'paragraph',
           nodes: [
             {
-              kind: 'text',
+              object: 'text',
+              data: undefined,
               leaves: [
                 {
                   text: 'foo ', // <--
@@ -52,10 +53,7 @@ describe('slate', () => {
                 },
               ],
             },
-            {
-              kind: 'text',
-              leaves: [{ text: 'bar' }],
-            },
+            { object: 'text', data: undefined, leaves: [{ text: 'bar' }] },
           ],
         },
       ],
@@ -65,19 +63,17 @@ describe('slate', () => {
 
   it('should not produce invalid markdown when a styled block has leading whitespace', () => {
     const slateAst = {
-      kind: 'block',
+      object: 'block',
       type: 'root',
       nodes: [
         {
-          kind: 'block',
+          object: 'block',
           type: 'paragraph',
           nodes: [
+            { object: 'text', data: undefined, leaves: [{ text: 'foo' }] },
             {
-              kind: 'text',
-              leaves: [{ text: 'foo' }],
-            },
-            {
-              kind: 'text',
+              object: 'text',
+              data: undefined,
               leaves: [
                 {
                   text: ' bar', // <--

--- a/packages/netlify-cms-widget-markdown/src/serializers/__tests__/slate.spec.js
+++ b/packages/netlify-cms-widget-markdown/src/serializers/__tests__/slate.spec.js
@@ -33,4 +33,62 @@ describe('slate', () => {
   it('should not escape markdown entities in html', () => {
     expect(process('<span>*</span>')).toEqual('<span>*</span>');
   });
+
+  it('should not produce invalid markdown when a styled block has trailing whitespace', () => {
+    const slateAst = {
+      kind: 'block',
+      type: 'root',
+      nodes: [
+        {
+          kind: 'block',
+          type: 'paragraph',
+          nodes: [
+            {
+              kind: 'text',
+              leaves: [
+                {
+                  text: 'foo ', // <--
+                  marks: [{ type: 'bold' }],
+                },
+              ],
+            },
+            {
+              kind: 'text',
+              leaves: [{ text: 'bar' }],
+            },
+          ],
+        },
+      ],
+    };
+    expect(slateToMarkdown(slateAst)).toEqual('**foo** bar');
+  });
+
+  it('should not produce invalid markdown when a styled block has leading whitespace', () => {
+    const slateAst = {
+      kind: 'block',
+      type: 'root',
+      nodes: [
+        {
+          kind: 'block',
+          type: 'paragraph',
+          nodes: [
+            {
+              kind: 'text',
+              leaves: [{ text: 'foo' }],
+            },
+            {
+              kind: 'text',
+              leaves: [
+                {
+                  text: ' bar', // <--
+                  marks: [{ type: 'bold' }],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+    expect(slateToMarkdown(slateAst)).toEqual('foo **bar**');
+  });
 });


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines;
https://github.com/netlify/netlify-cms/blob/master/CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first three fields are mandatory:
-->

**- Summary**

<!--
Explain the **motivation** for making this change.
What existing problem does the pull request solve?
-->

See the background on #1448.

I'm not sure if this is the "correct" place to fix it up, let me know if there's a better way.

I've added the fix to my fork and am now running it in production. Will update here if I find bugs or cases it doesn't cover :)

**- Test plan**

<!--
Demonstrate the code is solid.
Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.
-->

Added some test cases, tested manually.

**- Description for the changelog**

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Fix: Invalid markdown generated when applying styling to a selection with leading or trailing whitespace (#1448)