### PR TITLE
Add Firebase Cloud Function OAuth client to the list of external clients

### DIFF
--- a/website/content/docs/authentication-backends.md
+++ b/website/content/docs/authentication-backends.md
@@ -132,6 +132,7 @@ If you would like to facilitate your own OAuth authentication rather than use Ne
 | [@igk1972](https://github.com/igk1972)         | GitHub, GitHub Enterprise | Go                      | [Repo](https://github.com/igk1972/netlify-cms-oauth-provider-go)                                                                             |
 | [@davidejones](https://github.com/davidejones) | GitHub, GitHub Enterprise | Python                  | [Repo](https://github.com/davidejones/netlify-cms-oauth-provider-python)                                                                     |
 | [@marksteele](https://github.com/marksteele)   | GitHub, GitHub Enterprise | Serverless              | [Repo](https://github.com/marksteele/netlify-serverless-oauth2-backend), [Blog](https://www.control-alt-del.org/blog/serverless-blog-howto/) |
+| [@Herohtar](https://github.com/Herohtar)       | GitHub, GitHub Enterprise | Firebase Cloud Function | [Repo](https://github.com/Herohtar/netlify-cms-oauth-firebase)                                                                               |
 
 Check each project's documentation for instructions on how to configure it.
 


### PR DESCRIPTION
**Summary**

I've written a GitHub OAuth client that can be deployed as a [Firebase Cloud Function](https://firebase.google.com/docs/functions/). Just adding it to the list.

**Test plan**

No code was changed, only website markdown.