### PR TITLE
WIP - Implement feature to allow_publish be configured

### DIFF
--- a/dev-test/config.yml
+++ b/dev-test/config.yml
@@ -5,6 +5,7 @@ display_url: https://example.com
 media_folder: "assets/uploads"
 
 publish_mode: editorial_workflow
+allow_publish: false # defaults to true if `allow_publish` not set
 
 collections: # A list of collections the CMS should be able to edit
   - name: "posts" # Used in routes, ie.: /admin/collections/:slug/edit

--- a/dev-test/config.yml
+++ b/dev-test/config.yml
@@ -5,7 +5,7 @@ display_url: https://example.com
 media_folder: "assets/uploads"
 
 publish_mode: editorial_workflow
-allow_publish: false # defaults to true if `allow_publish` not set
+# allow_publish: false # defaults to true if `allow_publish` not set
 
 collections: # A list of collections the CMS should be able to edit
   - name: "posts" # Used in routes, ie.: /admin/collections/:slug/edit

--- a/packages/netlify-cms-core/src/components/Editor/Editor.js
+++ b/packages/netlify-cms-core/src/components/Editor/Editor.js
@@ -55,6 +55,7 @@ class Editor extends React.Component {
     newEntry: PropTypes.bool.isRequired,
     displayUrl: PropTypes.string,
     hasWorkflow: PropTypes.bool,
+    hasPublishflow: PropTypes.bool,
     unpublishedEntry: PropTypes.bool,
     isModification: PropTypes.bool,
     collectionEntriesLoaded: PropTypes.bool,
@@ -312,6 +313,7 @@ class Editor extends React.Component {
       hasChanged,
       displayUrl,
       hasWorkflow,
+      hasPublishflow,
       unpublishedEntry,
       newEntry,
       isModification,
@@ -353,6 +355,7 @@ class Editor extends React.Component {
         hasChanged={hasChanged}
         displayUrl={displayUrl}
         hasWorkflow={hasWorkflow}
+        hasPublishflow={hasPublishflow}
         hasUnpublishedChanges={unpublishedEntry}
         isNewEntry={newEntry}
         isModification={isModification}
@@ -376,6 +379,9 @@ function mapStateToProps(state, ownProps) {
   const hasChanged = entryDraft.get('hasChanged');
   const displayUrl = config.get('display_url');
   const hasWorkflow = config.get('publish_mode') === EDITORIAL_WORKFLOW;
+  let hasPublishflow = config.get('allow_publish')
+  // catch undefined and default to true to allow users not have to set it to enable the feature
+  if (typeof hasPublishflow === 'undefined') { hasPublishflow = true; };
   const isModification = entryDraft.getIn(['entry', 'isModification']);
   const collectionEntriesLoaded = !!entries.getIn(['entities', collectionName]);
   const unpublishedEntry = selectUnpublishedEntry(state, collectionName, slug);
@@ -393,6 +399,7 @@ function mapStateToProps(state, ownProps) {
     hasChanged,
     displayUrl,
     hasWorkflow,
+    hasPublishflow,
     isModification,
     collectionEntriesLoaded,
     currentStatus,

--- a/packages/netlify-cms-core/src/components/Editor/EditorInterface.js
+++ b/packages/netlify-cms-core/src/components/Editor/EditorInterface.js
@@ -164,6 +164,7 @@ class EditorInterface extends Component {
       hasChanged,
       displayUrl,
       hasWorkflow,
+      hasPublishflow,
       hasUnpublishedChanges,
       isNewEntry,
       isModification,
@@ -234,6 +235,7 @@ class EditorInterface extends Component {
           displayUrl={displayUrl}
           collection={collection}
           hasWorkflow={hasWorkflow}
+          hasPublishflow={hasPublishflow}
           hasUnpublishedChanges={hasUnpublishedChanges}
           isNewEntry={isNewEntry}
           isModification={isModification}
@@ -285,6 +287,7 @@ EditorInterface.propTypes = {
   hasChanged: PropTypes.bool,
   displayUrl: PropTypes.string,
   hasWorkflow: PropTypes.bool,
+  hasPublishflow: PropTypes.bool,
   hasUnpublishedChanges: PropTypes.bool,
   isNewEntry: PropTypes.bool,
   isModification: PropTypes.bool,

--- a/packages/netlify-cms-core/src/components/Editor/EditorToolbar.js
+++ b/packages/netlify-cms-core/src/components/Editor/EditorToolbar.js
@@ -185,6 +185,7 @@ export default class EditorToolbar extends React.Component {
     displayUrl: PropTypes.string,
     collection: ImmutablePropTypes.map.isRequired,
     hasWorkflow: PropTypes.bool,
+    hasPublishflow: PropTypes.bool,
     hasUnpublishedChanges: PropTypes.bool,
     isNewEntry: PropTypes.bool,
     isModification: PropTypes.bool,
@@ -217,6 +218,7 @@ export default class EditorToolbar extends React.Component {
           dropdownTopOverlap="40px"
           dropdownWidth="150px"
           renderButton={() => (
+            // console.log("PUBLISH BUTTON HERE ")
             <PublishButton>{isPersisting ? 'Publishing...' : 'Publish'}</PublishButton>
           )}
         >
@@ -331,7 +333,7 @@ export default class EditorToolbar extends React.Component {
   };
 
   render() {
-    const { user, hasChanged, displayUrl, collection, hasWorkflow, onLogoutClick } = this.props;
+    const { user, hasChanged, displayUrl, collection, hasWorkflow, hasPublishflow, onLogoutClick } = this.props;
 
     return (
       <ToolbarContainer>
@@ -352,11 +354,13 @@ export default class EditorToolbar extends React.Component {
           <ToolbarSubSectionFirst>
             {hasWorkflow ? this.renderWorkflowSaveControls() : this.renderSimpleSaveControls()}
           </ToolbarSubSectionFirst>
+          {hasPublishflow ? (
           <ToolbarSubSectionLast>
             {hasWorkflow
               ? this.renderWorkflowPublishControls()
               : this.renderSimplePublishControls()}
           </ToolbarSubSectionLast>
+          ) : ``}
         </ToolbarSectionMain>
         <ToolbarSectionMeta>
           <SettingsDropdown


### PR DESCRIPTION
closes #1298 
and closes https://github.com/openpracticelibrary/openpracticelibrary/issues/349
**Summary**

Add a config flag `allow_publish` to the cms `config.toml` file that allows an admin configure if the publish feature should be enabled. Defaults to true, so admin would have to set `allow_publish: false` to remove it. 

Still TODO 
- [ ]  Add same functionality to the Workflow view which can also be published from.
- [ ]  Fix linting / tests

**Test plan**

Set the `allow_publish: false` and you'll see the Publish button disappear. 

**A picture of a cute animal (not mandatory but encouraged)**
![image](https://user-images.githubusercontent.com/6122439/44241229-7a247a00-a1ba-11e8-9e5b-56949e7c87e8.png)
