### PR TITLE
fix(workflow): enable workflow per method

### DIFF
--- a/packages/netlify-cms-backend-github/src/implementation.js
+++ b/packages/netlify-cms-backend-github/src/implementation.js
@@ -43,7 +43,6 @@ export default class GitHub {
       repo: this.repo,
       api_root: this.api_root,
       squash_merges: this.squash_merges,
-      useWorkflow: this.options.useWorkflow,
       initialWorkflowStatus: this.options.initialWorkflowStatus,
     });
     return this.api.user().then(user =>

--- a/packages/netlify-cms-backend-test/src/implementation.js
+++ b/packages/netlify-cms-backend-test/src/implementation.js
@@ -134,7 +134,7 @@ export default class TestRepo {
   }
 
   persistEntry({ path, raw, slug }, mediaFiles = [], options = {}) {
-    if (this.options.useWorkflow) {
+    if (options.useWorkflow) {
       const unpubStore = window.repoFilesUnpublished;
       const existingEntryIndex = unpubStore.findIndex(e => e.file.path === path);
       if (existingEntryIndex >= 0) {

--- a/packages/netlify-cms-core/src/backend.js
+++ b/packages/netlify-cms-core/src/backend.js
@@ -385,6 +385,8 @@ class Backend {
 
     const commitMessage = commitMessageFormatter(newEntry ? 'create' : 'update', config, { collection, slug: entryObj.slug, path: entryObj.path });
 
+    const useWorkflow = config.getIn(["publish_mode"]) === EDITORIAL_WORKFLOW;
+
     const collectionName = collection.get("name");
 
     /**
@@ -397,6 +399,7 @@ class Backend {
       parsedData,
       commitMessage,
       collectionName,
+      useWorkflow,
       ...updatedOptions
     };
 


### PR DESCRIPTION
Workflow needs to be enabled per method. `persistEntry` should only use it when persisting an unpublished entry, but must behave as if workflow were not enabled for publishing. This fixes a 2.0 regression.