### PR TITLE
fixes #1564, #1565

### DIFF
--- a/packages/netlify-cms-backend-gitlab/src/API.js
+++ b/packages/netlify-cms-backend-gitlab/src/API.js
@@ -185,11 +185,7 @@ export default class API {
   toBase64 = str => Promise.resolve(Base64.encode(str));
   fromBase64 = str => Base64.decode(str);
   uploadAndCommit = async (item, { commitMessage, updateFile = false, branch = this.branch, author = this.commitAuthor }) => {
-    let content = result(item, 'toBase64', partial(this.toBase64, item.raw));
-    if (content instanceof Promise) {
-      content = await content;
-    }
-
+    const content = await result(item, 'toBase64', partial(this.toBase64, item.raw));
     const file_path = item.path.replace(/^\//, "");
     const action = (updateFile ? "update" : "create");
     const encoding = "base64";

--- a/packages/netlify-cms-backend-gitlab/src/API.js
+++ b/packages/netlify-cms-backend-gitlab/src/API.js
@@ -1,7 +1,7 @@
 import { localForage, unsentRequest, then, APIError, Cursor } from "netlify-cms-lib-util";
 import { Base64 } from "js-base64";
 import { List, Map } from "immutable";
-import { flow, partial, pick, get } from "lodash";
+import { flow, partial, pick, get, result } from "lodash";
 
 export default class API {
   constructor(config) {
@@ -185,7 +185,11 @@ export default class API {
   toBase64 = str => Promise.resolve(Base64.encode(str));
   fromBase64 = str => Base64.decode(str);
   uploadAndCommit = async (item, { commitMessage, updateFile = false, branch = this.branch, author = this.commitAuthor }) => {
-    const content = get(item, 'toBase64', partial(this.toBase64, item.raw))();
+    let content = result(item, 'toBase64', partial(this.toBase64, item.raw));
+    if (content instanceof Promise) {
+      content = await content;
+    }
+
     const file_path = item.path.replace(/^\//, "");
     const action = (updateFile ? "update" : "create");
     const encoding = "base64";


### PR DESCRIPTION
**- Summary**
This fixes the netlify-cms with GitLab as backend. Now it is possible to upload images and publish posts using the CMS.

**- Test plan**
Publishing issue (#1564):
Prior to this pull request, the `content` variable, which is passed to the `JSON.stringify()` method later, was a Promise. `JSON.stringify` transformed it to `{}` instead of the content in the markdown text editing field. Now the value is extracted out of the Promise by using the `await` operator ([source code](https://github.com/netlify/netlify-cms/blob/d08e5f5183dec997cbd2bb602b1584690ab0c324/packages/netlify-cms-backend-gitlab/src/API.js#L189-L191)).

Image uploading issue (#1565):
Prior to this pull request, it wasn't possible to upload images with the CMS. If `item`, the argument of the `uploadAndCommit` function is an AssetProxy, the `get` function does not bind `item` to the `this` variable inside the `item.toBase64()` function. As result the function crashes at the execution of `this.fileObj`.
Use `result` instead of `get` to resolve the issue ([source code](https://github.com/netlify/netlify-cms/blob/d08e5f5183dec997cbd2bb602b1584690ab0c324/packages/netlify-cms-backend-gitlab/src/API.js#L188)).

**- Description for the changelog**
- Extract the value of the Promise instead of passing the Promise to `JSON.stringify()` (#1564, [source code](https://github.com/netlify/netlify-cms/blob/d08e5f5183dec997cbd2bb602b1584690ab0c324/packages/netlify-cms-backend-gitlab/src/API.js#L189-L191))
- Use `result` instead of `get` to get the function work with `AssetProxy`. (#1565, [source code](https://github.com/netlify/netlify-cms/blob/d08e5f5183dec997cbd2bb602b1584690ab0c324/packages/netlify-cms-backend-gitlab/src/API.js#L188))

If you have any questions, let me know.

Closes #1564, closes #1565.