### PR TITLE
#1768: Fix using Uploadcare library in list widget

### DIFF
--- a/packages/netlify-cms-media-library-uploadcare/src/index.js
+++ b/packages/netlify-cms-media-library-uploadcare/src/index.js
@@ -1,4 +1,5 @@
 import { loadScript } from 'netlify-cms-lib-util';
+import { Iterable } from 'immutable';
 
 /**
  * Default Uploadcare widget configuration, can be overriden via config.yml.
@@ -44,7 +45,7 @@ function getFileGroup(files) {
  * because the value we're returning may be a promise that we created.
  */
 function getFiles(value, cdnBase) {
-  if (typeof value === 'object') {
+  if (Array.isArray(value) || Iterable.isIterable(value)) {
     const arr = Array.isArray(value) ? value : value.toJS();
     return isFileGroup(arr) ? getFileGroup(arr) : arr.map(val => getFile(val, cdnBase));
   }


### PR DESCRIPTION
Fixes #1768 

**Summary**

The problem was caused by loose checking value for array type (plain or immutable) using `typeof value === 'object'`. In case of usage at list widget, value passed to `#getFiles` was `null` which also an object. So I did this check explicitly for the plain array and the Immutable Iterable.

**Test plan**

And now it works.

![image](https://user-images.githubusercontent.com/670959/46073211-f2546700-c18c-11e8-92c1-3317af0f46f0.png)
