### PR TITLE
fix: add support for default field values in editor components

### DIFF
--- a/packages/netlify-cms-widget-markdown/src/MarkdownControl/VisualEditor.js
+++ b/packages/netlify-cms-widget-markdown/src/MarkdownControl/VisualEditor.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import ImmutablePropTypes from 'react-immutable-proptypes';
 import styled, { cx } from 'react-emotion';
 import { get, isEmpty, debounce } from 'lodash';
-import { Map, List } from 'immutable';
+import { List } from 'immutable';
 import { Value, Document, Block, Text } from 'slate';
 import { Editor as Slate } from 'slate-react';
 import { slateToMarkdown, markdownToSlate, htmlToSlate } from '../serializers';
@@ -144,7 +144,9 @@ export default class Editor extends React.Component {
     const { getEditorComponents } = this.props;
     const { value } = this.state;
     const nodes = [Text.create('')];
-    const pluginFields = getEditorComponents().get(pluginId).get('fields', List());
+    const pluginFields = getEditorComponents()
+      .get(pluginId)
+      .get('fields', List());
     const shortcodeData = pluginFields
       .map(field => field.get('default'))
       .filter(val => val)

--- a/packages/netlify-cms-widget-markdown/src/MarkdownControl/VisualEditor.js
+++ b/packages/netlify-cms-widget-markdown/src/MarkdownControl/VisualEditor.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import ImmutablePropTypes from 'react-immutable-proptypes';
 import styled, { cx } from 'react-emotion';
 import { get, isEmpty, debounce } from 'lodash';
-import { Map } from 'immutable';
+import { Map, List } from 'immutable';
 import { Value, Document, Block, Text } from 'slate';
 import { Editor as Slate } from 'slate-react';
 import { slateToMarkdown, markdownToSlate, htmlToSlate } from '../serializers';
@@ -141,15 +141,23 @@ export default class Editor extends React.Component {
   };
 
   handlePluginAdd = pluginId => {
+    const { getEditorComponents } = this.props;
     const { value } = this.state;
     const nodes = [Text.create('')];
+    const pluginDefinition = getEditorComponents().get(pluginId);
+
+    const defaultValues = {};
+    pluginDefinition.get('fields', List()).forEach(field => {
+      let defaultValue = field.get('default');
+      defaultValues[field.get('name')] = defaultValue;
+    });
     const block = {
       kind: 'block',
       type: 'shortcode',
       data: {
         shortcode: pluginId,
         shortcodeNew: true,
-        shortcodeData: Map(),
+        shortcodeData: new Map(defaultValues),
       },
       isVoid: true,
       nodes,

--- a/packages/netlify-cms-widget-markdown/src/MarkdownControl/VisualEditor.js
+++ b/packages/netlify-cms-widget-markdown/src/MarkdownControl/VisualEditor.js
@@ -144,20 +144,19 @@ export default class Editor extends React.Component {
     const { getEditorComponents } = this.props;
     const { value } = this.state;
     const nodes = [Text.create('')];
-    const pluginDefinition = getEditorComponents().get(pluginId);
-
-    const defaultValues = {};
-    pluginDefinition.get('fields', List()).forEach(field => {
-      let defaultValue = field.get('default');
-      defaultValues[field.get('name')] = defaultValue;
-    });
+    const pluginFields = getEditorComponents().get(pluginId).get('fields', List());
+    const shortcodeData = pluginFields
+      .map(field => field.get('default'))
+      .filter(val => val)
+      .toMap()
+      .mapKeys((idx, field) => field.get('name'));
     const block = {
       kind: 'block',
       type: 'shortcode',
       data: {
         shortcode: pluginId,
         shortcodeNew: true,
-        shortcodeData: new Map(defaultValues),
+        shortcodeData,
       },
       isVoid: true,
       nodes,


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines;
https://github.com/netlify/netlify-cms/blob/master/CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first three fields are mandatory:
-->

**- Summary**

<!--
Explain the **motivation** for making this change.
What existing problem does the pull request solve?
-->

Fix #1406 -- see the description in the issue.

This PR was ported from #1511, created by @papandreou, see discussion there:
> @erquhart:
> We should hold off on the dynamic part in this PR and just support static default values. Fields in editor components should work exactly the same as fields that are not in an editor component, which is the basis for #1406 being considered a bug.

**- Test plan**

<!--
Demonstrate the code is solid.
Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.
-->
> @papandreou:
> I've tested it manually in my own application and found that the default values work with various widgets, including `hidden`.

