### PR TITLE
Change isFetching to consistently be boolean

### DIFF
--- a/packages/netlify-cms-core/src/reducers/search.js
+++ b/packages/netlify-cms-core/src/reducers/search.js
@@ -44,7 +44,7 @@ const entries = (state = defaultState, action) => {
     case QUERY_REQUEST:
       if (action.payload.searchTerm !== state.get('term')) {
         return state.withMutations((map) => {
-          map.set('isFetching', action.payload.namespace);
+          map.set('isFetching', action.payload.namespace ? true : false);
           map.set('term', action.payload.searchTerm);
         });
       }


### PR DESCRIPTION
**- Summary**

In the `search.js` reducer, `isFetching` is set to the payloads namespace, which is a string. In all other cases it is set to a boolean, as the name implies. A truthy `if` check happens down the line, and this change simply sets it to be a boolean consistently to avoid possible issues in the future.
