### PR TITLE
chore(tests): fix jest localstorage bug

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -7,4 +7,5 @@ module.exports = {
     "netlify-cms-lib-util": "<rootDir>/packages/netlify-cms-lib-util/src/index.js",
     "netlify-cms-ui-default": "<rootDir>/packages/netlify-cms-ui-default/src/index.js",
   },
+  testEnvironment: "node",
 };


### PR DESCRIPTION
Travis now fails all tests with error: 

```
SecurityError: localStorage is not available for opaque origins
```

It's a Jsdom/Jest issue outlined here w/ solution: https://github.com/facebook/jest/issues/6766#issuecomment-408344243