### PR TITLE
Date widget formatting of input values

### DIFF
--- a/dev-test/config.yml
+++ b/dev-test/config.yml
@@ -18,7 +18,7 @@ collections: # A list of collections the CMS should be able to edit
     create: true # Allow users to create new documents in this collection
     fields: # The fields each document in this collection have
       - { label: 'Title', name: 'title', widget: 'string', tagname: 'h1' }
-      - { label: 'Publish Date', name: 'date', widget: 'datetime', format: 'YYYY-MM-DD hh:mma' }
+      - { label: 'Publish Date', name: 'date', widget: 'datetime', dateFormat: 'YYYY-MM-DD', timeFormat: 'HH:mm', format: 'YYYY-MM-DD HH:mm' }
       - label: 'Cover Image'
         name: 'image'
         widget: 'image'

--- a/packages/netlify-cms-widget-date/src/DateControl.js
+++ b/packages/netlify-cms-widget-date/src/DateControl.js
@@ -22,13 +22,23 @@ export default class DateControl extends React.Component {
 
   getFormats() {
     const { field, includeTime } = this.props;
+    let timeFormat = field.get('timeFormat');
+    if (typeof timeFormat === 'undefined') {
+      timeFormat = !!includeTime;
+    }
+    if (timeFormat === true) {
+      timeFormat = 'LT';
+    }
+
     const date = field.get('dateFormat') || field.get('format') || true;
-    const time = field.get('timeFormat') || !!includeTime;
-    const datetime =
+    // let time = timeFormat || !!includeTime;
+    let time = timeFormat;
+    let datetime =
       date && date !== true && time && time !== true
         ? date + ' ' + time
         : (typeof date === 'string' && date) || (typeof time === 'string' && time) || undefined;
 
+    console.log(time, 'timeFormat', timeFormat, 'datetime', datetime);
     return { date, time, datetime };
   }
 

--- a/packages/netlify-cms-widget-date/src/DateControl.js
+++ b/packages/netlify-cms-widget-date/src/DateControl.js
@@ -17,12 +17,13 @@ export default class DateControl extends React.Component {
     setActiveStyle: PropTypes.func.isRequired,
     setInactiveStyle: PropTypes.func.isRequired,
     value: PropTypes.oneOfType([PropTypes.object, PropTypes.string]),
+    includeTime: PropTypes.bool,
   };
 
   getFormats() {
-    const { field } = this.props;
+    const { field, includeTime } = this.props;
     const date = field.get('dateFormat') || field.get('format') || true;
-    const time = field.get('timeFormat') || field.get('widget') === 'datetime';
+    const time = field.get('timeFormat') || !!includeTime;
     const datetime =
       date && date !== true && time && time !== true
         ? date + ' ' + time

--- a/packages/netlify-cms-widget-date/src/DateControl.js
+++ b/packages/netlify-cms-widget-date/src/DateControl.js
@@ -17,10 +17,21 @@ export default class DateControl extends React.Component {
     setActiveStyle: PropTypes.func.isRequired,
     setInactiveStyle: PropTypes.func.isRequired,
     value: PropTypes.oneOfType([PropTypes.object, PropTypes.string]),
-    includeTime: PropTypes.bool,
   };
 
-  format = this.props.field.get('format');
+  getFormats() {
+    const { field } = this.props;
+    const date = field.get('dateFormat') || field.get('format') || true;
+    const time = field.get('timeFormat') || field.get('widget') === 'datetime';
+    const datetime =
+      date && date !== true && time && time !== true
+        ? date + ' ' + time
+        : (typeof date === 'string' && date) || (typeof time === 'string' && time) || undefined;
+
+    return { date, time, datetime };
+  }
+
+  formats = this.getFormats();
 
   componentDidMount() {
     const { value } = this.props;
@@ -55,8 +66,8 @@ export default class DateControl extends React.Component {
      * Produce a formatted string only if a format is set in the config.
      * Otherwise produce a date object.
      */
-    if (this.format) {
-      const formattedValue = moment(datetime).format(this.format);
+    if (this.formats.datetime) {
+      const formattedValue = moment(datetime).format(this.formats.datetime);
       onChange(formattedValue);
     } else {
       const value = moment.isMoment(datetime) ? datetime.toDate() : datetime;
@@ -81,11 +92,12 @@ export default class DateControl extends React.Component {
   };
 
   render() {
-    const { includeTime, value, classNameWrapper, setActiveStyle } = this.props;
+    const { value, classNameWrapper, setActiveStyle } = this.props;
     return (
       <DateTime
-        timeFormat={!!includeTime}
-        value={moment(value, this.format)}
+        dateFormat={this.formats.date}
+        timeFormat={this.formats.time}
+        value={moment(value, this.formats.datetime)}
         onChange={this.handleChange}
         onFocus={setActiveStyle}
         onBlur={this.onBlur}

--- a/packages/netlify-cms-widget-date/src/DateControl.js
+++ b/packages/netlify-cms-widget-date/src/DateControl.js
@@ -22,24 +22,22 @@ export default class DateControl extends React.Component {
 
   getFormats() {
     const { field, includeTime } = this.props;
+    const format = field.get('format');
+
+    // dateFormat and timeFormat are strictly for modifying
+    // input field with the date/time pickers
+    const dateFormat = field.get('dateFormat');
+    // show time-picker? false hides it, true shows it using default format
     let timeFormat = field.get('timeFormat');
     if (typeof timeFormat === 'undefined') {
       timeFormat = !!includeTime;
     }
-    if (timeFormat === true) {
-      timeFormat = 'LT';
-    }
 
-    const date = field.get('dateFormat') || field.get('format') || true;
-    // let time = timeFormat || !!includeTime;
-    let time = timeFormat;
-    let datetime =
-      date && date !== true && time && time !== true
-        ? date + ' ' + time
-        : (typeof date === 'string' && date) || (typeof time === 'string' && time) || undefined;
-
-    console.log(time, 'timeFormat', timeFormat, 'datetime', datetime);
-    return { date, time, datetime };
+    return {
+      format,
+      dateFormat,
+      timeFormat,
+    };
   }
 
   formats = this.getFormats();
@@ -64,8 +62,6 @@ export default class DateControl extends React.Component {
     moment.isMoment(datetime) || datetime instanceof Date || datetime === '';
 
   handleChange = datetime => {
-    const { onChange } = this.props;
-
     /**
      * Set the date only if it is valid.
      */
@@ -73,12 +69,15 @@ export default class DateControl extends React.Component {
       return;
     }
 
+    const { onChange } = this.props;
+    const { format } = this.formats;
+
     /**
      * Produce a formatted string only if a format is set in the config.
      * Otherwise produce a date object.
      */
-    if (this.formats.datetime) {
-      const formattedValue = moment(datetime).format(this.formats.datetime);
+    if (format) {
+      const formattedValue = moment(datetime).format(format);
       onChange(formattedValue);
     } else {
       const value = moment.isMoment(datetime) ? datetime.toDate() : datetime;
@@ -104,11 +103,12 @@ export default class DateControl extends React.Component {
 
   render() {
     const { value, classNameWrapper, setActiveStyle } = this.props;
+    const { format, dateFormat, timeFormat } = this.formats;
     return (
       <DateTime
-        dateFormat={this.formats.date}
-        timeFormat={this.formats.time}
-        value={moment(value, this.formats.datetime)}
+        dateFormat={dateFormat}
+        timeFormat={timeFormat}
+        value={moment(value, format)}
         onChange={this.handleChange}
         onFocus={setActiveStyle}
         onBlur={this.onBlur}

--- a/packages/netlify-cms-widget-datetime/src/DateTimeControl.js
+++ b/packages/netlify-cms-widget-datetime/src/DateTimeControl.js
@@ -3,6 +3,6 @@ import { DateControl } from 'netlify-cms-widget-date';
 
 export default class DateTimeControl extends React.Component {
   render() {
-    return <DateControl {...this.props} includeTime />;
+    return <DateControl {...this.props} />;
   }
 }

--- a/packages/netlify-cms-widget-datetime/src/DateTimeControl.js
+++ b/packages/netlify-cms-widget-datetime/src/DateTimeControl.js
@@ -3,6 +3,6 @@ import { DateControl } from 'netlify-cms-widget-date';
 
 export default class DateTimeControl extends React.Component {
   render() {
-    return <DateControl {...this.props} />;
+    return <DateControl {...this.props} includeTime />;
   }
 }

--- a/website/content/docs/widgets/date.md
+++ b/website/content/docs/widgets/date.md
@@ -3,6 +3,8 @@ title: date
 label: "Date"
 ---
 
+**Deprecated** – use datetime widget with `timeFormat: false`
+
 The date widget translates a date picker input to a date string. For saving date and time together, use the datetime widget.
 
 - **Name:** `date`

--- a/website/content/docs/widgets/date.md
+++ b/website/content/docs/widgets/date.md
@@ -3,8 +3,6 @@ title: date
 label: "Date"
 ---
 
-**Deprecated** – use datetime widget with `timeFormat: false`
-
 The date widget translates a date picker input to a date string. For saving date and time together, use the datetime widget.
 
 - **Name:** `date`
@@ -13,6 +11,8 @@ The date widget translates a date picker input to a date string. For saving date
 - **Options:**
   - `default`: accepts a date string, or an empty string to accept blank input; otherwise defaults to current date
   - `format`: optional; accepts Moment.js [tokens](https://momentjs.com/docs/#/parsing/string-format/); defaults to raw Date object (if supported by output format)
+  - `dateFormat`: optional; boolean or Moment.js [tokens](https://momentjs.com/docs/#/parsing/string-format/). If `true` use default locale format.
+  - `timeFormat`: optional; boolean or Moment.js [tokens](https://momentjs.com/docs/#/parsing/string-format/). If `true` use default locale format, `false` hides time-picker. Defaults to false.
 - **Example:**
     ```yaml
     - label: "Birthdate"

--- a/website/content/docs/widgets/datetime.md
+++ b/website/content/docs/widgets/datetime.md
@@ -10,7 +10,8 @@ The datetime widget translates a datetime picker to a datetime string. For savin
 - **Data type:** Moment.js-formatted datetime string
 - **Options:**
   - `default`: accepts a datetime string, or an empty string to accept blank input; otherwise defaults to current datetime
-  - `format`: optional; accepts Moment.js [tokens](https://momentjs.com/docs/#/parsing/string-format/); defaults to raw Date object (if supported by output format)
+  - ~~`format`~~: **Deprecated** (use `dateFormat` and/or `timeFormat` instead) optional; accepts Moment.js [tokens](https://momentjs.com/docs/#/parsing/string-format/); defaults to raw Date object (if supported by output format)
+  - `dateFormat`: boolean or Moment.js [tokens](https://momentjs.com/docs/#/parsing/string-format/). If `true` use default locale format. 
 - **Example:**
     ```yaml
     - label: "Start time"

--- a/website/content/docs/widgets/datetime.md
+++ b/website/content/docs/widgets/datetime.md
@@ -10,8 +10,9 @@ The datetime widget translates a datetime picker to a datetime string. For savin
 - **Data type:** Moment.js-formatted datetime string
 - **Options:**
   - `default`: accepts a datetime string, or an empty string to accept blank input; otherwise defaults to current datetime
-  - ~~`format`~~: **Deprecated** (use `dateFormat` and/or `timeFormat` instead) optional; accepts Moment.js [tokens](https://momentjs.com/docs/#/parsing/string-format/); defaults to raw Date object (if supported by output format)
-  - `dateFormat`: boolean or Moment.js [tokens](https://momentjs.com/docs/#/parsing/string-format/). If `true` use default locale format. 
+  - `format`: optional; accepts Moment.js [tokens](https://momentjs.com/docs/#/parsing/string-format/); defaults to raw Date object (if supported by output format)
+  - `dateFormat`: optional; boolean or Moment.js [tokens](https://momentjs.com/docs/#/parsing/string-format/). If `true` use default locale format.
+  - `timeFormat`: optional; boolean or Moment.js [tokens](https://momentjs.com/docs/#/parsing/string-format/). If `true` use default locale format, `false` hides time-picker.
 - **Example:**
     ```yaml
     - label: "Start time"


### PR DESCRIPTION
fixes #1648, #1736

**Summary**

If the format property in a date widget is set to YYYY-MM-DD, the field is saved correctly in the file, but in the date input in the CMS, the date is still shown as MM/DD/YYYY. 

This PR deprecates the `format` property in favor of `dateFormat` and `timeFormat` 

Currently two widgets exists, "date" and "datetime", but according to #1688 the goal is to combine these two into a single `datetime` widget.

This PR currently tries to add formatting without breaking defaults (eg. if user configs a "datetime" widget, `dateFormat` and `timeFormat` would be implicitly set to `true` and get the default formatting from the underlying `react-datetime` component.)

If desired, we could easily expand this PR to deprecate the `date` widget, and require setting `timeFormat: true` in config.yml if the timepicker should be visible. 

```- { label: "Datetime", name: "datetime", widget: "datetime" timeFormat: true }```

Let me know if I should go ahead with that. Remaining on the todo-list is to update documentation regardless