### PR TITLE
Add support for setting custom identifier field 

### DIFF
--- a/packages/netlify-cms-core/src/backend.js
+++ b/packages/netlify-cms-core/src/backend.js
@@ -42,7 +42,9 @@ const slugFormatter = (collection, entryData, slugConfig) => {
 
   const identifier = entryData.get(selectIdentifier(collection));
   if (!identifier) {
-    throw new Error('Collection must have a field name that is a valid entry identifier, or must have `identifier_field` set');
+    throw new Error(
+      'Collection must have a field name that is a valid entry identifier, or must have `identifier_field` set',
+    );
   }
 
   const slug = template

--- a/packages/netlify-cms-core/src/backend.js
+++ b/packages/netlify-cms-core/src/backend.js
@@ -42,7 +42,7 @@ const slugFormatter = (collection, entryData, slugConfig) => {
 
   const identifier = entryData.get(selectIdentifier(collection));
   if (!identifier) {
-    throw new Error('Collection must have a field name that is a valid entry identifier');
+    throw new Error('Collection must have a field name that is a valid entry identifier, or must have `identifier_field` set');
   }
 
   const slug = template

--- a/packages/netlify-cms-core/src/constants/configSchema.js
+++ b/packages/netlify-cms-core/src/constants/configSchema.js
@@ -126,7 +126,7 @@ const getConfigSchema = () => ({
               fields: {
                 contains: {
                   properties: {
-                    name: { enum: [{ '$data': '3/identifier_field' }, ...IDENTIFIER_FIELDS] },
+                    name: { enum: [{ $data: '3/identifier_field' }, ...IDENTIFIER_FIELDS] },
                   },
                 },
               },

--- a/packages/netlify-cms-core/src/constants/configSchema.js
+++ b/packages/netlify-cms-core/src/constants/configSchema.js
@@ -126,7 +126,7 @@ const getConfigSchema = () => ({
               fields: {
                 contains: {
                   properties: {
-                    name: { enum: IDENTIFIER_FIELDS },
+                    name: { enum: [{ '$data': '3/identifier_field' }, ...IDENTIFIER_FIELDS] },
                   },
                 },
               },
@@ -169,7 +169,7 @@ class ConfigError extends Error {
  * the config that is passed in.
  */
 export function validateConfig(config) {
-  const ajv = new AJV({ allErrors: true, jsonPointers: true });
+  const ajv = new AJV({ allErrors: true, jsonPointers: true, $data: true });
   ajvErrors(ajv);
 
   const valid = ajv.validate(getConfigSchema(), config);

--- a/packages/netlify-cms-core/src/reducers/collections.js
+++ b/packages/netlify-cms-core/src/reducers/collections.js
@@ -114,7 +114,7 @@ export const selectTemplateName = (collection, slug) =>
   selectors[collection.get('type')].templateName(collection, slug);
 export const selectIdentifier = collection => {
   const identifier = collection.get('identifier_field');
-  const indentifierFields = !!identifier ? [identifier, ...IDENTIFIER_FIELDS] : IDENTIFIER_FIELDS;
+  const indentifierFields = identifier ? [identifier, ...IDENTIFIER_FIELDS] : IDENTIFIER_FIELDS;
   const fieldNames = collection.get('fields').map(field => field.get('name'));
   return indentifierFields.find(id => fieldNames.find(name => name.toLowerCase().trim() === id));
 };

--- a/packages/netlify-cms-core/src/reducers/collections.js
+++ b/packages/netlify-cms-core/src/reducers/collections.js
@@ -113,9 +113,10 @@ export const selectAllowDeletion = collection =>
 export const selectTemplateName = (collection, slug) =>
   selectors[collection.get('type')].templateName(collection, slug);
 export const selectIdentifier = collection => {
+  const identifier = collection.get('identifier_field');
+  const indentifierFields = !!identifier ? [identifier, ...IDENTIFIER_FIELDS] : IDENTIFIER_FIELDS;
   const fieldNames = collection.get('fields').map(field => field.get('name'));
-  return IDENTIFIER_FIELDS.find(id => fieldNames.find(name => name.toLowerCase().trim() === id));
-  // There must be a field whose `name` matches one of the IDENTIFIER_FIELDS.
+  return indentifierFields.find(id => fieldNames.find(name => name.toLowerCase().trim() === id));
 };
 export const selectInferedField = (collection, fieldName) => {
   const inferableField = INFERABLE_FIELDS[fieldName];

--- a/website/content/docs/collection-types.md
+++ b/website/content/docs/collection-types.md
@@ -13,7 +13,7 @@ Folder collections represent one or more files with the same format, fields, and
 
 Unlike file collections, folder collections have the option to allow editors to create new items in the collection. This is set by the boolean `create` field.
 
-**Note:** Folder collections must have at least one field with the name `title` for creating new entry slugs. That field should use the default `string` widget. The `label` for the field can be any string value. See the [Collections reference doc](../configuration-options/#collections) for details on how collections and fields are configured. If you forget to add this field, you will get an error that your collection "must have a field that is a valid entry identifier".
+**Note:** Folder collections must have at least one field with the name `title` for creating new entry slugs. That field should use the default `string` widget. The `label` for the field can be any string value. If you wish to use a different field as your identifier, set `identifier_field` to the field name. See the [Collections reference doc](../configuration-options/#collections) for details on how collections and fields are configured. If you forget to add this field, you will get an error that your collection "must have a field that is a valid entry identifier".
 
 Example:
 
@@ -28,6 +28,21 @@ collections:
       - {label: "Publish Date", name: "date", widget: "datetime"}
       - {label: "Featured Image", name: "thumbnail", widget: "image"}
       - {label: "Body", name: "body", widget: "markdown"}
+```
+
+With `identifier_field`:
+
+```yaml
+- label: "Blog"
+  name: "blog"
+  folder: "_posts/blog"
+  create: true
+  identifier_field: name
+  fields:
+    - {label: "Name", name: "name", widget: "string"}
+    - {label: "Publish Date", name: "date", widget: "datetime"}
+    - {label: "Featured Image", name: "thumbnail", widget: "image"}
+    - {label: "Body", name: "body", widget: "markdown"}
 ```
 
 ### Filtered folder collections


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines;
https://github.com/netlify/netlify-cms/blob/master/CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first three fields are mandatory:
-->

**- Summary**

Sometimes `title` doesn't make sense as the identifier for a collection. For example I have a JSON collection called `clients`, which has a `name` field which I want to use for the slug. This PR adds support for an `identifier_field` setting for collections, which lets the user choose a different identifier field.

Closes #1802, #1700.

**- Test plan**

Try using the following collection:

```yaml
- label: "Blog"
  name: "blog"
  folder: "_posts/blog"
  create: true
  identifier_field: name
  fields:
    - {label: "Name", name: "name", widget: "string"}
    - {label: "Publish Date", name: "date", widget: "datetime"}
    - {label: "Featured Image", name: "thumbnail", widget: "image"}
    - {label: "Body", name: "body", widget: "markdown"}
```

**- Description for the changelog**

Allow identifier fields other than title or path.

**- A picture of a cute animal (not mandatory but encouraged)**

![Military hound](https://scontent-lhr3-1.cdninstagram.com/vp/611764fd7c4b61da04e75c4cf27b3992/5C0A3DC7/t51.2885-15/e35/20214058_368830506853445_4842863668221706240_n.jpg)