### PR TITLE
Check possible identifier values for a valid one to use for {{slug}}

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ npm-debug.log
 .tern-project
 yarn-error.log
 .vscode/
+.idea/
 manifest.yml
 .imdone/
 website/data/contributors.json

--- a/packages/netlify-cms-core/src/backend.js
+++ b/packages/netlify-cms-core/src/backend.js
@@ -10,7 +10,7 @@ import {
   selectAllowNewEntries,
   selectAllowDeletion,
   selectFolderEntryExtension,
-  selectIdentifier,
+  selectIdentifierCandidates,
   selectInferedField,
 } from 'Reducers/collections';
 import { createEntry } from 'ValueObjects/Entry';
@@ -40,7 +40,11 @@ const slugFormatter = (collection, entryData, slugConfig) => {
   const template = collection.get('slug') || '{{slug}}';
   const date = new Date();
 
-  const identifier = entryData.get(selectIdentifier(collection));
+  const identifierFieldCandidates = selectIdentifierCandidates(collection);
+  const identifier = identifierFieldCandidates
+    .map(fieldName => entryData.get(fieldName))
+    .find(value => value);
+
   if (!identifier) {
     throw new Error('Collection must have a field name that is a valid entry identifier');
   }

--- a/packages/netlify-cms-core/src/reducers/collections.js
+++ b/packages/netlify-cms-core/src/reducers/collections.js
@@ -112,9 +112,10 @@ export const selectAllowDeletion = collection =>
   selectors[collection.get('type')].allowDeletion(collection);
 export const selectTemplateName = (collection, slug) =>
   selectors[collection.get('type')].templateName(collection, slug);
-export const selectIdentifier = collection => {
+export const selectIdentifierCandidates = collection => {
   const fieldNames = collection.get('fields').map(field => field.get('name'));
-  return IDENTIFIER_FIELDS.find(id => fieldNames.find(name => name.toLowerCase().trim() === id));
+  const identifierFieldsSet = new Set(IDENTIFIER_FIELDS);
+  return fieldNames.filter(name => identifierFieldsSet.has(name.toLowerCase.trim()));
   // There must be a field whose `name` matches one of the IDENTIFIER_FIELDS.
 };
 export const selectInferedField = (collection, fieldName) => {

--- a/packages/netlify-cms-core/src/reducers/collections.js
+++ b/packages/netlify-cms-core/src/reducers/collections.js
@@ -115,7 +115,7 @@ export const selectTemplateName = (collection, slug) =>
 export const selectIdentifierCandidates = collection => {
   const fieldNames = collection.get('fields').map(field => field.get('name'));
   const identifierFieldsSet = new Set(IDENTIFIER_FIELDS);
-  return fieldNames.filter(name => identifierFieldsSet.has(name.toLowerCase.trim()));
+  return fieldNames.filter(name => identifierFieldsSet.has(name.toLowerCase().trim()));
   // There must be a field whose `name` matches one of the IDENTIFIER_FIELDS.
 };
 export const selectInferedField = (collection, fieldName) => {


### PR DESCRIPTION
Fixes #1700 

# Summary

This change checks the entry values for `IDENTIFIER_FIELDS` for one that is valid (truthy) rather than using the first one found (`title`). I'm not sure this is how the community wants to solve this issue, but this works for my workflow.

Was able to successfully create a post where `path` was specified and `title` was left empty (`""`). For reference, my `slug` field in my `config.yml` file was `"{{year}}-{{month}}-{{day}}-{{hour}}_{{minute}}_{{second}}"` so it didn't contain {{slug}} to begin with.