### PR TITLE
chore: only run netlify-cms for development

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,8 +1,9 @@
 {
   "scripts": {
     "bootstrap": "yarn && lerna bootstrap",
-    "start": "npm run bootstrap && npm run watch",
+    "start": "npm run bootstrap && npm run develop",
     "watch": "lerna run watch --parallel",
+    "develop": "lerna run develop --parallel",
     "build": "npm run clean && lerna run build",
     "build-preview": "npm run build && lerna run build-preview",
     "clean": "rimraf packages/*/dist",

--- a/packages/netlify-cms/package.json
+++ b/packages/netlify-cms/package.json
@@ -7,9 +7,10 @@
   "bugs": "https://github.com/netlify/netlify-cms/issues",
   "main": "dist/netlify-cms.js",
   "scripts": {
-    "watch": "webpack-dev-server --hot --open",
+    "watch": "webpack -w",
     "build": "cross-env NODE_ENV=production webpack",
-    "build-preview": "cross-env NODE_ENV=production webpack-dev-server --open"
+    "build-preview": "cross-env NODE_ENV=production webpack-dev-server --open",
+    "develop": "webpack-dev-server --hot --open"
   },
   "keywords": [
     "netlify",


### PR DESCRIPTION
Because we use `netlify-cms` for development and it builds from package sources directly, we don't need to watch all packages during development. This PR adds a `develop` task and redirects `yarn start` at repo root to use that task, which only `netlify-cms` has. Leaving the other `watch` tasks in place for future use.