### PR TITLE
dev: update website linting rules

### DIFF
--- a/website/.stylelintrc
+++ b/website/.stylelintrc
@@ -6,8 +6,6 @@
     "at-rule-no-unknown": [true, {
       "ignoreAtRules": ["/^neat/"]
     }],
-    "no-descending-specificity": [true, {
-      "severity": "warning"
-    }]
+    "no-descending-specificity": null
   }
 }

--- a/website/gatsby-node.js
+++ b/website/gatsby-node.js
@@ -26,7 +26,7 @@ exports.createPages = async ({ graphql, boundActionCreators }) => {
   `);
 
   if (allMarkdown.errors) {
-    console.error(allMarkdown.errors);
+    console.error(allMarkdown.errors); // eslint-disable-line no-console
     throw Error(allMarkdown.errors);
   }
 

--- a/website/package.json
+++ b/website/package.json
@@ -7,8 +7,7 @@
     "build": "gatsby build && mv public dist",
     "copy:contribs": "cp ../.all-contributorsrc data/contributors.json",
     "prepare": "npm run copy:contribs",
-    "reset": "rm -rf .cache",
-    "lint": "eslint src"
+    "reset": "rm -rf .cache"
   },
   "author": "",
   "homepage": "https://www.netlifycms.org/",

--- a/website/src/components/event-widget.js
+++ b/website/src/components/event-widget.js
@@ -28,7 +28,7 @@ class EventWidget extends Component {
         });
       })
       .catch(err => {
-        console.log(err);
+        console.log(err); // eslint-disable-line no-console
         // TODO: set state to show error message
         this.setState({
           loading: false,


### PR DESCRIPTION
Don't require prop-types for Gatsby components on website.
Do enforce no `console.log`s on website.
Remove ESLint copy on website -- just use top-level one. @verythorough Is this OK for website-only contributors?