### PR TITLE
Fix/is fetching strikes again

### DIFF
--- a/packages/netlify-cms-core/src/components/Editor/EditorControlPane/Widget.js
+++ b/packages/netlify-cms-core/src/components/Editor/EditorControlPane/Widget.js
@@ -41,7 +41,7 @@ export default class Widget extends Component {
     getAsset: PropTypes.func.isRequired,
     resolveWidget: PropTypes.func.isRequired,
     getEditorComponents: PropTypes.func.isRequired,
-    isFetching: PropTypes.node,
+    isFetching: PropTypes.bool,
     query: PropTypes.func.isRequired,
     clearSearch: PropTypes.func.isRequired,
     queryHits: PropTypes.oneOfType([

--- a/packages/netlify-cms-core/src/reducers/search.js
+++ b/packages/netlify-cms-core/src/reducers/search.js
@@ -36,6 +36,7 @@ const entries = (state = defaultState, action) => {
       return state.withMutations((map) => {
         const entryIds = List(loadedEntries.map(entry => ({ collection: entry.collection, slug: entry.slug })));
         map.set('isFetching', false);
+        map.set('fetchID', null);
         map.set('page', page);
         map.set('term', searchTerm);
         map.set('entryIds', (!page || isNaN(page) || page === 0) ? entryIds : map.get('entryIds', List()).concat(entryIds));
@@ -45,6 +46,7 @@ const entries = (state = defaultState, action) => {
       if (action.payload.searchTerm !== state.get('term')) {
         return state.withMutations((map) => {
           map.set('isFetching', action.payload.namespace ? true : false);
+          map.set('fetchID', action.payload.namespace)
           map.set('term', action.payload.searchTerm);
         });
       }
@@ -55,6 +57,7 @@ const entries = (state = defaultState, action) => {
       response = action.payload.response;
       return state.withMutations((map) => {
         map.set('isFetching', false);
+        map.set('fetchID', null);
         map.set('term', searchTerm);
         map.mergeIn(['queryHits'], Map({ [action.payload.namespace]: response.hits }));
       });

--- a/packages/netlify-cms-widget-relation/src/RelationControl.js
+++ b/packages/netlify-cms-widget-relation/src/RelationControl.js
@@ -51,7 +51,7 @@ export default class RelationControl extends React.Component {
     forID: PropTypes.string.isRequired,
     value: PropTypes.node,
     field: PropTypes.node,
-    isFetching: PropTypes.node,
+    isFetching: PropTypes.bool,
     query: PropTypes.func.isRequired,
     clearSearch: PropTypes.func.isRequired,
     queryHits: PropTypes.oneOfType([
@@ -172,7 +172,7 @@ export default class RelationControl extends React.Component {
           inputProps={inputProps}
           focusInputOnSuggestionClick={false}
         />
-        <Loader active={isFetching === this.controlID} />
+        <Loader active={isFetching} />
       </div>
     );
   }

--- a/packages/netlify-cms-widget-relation/src/RelationControl.js
+++ b/packages/netlify-cms-widget-relation/src/RelationControl.js
@@ -52,6 +52,7 @@ export default class RelationControl extends React.Component {
     value: PropTypes.node,
     field: PropTypes.node,
     isFetching: PropTypes.bool,
+    fetchID: PropTypes.string,
     query: PropTypes.func.isRequired,
     clearSearch: PropTypes.func.isRequired,
     queryHits: PropTypes.oneOfType([
@@ -141,6 +142,7 @@ export default class RelationControl extends React.Component {
     const {
       value,
       isFetching,
+      fetchID,
       forID,
       queryHits,
       classNameWrapper,
@@ -172,7 +174,7 @@ export default class RelationControl extends React.Component {
           inputProps={inputProps}
           focusInputOnSuggestionClick={false}
         />
-        <Loader active={isFetching} />
+        <Loader active={isFetching && this.controlID === fetchID} />
       </div>
     );
   }


### PR DESCRIPTION
**- Summary**
This is a follow-up to a bug introduced with #1570.

I didn't realize you were referencing the UUID from isFetching in `RelationControl.js`, which caused a constant loading spinner in the editor when a boolean was passed (it compared `this.controlID` to `isFetching`).

In some places `isFetching` was a boolean propType and in others is was a node propType. It seems to me that it should consistently be a boolean still, so I've created a new prop `fetchID`, in addition to `isFetching` and passed it to `RelationControl.js` the same way `isFetching` is passed.

This appears to solve the issue, but you may want to check in other components that might use this prop to be certain. If you don't accept this pull request, you can simple revert the previous that I linked above. 