### PR TITLE
chore: comment out issue template guidelines

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -16,11 +16,13 @@ If you have an issue that can be shown visually, please provide a screenshot or 
 <!-- A clear and concise description of what the bug is. -->
 
 **To Reproduce**
-Steps to reproduce the behavior:
+<!--
+Steps to reproduce the behavior. For example:
 1. Go to '...'
 2. Click on '....'
 3. Scroll down to '....'
 4. See error
+-->
 
 **Expected behavior**
 <!-- A clear and concise description of what you expected to happen. -->
@@ -29,7 +31,7 @@ Steps to reproduce the behavior:
 <!-- If applicable, add screenshots to help explain your problem. -->
 
 **Applicable Versions:**
-<!-- You can find the CMS version by checking your web browser's developer tools console while in the CMS. -->
+<!--You can find the CMS version by checking your web browser's developer tools console while in the CMS. -->
  - Netlify CMS version: [e.g. 2.0.4]
  - Git provider: [e.g. GitHub, BitBucket]
  - OS: [e.g. Windows 7]

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -13,7 +13,7 @@ If you have an issue that can be shown visually, please provide a screenshot or 
 -->
 
 **Describe the bug**
-A clear and concise description of what the bug is.
+<!-- A clear and concise description of what the bug is. -->
 
 **To Reproduce**
 Steps to reproduce the behavior:
@@ -23,10 +23,10 @@ Steps to reproduce the behavior:
 4. See error
 
 **Expected behavior**
-A clear and concise description of what you expected to happen.
+<!-- A clear and concise description of what you expected to happen. -->
 
 **Screenshots**
-If applicable, add screenshots to help explain your problem.
+<!-- If applicable, add screenshots to help explain your problem. -->
 
 **Applicable Versions:**
 <!-- You can find the CMS version by checking your web browser's developer tools console while in the CMS. -->
@@ -38,8 +38,8 @@ If applicable, add screenshots to help explain your problem.
  - Node.JS version:
 
 **CMS configuration**
-Please link or paste your CMS `config.yml` here.
+<!-- Please link or paste your CMS `config.yml` here. -->
 
 
 **Additional context**
-Add any other context about the problem here.
+<!-- Add any other context about the problem here. -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -9,13 +9,17 @@ Please make sure that we do not have any requests for this feature already open.
 -->
 
 **Is your feature request related to a problem? Please describe.**
+<!--
 A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+-->
 
 **Describe the solution you'd like**
-A clear and concise description of what you want to happen.
+<!-- A clear and concise description of what you want to happen. -->
 
 **Describe alternatives you've considered**
+<!--
 A clear and concise description of any alternative solutions or features you've considered.
+-->
 
 **Additional context**
-Add any other context or screenshots about the feature request here.
+<!-- Add any other context or screenshots about the feature request here. -->


### PR DESCRIPTION
Comment out the guidelines as some issues are being opened with the guideline text still there, making the issue text harder to parse.