### PR TITLE
If no lable is supplied, use the name.

### DIFF
--- a/packages/netlify-cms-core/src/components/Editor/EditorControlPane/EditorControl.js
+++ b/packages/netlify-cms-core/src/components/Editor/EditorControlPane/EditorControl.js
@@ -196,7 +196,7 @@ class EditorControl extends React.Component {
           )}
           htmlFor={fieldName + uniqueFieldId}
         >
-          {field.get('label')}
+          {field.get('label', field.get('name'))}
         </label>
         <Widget
           classNameWrapper={cx(

--- a/packages/netlify-cms-core/src/components/Editor/EditorPreviewPane/EditorPreviewPane.js
+++ b/packages/netlify-cms-core/src/components/Editor/EditorPreviewPane/EditorPreviewPane.js
@@ -89,7 +89,7 @@ export default class PreviewPane extends React.Component {
     ) {
       value = (
         <div>
-          <strong>{field.get('label')}:</strong> {value}
+          <strong>{field.get('label', field.get('name'))}:</strong> {value}
         </div>
       );
     }

--- a/packages/netlify-cms-widget-list/src/ListControl.js
+++ b/packages/netlify-cms-widget-list/src/ListControl.js
@@ -267,8 +267,8 @@ export default class ListControl extends React.Component {
     const { value, forID, field, classNameWrapper } = this.props;
     const { itemsCollapsed } = this.state;
     const items = value || List();
-    const label = field.get('label');
-    const labelSingular = field.get('label_singular') || field.get('label');
+    const label = field.get('label', field.get('name'));
+    const labelSingular = field.get('label_singular') || field.get('label', field.get('name'));
     const listLabel = items.size === 1 ? labelSingular.toLowerCase() : label.toLowerCase();
 
     return (


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines;
https://github.com/netlify/netlify-cms/blob/master/CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first three fields are mandatory:
-->

**- Summary**
This PR fixes https://github.com/netlify/netlify-cms/issues/1256 .
If a label is not supplied within the configuration then the name will be used as the label of the widget. 
<!--
Explain the **motivation** for making this change.
What existing problem does the pull request solve?
-->

**- Test plan**
1. Add this to your config.yml
`- name: "Test", widget: "markdown"`
you will see that a label is added to your widget. The cms takes the name of your widget and generates a label based off that name. 

Before this PR, you had to specify a label when creating a widget. If you did not supply a label then the widget would display without a label, like this: 
![image](https://user-images.githubusercontent.com/16070192/43416924-3c87f0aa-93ff-11e8-907b-4248ec1654fa.png)

The code changes in this PR allow for the CMS to use the name of the widget as a label if no label is supplied; like this: 
![image](https://user-images.githubusercontent.com/16070192/43417132-c0f5ceac-93ff-11e8-8a4e-51792c180989.png)


<!--
Demonstrate the code is solid.
Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.
-->


**- Description for the changelog**

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
If a widget does not have a label the CMS will generate one based on the widget name.
**- A picture of a cute animal (not mandatory but encouraged)**
![img_0510](https://user-images.githubusercontent.com/16070192/43417328-504a32d2-9400-11e8-9b25-e1f5e2fffe82.JPG)
