### PR TITLE
fix(build): output aliased cms.js w/ deprecation

### DIFF
--- a/packages/netlify-cms/scripts/deprecate-old-dist.js
+++ b/packages/netlify-cms/scripts/deprecate-old-dist.js
@@ -1,0 +1,1 @@
+console.warn('The `cms.js` file is deprecated and  will be removed in the next major release. Please use `netlify-cms.js` instead.');

--- a/packages/netlify-cms/webpack.config.js
+++ b/packages/netlify-cms/webpack.config.js
@@ -1,8 +1,27 @@
 const path = require('path');
 const coreWebpackConfig = require('../netlify-cms-core/webpack.config.js');
 
-module.exports = {
-  ...coreWebpackConfig,
-  context: path.join(__dirname, 'src'),
-  entry: './index.js',
-};
+module.exports = [
+  {
+    ...coreWebpackConfig,
+    context: path.join(__dirname, 'src'),
+    entry: './index.js',
+  },
+
+  /**
+   * Output the same script a second time, but named `cms.js`, and with a
+   * deprecation notice.
+   */
+  {
+    ...coreWebpackConfig,
+    context: path.join(__dirname, 'src'),
+    entry: [
+      ...coreWebpackConfig.entry,
+      path.join(__dirname, 'scripts/deprecate-old-dist.js'),
+    ],
+    output: {
+      ...coreWebpackConfig.output,
+      filename: 'dist/cms.js',
+    },
+  },
+];

--- a/website/content/docs/add-to-your-site.md
+++ b/website/content/docs/add-to-your-site.md
@@ -30,7 +30,7 @@ admin
  └ config.yml
 ```
 
-The first file, `admin/index.html`, is the entry point for the Netlify CMS admin interface. This means that users can navigate to `yoursite.com/admin/` to access it. On the code side, it's a basic HTML starter page that loads the necessary CSS and JavaScript files. In this example, we pull those files from a public CDN:
+The first file, `admin/index.html`, is the entry point for the Netlify CMS admin interface. This means that users can navigate to `yoursite.com/admin/` to access it. On the code side, it's a basic HTML starter page that loads the Netlify CMS JavaScript file. In this example, we pull the file from a public CDN:
 
 ```html
 <!doctype html>
@@ -39,14 +39,10 @@ The first file, `admin/index.html`, is the entry point for the Netlify CMS admin
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Content Manager</title>
-
-  <!-- Include the styles for the Netlify CMS UI, after your own styles -->
-  <link rel="stylesheet" href="https://unpkg.com/netlify-cms@^1.0.0/dist/cms.css" />
-
 </head>
 <body>
   <!-- Include the script that builds the page and powers Netlify CMS -->
-  <script src="https://unpkg.com/netlify-cms@^1.0.0/dist/cms.js"></script>
+  <script src="https://unpkg.com/netlify-cms@^2.0.0/dist/netlify-cms.js"></script>
 </body>
 </html>
 ```

--- a/website/content/docs/custom-widgets.md
+++ b/website/content/docs/custom-widgets.md
@@ -45,7 +45,7 @@ CMS.registerWidget(name, control, [preview]);
 **Example:**
 
 ```html
-<script src="https://unpkg.com/netlify-cms@^1.0.0/dist/cms.js"></script>
+<script src="https://unpkg.com/netlify-cms@^2.0.0/dist/netlify-cms.js"></script>
 <script>
 var CategoriesControl = createClass({
   handleChange: function(e) {
@@ -87,7 +87,7 @@ CMS.registerEditorComponent(definition)
 **Example:**
 
 ```html
-<script src="https://unpkg.com/netlify-cms@^1.0.0/dist/cms.js"></script>
+<script src="https://unpkg.com/netlify-cms@^2.0.0/dist/netlify-cms.js"></script>
 <script>
 CMS.registerEditorComponent({
   // Internal id of the component

--- a/website/content/docs/customization.md
+++ b/website/content/docs/customization.md
@@ -31,7 +31,7 @@ CMS.registerPreviewStyle(file);
 
 ```html
 // index.html
-<script src="https://unpkg.com/netlify-cms@^1.0.0/dist/cms.js"></script>
+<script src="https://unpkg.com/netlify-cms@^2.0.0/dist/netlify-cms.js"></script>
 <script>
   CMS.registerPreviewStyle("/example.css");
 </script>
@@ -69,7 +69,7 @@ Registers a template for a collection.
     **Example:**
 
     ```html
-    <script src="https://unpkg.com/netlify-cms@^1.0.0/dist/cms.js"></script>
+    <script src="https://unpkg.com/netlify-cms@^2.0.0/dist/netlify-cms.js"></script>
     <script>
     var PostPreview = createClass({
       render: function() {

--- a/website/content/docs/update-the-cms-version.md
+++ b/website/content/docs/update-the-cms-version.md
@@ -14,12 +14,12 @@ If you are using a package manager like Yarn or NPM, you will use their standard
 
 If you are using the CMS through a CDN like Unpkg, then that depends on the version tag you are using. You can find the version tag you are using in the `/admin/index.html` file of your site.
 
-- (Recommended) If you use `^1.0.0`, the CMS will do all updates except major versions automatically.
-   - It will upgrade to `1.0.1`, `1.1.0`, `1.1.2`.
-   - It will not upgrade to `2.0.0` or higher.
+- (Recommended) If you use `^2.0.0`, the CMS will do all updates except major versions automatically.
+   - It will upgrade to `2.0.1`, `2.1.0`, `2.1.2`.
+   - It will not upgrade to `3.0.0` or higher.
    - It will not upgrade to beta versions.
 
-- If you use `~1.0.0`, the CMS will do only patch updates automatically.
-   - It will upgrade `1.0.1`, `1.0.2`.
-   - It will not upgrade to `1.1.0` or higher.
+- If you use `~2.0.0`, the CMS will do only patch updates automatically.
+   - It will upgrade `2.0.1`, `2.0.2`.
+   - It will not upgrade to `2.1.0` or higher.
    - It will not upgrade beta versions.

--- a/website/static/admin/index.html
+++ b/website/static/admin/index.html
@@ -5,12 +5,8 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 
   <title>Content Manager</title>
-  <!-- Include the stylesheets from your site here -->
-  <link rel="stylesheet" href="https://unpkg.com/netlify-cms/dist/cms.css" />
-  <!-- Include a CMS specific stylesheet here -->
-
 </head>
 <body>
-  <script src="https://unpkg.com/netlify-cms/dist/cms.js"></script>
+  <script src="https://unpkg.com/netlify-cms/dist/netlify-cms.js"></script>
 </body>
 </html>


### PR DESCRIPTION
When loading Netlify CMS via script tag from a CDN, the file was named
`cms.js` until 2.0, when it was renamed to `netlify-cms.js` in alignment
with all packages outputting files that match the package name. To avoid
a lot of broken sites and confusion, this commit outputs both filenames
and prints a deprecation warning to the console in `cms.js` only.