### PR TITLE
fix: double slashes when gateway_url contained a backend

### DIFF
--- a/packages/netlify-cms-backend-git-gateway/src/implementation.js
+++ b/packages/netlify-cms-backend-git-gateway/src/implementation.js
@@ -63,7 +63,7 @@ export default class GitGateway {
     const backendTypeMatches = this.gatewayUrl.match(backendTypeRegex);
     if (backendTypeMatches) {
       this.backendType = backendTypeMatches[1];
-      this.gatewayUrl = this.gatewayUrl.replace(backendTypeRegex, '/');
+      this.gatewayUrl = this.gatewayUrl.replace(backendTypeRegex, '');
     } else {
       this.backendType = null;
     }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines.

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first two fields are mandatory:
-->

**Summary**

For example, if the `gateway_url` is set to `https://www.my-netlify-site.com/.netlify/git/github`, it was being changed to `https://www.my-netlify-site.com/.netlify/git//github` (notice the double slash).  This commit stops adding the extra slash.
<!--
Explain the **motivation** for making this change.
What existing problem does the pull request solve?
-->

**Test plan**

Test manually.
<!--
Demonstrate the code is solid.
Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.
-->

**A picture of a cute animal (not mandatory but encouraged)**
