### PR TITLE
docs: update register preview template parameter description

### DIFF
--- a/website/content/docs/customization.md
+++ b/website/content/docs/customization.md
@@ -54,13 +54,15 @@ body {
 
 ## `registerPreviewTemplate`
 
-Registers a template for a collection.
+Registers a template for a folder collection or an individual file in a file collection.
 
-`CMS.registerPreviewTemplate(collection, react_component);`
+`CMS.registerPreviewTemplate(name, react_component);`
 
 **Params:**
 
-* collection: The name of the collection which this preview component will be used for.
+* name: The name of the entry which this preview component will be used for.
+  * Folder collections: Use the name of the collection
+  * File collections: Use the name of the file
 * react_component: A React component that renders the collection data. Four props will be passed to your component during render:
   * entry: Immutable collection containing the entry data.
   * widgetFor: Returns the appropriate widget preview component for a given field.

--- a/website/content/docs/customization.md
+++ b/website/content/docs/customization.md
@@ -60,7 +60,7 @@ Registers a template for a folder collection or an individual file in a file col
 
 **Params:**
 
-* name: The name of the entry which this preview component will be used for.
+* name: The name of the collection (or file for file collections) which this preview component will be used for.
   * Folder collections: Use the name of the collection
   * File collections: Use the name of the file
 * react_component: A React component that renders the collection data. Four props will be passed to your component during render:


### PR DESCRIPTION
**Summary**

This feature branch updates the API documentation for `CMS.registerPreviewTemplate`. The issue that gave motivation for this PR is #1625. The goal is to make the documentation more clear for registering file collection templates.

This also closes #1197.