### PR TITLE
docs: fix public_folder greedy match for _ rendered

### DIFF
--- a/website/content/docs/add-to-your-site.md
+++ b/website/content/docs/add-to-your-site.md
@@ -118,7 +118,7 @@ public_folder: '/images/uploads' # The src attribute for uploaded media will beg
 
 The configuration above adds a new setting, `public_folder`. While `media_folder` specifies where uploaded files will be saved in the repo, `public_folder` indicates where they can be found in the published site. This path is used in image `src` attributes and is relative to the file where it's called. For this reason, we usually start the path at the site root, using the opening `/`.
 
-_If `public_folder` is not set, Netlify CMS will default to the same value as `media_folder`, adding an opening `/` if one is not included._
+*If `public_folder` is not set, Netlify CMS will default to the same value as `media_folder`, adding an opening `/` if one is not included.*
 
 ### Collections
 


### PR DESCRIPTION
**Summary**
There's a rendering issue where the _ is greedily matched in `public_folder`.

**Before:**

![image](https://user-images.githubusercontent.com/1024544/44065027-3c58c93c-9f1d-11e8-9f0b-d5b8c33869b1.png)

**After:**

![image](https://user-images.githubusercontent.com/1024544/44065571-5a81931e-9f20-11e8-93a3-18fb3ac5af20.png)


I don't normally like to use * for emphasis, but this was a good example of when it's useful. It seems like remark doesn't respect escaping with `\_`.

**Test plan**

- validate the test branch preview.

**A picture of a cute animal (not mandatory but encouraged)**

![image](https://user-images.githubusercontent.com/1024544/44065050-612c4f68-9f1d-11e8-801d-038551944683.png)

