### PR TITLE
fix: log version from netlify-cms package only

### DIFF
--- a/packages/netlify-cms-core/src/bootstrap.js
+++ b/packages/netlify-cms-core/src/bootstrap.js
@@ -20,7 +20,11 @@ function bootstrap(opts = {}) {
   /**
    * Log the version number.
    */
-  console.log(`Netlify CMS version ${NETLIFY_CMS_VERSION}`);
+  if (NETLIFY_CMS_VERSION) {
+    console.log(`netlify-cms ${NETLIFY_CMS_VERSION}`);
+  } else if (NETLIFY_CMS_CORE_VERSION) {
+    console.log(`netlify-cms-core ${NETLIFY_CMS_CORE_VERSION}`);
+  }
 
   /**
    * Get DOM element where app will mount.

--- a/packages/netlify-cms-core/webpack.config.js
+++ b/packages/netlify-cms-core/webpack.config.js
@@ -1,4 +1,6 @@
 const path = require('path');
+const webpack = require('webpack');
+const pkg = require('./package.json');
 const FriendlyErrorsWebpackPlugin = require('friendly-errors-webpack-plugin');
 const { getConfig, rules, plugins } = require('../../scripts/webpack.js');
 
@@ -47,6 +49,10 @@ module.exports = {
     ...Object.entries(plugins)
       .filter(([ key ]) => key !== 'friendlyErrors')
       .map(([ _, plugin ]) => plugin()),
+    new webpack.DefinePlugin({
+      NETLIFY_CMS_VERSION: null,
+      NETLIFY_CMS_CORE_VERSION: JSON.stringify(`${pkg.version}${isProduction ? '' : '-dev'}`),
+    }),
     new FriendlyErrorsWebpackPlugin({
       compilationSuccessInfo: {
         messages: ['Netlify CMS is now running at http://localhost:8080'],

--- a/packages/netlify-cms/scripts/deprecate-old-dist.js
+++ b/packages/netlify-cms/scripts/deprecate-old-dist.js
@@ -1,1 +1,1 @@
-console.warn('The `cms.js` file is deprecated and  will be removed in the next major release. Please use `netlify-cms.js` instead.');
+console.warn('You seem to be loading Netlify CMS by fetching `dist/cms.js` from a CDN. That file is deprecated and will be removed in the next major release. Please use `dist/netlify-cms.js` instead.')

--- a/packages/netlify-cms/webpack.config.js
+++ b/packages/netlify-cms/webpack.config.js
@@ -1,26 +1,38 @@
 const path = require('path');
+const webpack = require('webpack');
+const pkg = require('./package.json');
 const coreWebpackConfig = require('../netlify-cms-core/webpack.config.js');
 
+const isProduction = process.env.NODE_ENV === 'production';
+
+const baseConfig = {
+  ...coreWebpackConfig,
+  context: path.join(__dirname, 'src'),
+  entry: './index.js',
+  plugins: [
+    ...coreWebpackConfig.plugins.filter(plugin => !plugin instanceof webpack.DefinePlugin),
+    new webpack.DefinePlugin({
+      NETLIFY_CMS_VERSION: JSON.stringify(`${pkg.version}${isProduction ? '' : '-dev'}`),
+      NETLIFY_CMS_CORE_VERSION: null,
+    }),
+  ],
+};
+
 module.exports = [
-  {
-    ...coreWebpackConfig,
-    context: path.join(__dirname, 'src'),
-    entry: './index.js',
-  },
+  baseConfig,
 
   /**
    * Output the same script a second time, but named `cms.js`, and with a
    * deprecation notice.
    */
   {
-    ...coreWebpackConfig,
-    context: path.join(__dirname, 'src'),
+    ...baseConfig,
     entry: [
-      ...coreWebpackConfig.entry,
       path.join(__dirname, 'scripts/deprecate-old-dist.js'),
+      baseConfig.entry,
     ],
     output: {
-      ...coreWebpackConfig.output,
+      ...baseConfig.output,
       filename: 'dist/cms.js',
     },
   },

--- a/scripts/webpack.js
+++ b/scripts/webpack.js
@@ -25,9 +25,6 @@ const rules = () => ({
 
 const plugins = () => {
   return {
-    define: () => new webpack.DefinePlugin({
-      NETLIFY_CMS_VERSION: JSON.stringify(`${pkg.version}${isProduction ? '' : '-dev'}`),
-    }),
     ignoreEsprima: () => new webpack.IgnorePlugin(/^esprima$/, /js-yaml/),
     ignoreMomentOptionalDeps: () => new webpack.IgnorePlugin(/^\.\/locale$/, /moment$/),
     friendlyErrors: () => new FriendlyErrorsWebpackPlugin(),


### PR DESCRIPTION
Since `netlify-cms-core` and `netlify-cms` are independently versioned, we'll print the version of `netlify-cms` if it's used, otherwise of `netlify-cms-core`. We infer the version of every dependency  from the `netlify-cms` version, but when `netlify-cms-core` is used, extension versions are unknown.

Side note: extensions should start providing a package name and version at registration time for validation and error reporting purposes.