### PR TITLE
fix(widgets): push widget default values to entry state

### DIFF
--- a/packages/netlify-cms-widget-boolean/src/BooleanControl.js
+++ b/packages/netlify-cms-widget-boolean/src/BooleanControl.js
@@ -10,6 +10,12 @@ const BooleanBackground = styled(ToggleBackground)`
 `;
 
 export default class BooleanControl extends React.Component {
+  componentDidMount() {
+    if (!isBoolean(this.props.value)) {
+      this.props.onChange(false);
+    }
+  }
+
   render() {
     const {
       value,
@@ -43,8 +49,4 @@ BooleanControl.propTypes = {
   setInactiveStyle: PropTypes.func.isRequired,
   forID: PropTypes.string,
   value: PropTypes.bool,
-};
-
-BooleanControl.defaultProps = {
-  value: false,
 };

--- a/packages/netlify-cms-widget-file/src/withFileControl.js
+++ b/packages/netlify-cms-widget-file/src/withFileControl.js
@@ -62,13 +62,15 @@ export default function withFileControl({ forImage } = {}) {
       value: PropTypes.node,
     };
 
-    static defaultProps = {
-      value: '',
-    };
-
     constructor(props) {
       super(props);
       this.controlID = uuid();
+    }
+
+    componentDidMount() {
+      if (typeof this.props.value !== 'string') {
+        this.props.onChange('');
+      }
     }
 
     shouldComponentUpdate(nextProps) {

--- a/packages/netlify-cms-widget-list/src/ListControl.js
+++ b/packages/netlify-cms-widget-list/src/ListControl.js
@@ -76,10 +76,6 @@ export default class ListControl extends React.Component {
     setInactiveStyle: PropTypes.func.isRequired,
   };
 
-  static defaultProps = {
-    value: List(),
-  };
-
   constructor(props) {
     super(props);
     const { field, value } = props;
@@ -90,6 +86,12 @@ export default class ListControl extends React.Component {
       itemsCollapsed: List(itemsCollapsed),
       value: valueToString(value),
     };
+  }
+
+  componentDidMount() {
+    if (!List.isList(this.props.value)) {
+      this.props.onChange(List());
+    }
   }
 
   getValueType = () => {

--- a/packages/netlify-cms-widget-markdown/src/MarkdownControl/index.js
+++ b/packages/netlify-cms-widget-markdown/src/MarkdownControl/index.js
@@ -21,15 +21,17 @@ export default class MarkdownControl extends React.Component {
     value: PropTypes.string,
   };
 
-  static defaultProps = {
-    value: '',
-  };
-
   constructor(props) {
     super(props);
     editorControl = props.editorControl;
     _getEditorComponents = props.getEditorComponents;
     this.state = { mode: localStorage.getItem(MODE_STORAGE_KEY) || 'visual' };
+  }
+
+  componentDidMount() {
+    if (typeof this.props.value !== 'string') {
+      this.props.onChange('');
+    }
   }
 
   handleMode = mode => {

--- a/packages/netlify-cms-widget-number/src/NumberControl.js
+++ b/packages/netlify-cms-widget-number/src/NumberControl.js
@@ -15,9 +15,11 @@ export default class NumberControl extends React.Component {
     max: PropTypes.number,
   };
 
-  static defaultProps = {
-    value: '',
-  };
+  componentDidMount() {
+    if (!['number', 'string'].includes(typeof this.props.value)) {
+      this.props.onChange('');
+    }
+  }
 
   handleChange = e => {
     const valueType = this.props.field.get('valueType');

--- a/packages/netlify-cms-widget-object/src/ObjectControl.js
+++ b/packages/netlify-cms-widget-object/src/ObjectControl.js
@@ -25,15 +25,17 @@ export default class ObjectControl extends Component {
     resolveWidget: PropTypes.func.isRequired,
   };
 
-  static defaultProps = {
-    value: Map(),
-  };
-
   constructor(props) {
     super(props);
     this.state = {
       collapsed: false,
     };
+  }
+
+  componentDidMount() {
+    if (!Map.isMap(this.props.value)) {
+      this.props.onChange(Map());
+    }
   }
 
   /*

--- a/packages/netlify-cms-widget-relation/src/RelationControl.js
+++ b/packages/netlify-cms-widget-relation/src/RelationControl.js
@@ -61,10 +61,6 @@ export default class RelationControl extends React.Component {
     setInactiveStyle: PropTypes.func.isRequired,
   };
 
-  static defaultProps = {
-    value: '',
-  };
-
   constructor(props, ctx) {
     super(props, ctx);
     this.controlID = uuid();
@@ -72,7 +68,11 @@ export default class RelationControl extends React.Component {
   }
 
   componentDidMount() {
-    const { value, field } = this.props;
+    const { value, field, onChange } = this.props;
+    if (typeof value !== 'string') {
+      onChange('');
+    }
+
     if (value) {
       const collection = field.get('collection');
       const searchFields = field.get('searchFields').toJS();

--- a/packages/netlify-cms-widget-select/src/SelectControl.js
+++ b/packages/netlify-cms-widget-select/src/SelectControl.js
@@ -24,9 +24,11 @@ export default class SelectControl extends React.Component {
     }),
   };
 
-  static defaultProps = {
-    value: '',
-  };
+  componentDidMount() {
+    if (typeof this.props.value !== 'string') {
+      this.props.onChange('');
+    }
+  }
 
   handleChange = e => {
     this.props.onChange(e.target.value);

--- a/packages/netlify-cms-widget-string/src/StringControl.js
+++ b/packages/netlify-cms-widget-string/src/StringControl.js
@@ -11,9 +11,11 @@ export default class StringControl extends React.Component {
     setInactiveStyle: PropTypes.func.isRequired,
   };
 
-  static defaultProps = {
-    value: '',
-  };
+  componentDidMount() {
+    if (typeof this.props.value !== 'string') {
+      this.props.onChange('');
+    }
+  }
 
   render() {
     const {

--- a/packages/netlify-cms-widget-text/src/TextControl.js
+++ b/packages/netlify-cms-widget-text/src/TextControl.js
@@ -12,9 +12,11 @@ export default class TextControl extends React.Component {
     setInactiveStyle: PropTypes.func.isRequired,
   };
 
-  static defaultProps = {
-    value: '',
-  };
+  componentDidMount() {
+    if (typeof this.props.value !== 'string') {
+      this.props.onChange('');
+    }
+  }
 
   /**
    * Always update to ensure `react-textarea-autosize` properly calculates


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines.

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first two fields are mandatory:
-->

**Summary**

<!--
Explain the **motivation** for making this change.
What existing problem does the pull request solve?
-->

Fixes #1424 (and possibly others).

We currently use `defaultProps` to set default values in widgets, but these default values are local to the widget control component and don't make it to the Redux store unless the user changes the value of the field.

This PR drops widget control use of `defaultProps` and instead sets the default value in `componentDidMount`.


