### PR TITLE
Updated links in find out more sections

### DIFF
--- a/website/content/docs/intro.md
+++ b/website/content/docs/intro.md
@@ -19,7 +19,7 @@ At its core, Netlify CMS is an open-source React app that acts as a wrapper for 
 ## Find out more
 
 - Get a feel for the UI in the [demo site](https://cms-demo.netlify.com). (No login required. Click the login button to go straight to the CMS editor UI.)
-- [Start with a template](../start-with-a-template/) to make a Netlify CMS-enabled site of your own.
-- Configure your existing site by following a [tutorial](../add-to-your-site/) or checking [configuration options](../configuration-options).
+- [Start with a template](./start-with-a-template/) to make a Netlify CMS-enabled site of your own.
+- Configure your existing site by following a [tutorial](./add-to-your-site/) or checking [configuration options](./configuration-options).
 - Ask questions and share ideas in the Netlify CMS community on [Gitter](https://gitter.im/netlify/netlifycms).
 - Get involved in new developments and become a [contributor](https://docs-starters--netlify-cms-www.netlify.com/docs/contributor-guide/).


### PR DESCRIPTION
'Start with a template', 'tutorial' and 'configuration option' links were not up to date. Fixed them.

**Summary**
Fixed the broken links on the page. It is a minor documentation related fix.

