### PR TITLE
dev: add react-hot-loader

### DIFF
--- a/packages/netlify-cms-core/babel.config.js
+++ b/packages/netlify-cms-core/babel.config.js
@@ -5,6 +5,7 @@ module.exports = {
   ...babelConfig,
   plugins: [
     ...babelConfig.plugins,
+    'react-hot-loader/babel',
     ['module-resolver', {
       root: path.join(__dirname, 'src/components'),
       alias: {


### PR DESCRIPTION
RHL support was removed in the v2.0 transition.