### PR TITLE
Add notification banner to announce 2.0

### DIFF
--- a/website/data/notifications.yml
+++ b/website/data/notifications.yml
@@ -17,6 +17,12 @@ notifications:
 - loud: true
   message: >-
     Netlify CMS now supports GitLab!
-  published: true
+  published: false
   title: GitLab announcement
   url: '/blog/2018/06/netlify-cms-now-supports-gitlab-as-a-backend/'
+- loud: true
+  message: >-
+    Announcing 2.0 - Bitbucket support and monorepo architecture!
+  published: true
+  title: 2.0 announcement
+  url: '/blog/2018/07/netlify-cms-2-0-launches-with-bitbucket-support-and-a-new-monorepo-architecture'


### PR DESCRIPTION
**- Summary**

Updates the notification banner to announce 2.0 and link to the related blog post. Feel free to change the wording!

**- Test plan**

See it in the branch deploy: https://add-2-0-notification--netlify-cms-www.netlify.com.
Clicking the banner should take you to the blog post.

Once merged to master, this will join the new docs and blog post in the master branch deploy, ready to be published when the publication branch is switched from v1 to master.