### PR TITLE
[WIP] add roadmap to docs site

### DIFF
--- a/website/content/pages/roadmap.md
+++ b/website/content/pages/roadmap.md
@@ -42,6 +42,7 @@ intro: Planned features for Netlify CMS
 - in editor, show the resulting url for the current entry (provides slug visibility too)
 - duplicate existing entry
 - faux pagination for non-paginated backends (github)
+- accept dot notation in field names to achieve nested values
 
 ## Validation
 - nested entry validation

--- a/website/content/pages/roadmap.md
+++ b/website/content/pages/roadmap.md
@@ -1,0 +1,55 @@
+---
+title: Roadmap
+description: Planned features for Netlify CMS
+heading: Roadmap
+intro: Planned features for Netlify CMS
+---
+## Meta
+- tests, tests, and more tests
+- implement bootstrapping lifecycle (auth -> load extensions -> init extensions -> etc)
+- fix builds to provide cjs and umd with shared dependencies
+
+## Publishing
+- obvious metadata
+- store draft field values locally
+- simple drafts for non-editorial workflow
+- unpublish capability for both workflow and non-workflow
+- multiple file groups published/unpublished together
+
+## File handling
+- top level arrays in output (just use `field`)
+- stop deleting fields that exist in an entry but aren't in the config
+- content bundles
+  - support using the slug in the folder name
+  - support storing assets in the current entry's folder
+
+## Dev experience
+- local git backend
+
+## Markdown editor
+- tables in markdown
+- mdx support
+- improved html and code editing support for markdown editor
+- markdown shortcuts in markdown rich text editor
+- in markdown widget, show editor component preview instead of component fields
+
+## UX
+- collection sorting
+- per-entry controls on the collection screen (delete, publish/unpublish)
+- show both published and unpublished on collection screen
+- links to deploy previews everywhere (collection screen, editor, workflow)
+- responsive
+- in editor, show the resulting url for the current entry (provides slug visibility too)
+- duplicate existing entry
+- faux pagination for non-paginated backends (github)
+
+## Validation
+- nested entry validation
+- allow extensions to include their own validation methods, including for validation of their config
+
+## Future
+- i18n
+- config ui
+- pwa/offline
+- interactive merge conflict resolution
+- robust relations

--- a/website/src/cms/cms.js
+++ b/website/src/cms/cms.js
@@ -3,11 +3,14 @@ import CMS from 'netlify-cms';
 import dayjs from 'dayjs';
 import { BlogPostTemplate } from '../templates/blog-post';
 import { DocsTemplate } from '../templates/doc-page';
+import { RoadmapTemplate } from '../pages/roadmap';
+import { CommunityTemplate } from '../pages/community';
 import Release from '../components/release';
 import WhatsNew from '../components/whats-new';
 import Notification from '../components/notification';
 import '../css/lib/prism.css';
 import '../css/imports/docs.css';
+import '../css/imports/hero.css';
 import '../css/imports/whatsnew.css';
 import '../css/imports/header.css';
 
@@ -50,7 +53,46 @@ const NotificationPreview = ({ entry }) =>
       </Notification>
     ));
 
+const RoadmapPreview = ({ entry, widgetFor }) => {
+  const { title, description, heading, intro } = entry.get('data').toJS();
+  return (
+    <RoadmapTemplate
+      title={title}
+      description={description}
+      heading={heading}
+      intro={intro}
+      body={widgetFor('body')}
+    />
+  );
+};
+
+const CommunityPreview = ({ entry }) => {
+  const {
+    title,
+    headline,
+    subhead,
+    primarycta,
+    upcomingevent,
+    howitworks,
+    howtojoin
+  } = entry.get('data').toJS()
+  return (
+    <CommunityTemplate
+      title={title}
+      headline={headline}
+      subhead={subhead}
+      cta={primarycta}
+      eventIntro={upcomingevent.hook}
+      howItWorks={howitworks}
+      howToJoin={howtojoin}
+    />
+  );
+};
+
+
 CMS.registerPreviewTemplate('blog', BlogPostPreview);
 CMS.registerPreviewTemplate('docs', DocsPreview);
 CMS.registerPreviewTemplate('releases', ReleasePreview);
 CMS.registerPreviewTemplate('notifications', NotificationPreview);
+CMS.registerPreviewTemplate('roadmap', RoadmapPreview);
+CMS.registerPreviewTemplate('community', CommunityPreview);

--- a/website/src/cms/cms.js
+++ b/website/src/cms/cms.js
@@ -67,15 +67,9 @@ const RoadmapPreview = ({ entry, widgetFor }) => {
 };
 
 const CommunityPreview = ({ entry }) => {
-  const {
-    title,
-    headline,
-    subhead,
-    primarycta,
-    upcomingevent,
-    howitworks,
-    howtojoin
-  } = entry.get('data').toJS()
+  const { title, headline, subhead, primarycta, upcomingevent, howitworks, howtojoin } = entry
+    .get('data')
+    .toJS();
   return (
     <CommunityTemplate
       title={title}
@@ -88,7 +82,6 @@ const CommunityPreview = ({ entry }) => {
     />
   );
 };
-
 
 CMS.registerPreviewTemplate('blog', BlogPostPreview);
 CMS.registerPreviewTemplate('docs', DocsPreview);

--- a/website/src/components/header.js
+++ b/website/src/components/header.js
@@ -41,6 +41,7 @@ class Header extends Component {
         {({ location }) => {
           const isDocs = location.pathname.indexOf('docs') !== -1;
           const isBlog = location.pathname.indexOf('blog') !== -1;
+          const isRoadmap = location.pathname.indexOf('roadmap') !== -1;
 
           return (
             <header
@@ -48,6 +49,7 @@ class Header extends Component {
               className={classnames({
                 docs: isDocs,
                 blog: isBlog,
+                roadmap: isRoadmap,
                 scrolled,
               })}
             >
@@ -67,6 +69,9 @@ class Header extends Component {
                   </Link>
                   <Link className="nav-link" to="/community">
                     Community
+                  </Link>
+                  <Link className="nav-link" to="/roadmap">
+                    Roadmap
                   </Link>
                   <Link className="nav-link" to="/blog">
                     Blog

--- a/website/src/css/imports/docs.css
+++ b/website/src/css/imports/docs.css
@@ -1,5 +1,6 @@
 .docs.page,
-.blog.page {
+.blog.page,
+.roadmap.page {
   padding: 69px $tiny $xl;
   text-align: left;
   @media screen and (min-width: $mobile) {

--- a/website/src/css/imports/header.css
+++ b/website/src/css/imports/header.css
@@ -88,7 +88,8 @@ header {
   }
 
   &.docs,
-  &.blog {
+  &.blog,
+  &.roadmap {
     background: $darkerGrey;
     padding: $small 0;
 

--- a/website/src/pages/community.js
+++ b/website/src/pages/community.js
@@ -9,6 +9,53 @@ import Markdownify from '../components/markdownify';
 
 import '../css/imports/collab.css';
 
+export const CommunityTemplate = ({ headline, subhead, cta, eventIntro, howItWorks, howToJoin}) => (
+  <div className="community page">
+    <section className="community hero">
+      <div className="contained">
+        <div className="hero-copy">
+          <h1 className="headline">
+            <Markdownify source={headline} />
+          </h1>
+          <h2 className="subhead">
+            <Markdownify source={subhead} />
+          </h2>
+          <h3 className="ctas">
+            <ul>
+              <li>
+                <Markdownify source={cta} />
+              </li>
+            </ul>
+          </h3>
+        </div>
+
+        <div className="calendar-cta">
+          <h2>{eventIntro}</h2>
+          <EventWidget />
+          <div className="cal-cta">
+            <Markdownify source={cta} />
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section className="how-it-works clearfix">
+      <div className="contained">
+        <div className="half">
+          <h4 className="section-label">How it works</h4>
+          <p>
+            <Markdown source={howItWorks} />
+          </p>
+          <h4 className="section-label">How to join</h4>
+          <p>
+            <Markdown source={howToJoin} />
+          </p>
+        </div>
+      </div>
+    </section>
+  </div>
+);
+
 const CommunityPage = ({ data }) => {
   const {
     title,
@@ -22,51 +69,16 @@ const CommunityPage = ({ data }) => {
 
   return (
     <Layout>
-      <div className="community page">
-        <Helmet title={title} />
-        <section className="community hero">
-          <div className="contained">
-            <div className="hero-copy">
-              <h1 className="headline">
-                <Markdownify source={headline} />
-              </h1>
-              <h2 className="subhead">
-                <Markdownify source={subhead} />
-              </h2>
-              <h3 className="ctas">
-                <ul>
-                  <li>
-                    <Markdownify source={primarycta} />
-                  </li>
-                </ul>
-              </h3>
-            </div>
-
-            <div className="calendar-cta">
-              <h2>{upcomingevent.hook}</h2>
-              <EventWidget />
-              <div className="cal-cta">
-                <Markdownify source={primarycta} />
-              </div>
-            </div>
-          </div>
-        </section>
-
-        <section className="how-it-works clearfix">
-          <div className="contained">
-            <div className="half">
-              <h4 className="section-label">How it works</h4>
-              <p>
-                <Markdown source={howitworks} />
-              </p>
-              <h4 className="section-label">How to join</h4>
-              <p>
-                <Markdown source={howtojoin} />
-              </p>
-            </div>
-          </div>
-        </section>
-      </div>
+      <Helmet title={title} />
+      <CommunityTemplate
+        title={title}
+        headline={headline}
+        subhead={subhead}
+        cta={primarycta}
+        eventIntro={upcomingevent.hook}
+        howItWorks={howitworks}
+        howToJoin={howtojoin}
+      />
     </Layout>
   );
 };

--- a/website/src/pages/community.js
+++ b/website/src/pages/community.js
@@ -9,7 +9,14 @@ import Markdownify from '../components/markdownify';
 
 import '../css/imports/collab.css';
 
-export const CommunityTemplate = ({ headline, subhead, cta, eventIntro, howItWorks, howToJoin}) => (
+export const CommunityTemplate = ({
+  headline,
+  subhead,
+  cta,
+  eventIntro,
+  howItWorks,
+  howToJoin,
+}) => (
   <div className="community page">
     <section className="community hero">
       <div className="contained">

--- a/website/src/pages/roadmap.js
+++ b/website/src/pages/roadmap.js
@@ -18,7 +18,7 @@ const Roadmap = ({ data }) => {
         <div className="container">
           <h1>{heading}</h1>
           <p>{intro}</p>
-          <div dangerouslySetInnerHTML={{ __html: html }}/>
+          <div dangerouslySetInnerHTML={{ __html: html }} />
         </div>
       </div>
     </Layout>

--- a/website/src/pages/roadmap.js
+++ b/website/src/pages/roadmap.js
@@ -4,7 +4,7 @@ import { graphql } from 'gatsby';
 
 import Layout from '../components/layout';
 
-export const RoadmapTemplate = ({ title, description, heading, intro, body, html }) => (
+export const RoadmapTemplate = ({ heading, intro, body, html }) => (
   <div className="roadmap page">
     <div className="container">
       <h1>{heading}</h1>
@@ -13,7 +13,6 @@ export const RoadmapTemplate = ({ title, description, heading, intro, body, html
     </div>
   </div>
 );
-
 
 const Roadmap = ({ data }) => {
   const { html, frontmatter } = data.markdownRemark;
@@ -25,13 +24,7 @@ const Roadmap = ({ data }) => {
         <title>{title}</title>
         <meta name="description" content={description} />
       </Helmet>
-      <RoadmapTemplate
-        title={title}
-        description={description}
-        heading={heading}
-        intro={intro}
-        html={html}
-      />
+      <RoadmapTemplate heading={heading} intro={intro} html={html} />
     </Layout>
   );
 };

--- a/website/src/pages/roadmap.js
+++ b/website/src/pages/roadmap.js
@@ -1,0 +1,42 @@
+import React from 'react';
+import Helmet from 'react-helmet';
+import { graphql } from 'gatsby';
+
+import Layout from '../components/layout';
+
+const Roadmap = ({ data }) => {
+  const { html, frontmatter } = data.markdownRemark;
+  const { title, description, heading, intro } = frontmatter;
+
+  return (
+    <Layout>
+      <div className="roadmap page">
+        <Helmet>
+          <title>{title}</title>
+          <meta name="description" content={description} />
+        </Helmet>
+        <div className="container">
+          <h1>{heading}</h1>
+          <p>{intro}</p>
+          <div dangerouslySetInnerHTML={{ __html: html }}/>
+        </div>
+      </div>
+    </Layout>
+  );
+};
+
+export const pageQuery = graphql`
+  query roadmapPage {
+    markdownRemark(fileAbsolutePath: { regex: "/roadmap/" }) {
+      frontmatter {
+        title
+        description
+        heading
+        intro
+      }
+      html
+    }
+  }
+`;
+
+export default Roadmap;

--- a/website/src/pages/roadmap.js
+++ b/website/src/pages/roadmap.js
@@ -4,23 +4,34 @@ import { graphql } from 'gatsby';
 
 import Layout from '../components/layout';
 
+export const RoadmapTemplate = ({ title, description, heading, intro, body, html }) => (
+  <div className="roadmap page">
+    <div className="container">
+      <h1>{heading}</h1>
+      <p>{intro}</p>
+      {body ? body : <div dangerouslySetInnerHTML={{ __html: html }} />}
+    </div>
+  </div>
+);
+
+
 const Roadmap = ({ data }) => {
   const { html, frontmatter } = data.markdownRemark;
   const { title, description, heading, intro } = frontmatter;
 
   return (
     <Layout>
-      <div className="roadmap page">
-        <Helmet>
-          <title>{title}</title>
-          <meta name="description" content={description} />
-        </Helmet>
-        <div className="container">
-          <h1>{heading}</h1>
-          <p>{intro}</p>
-          <div dangerouslySetInnerHTML={{ __html: html }} />
-        </div>
-      </div>
+      <Helmet>
+        <title>{title}</title>
+        <meta name="description" content={description} />
+      </Helmet>
+      <RoadmapTemplate
+        title={title}
+        description={description}
+        heading={heading}
+        intro={intro}
+        html={html}
+      />
     </Layout>
   );
 };

--- a/website/static/admin/config.yml
+++ b/website/static/admin/config.yml
@@ -10,6 +10,30 @@ media_folder: "website/static/img" # Folder where user uploaded files should go
 public_folder: "img"
 
 collections: # A list of collections the CMS should be able to edit
+  - name: pages
+    label: Pages
+    files:
+      - name: community
+        label: Community
+        file: website/content/pages/community.md
+        fields:
+          - { name: title, label: Title }
+          - { name: headline, label: Headline }
+          - { name: subhead, label: Subheading, widget: markdown }
+          - { name: primarycta, label: Call To Action, widget: markdown }
+          - { name: upcomingevent, label: Event Intro, widget: text }
+          - { name: howitworks, label: How It Works, widget: text }
+          - { name: howtojoin, label: How To Join, widget: markdown }
+      - name: roadmap
+        label: Roadmap
+        file: website/content/pages/roadmap.md
+        fields:
+          - { name: title, label: Title }
+          - { name: description, label: Description, widget: text }
+          - { name: heading, label: Heading }
+          - { name: intro, label: Intro, widget: text }
+          - { name: body, label: Roadmap, widget: markdown }
+
   - name: "docs" # Used in routes, ie.: /admin/collections/:slug/edit
     label: "Docs" # Used in the UI, ie.: "New Post"
     folder: "website/content/docs" # The path to the folder where the documents are stored

--- a/website/static/admin/config.yml
+++ b/website/static/admin/config.yml
@@ -4,7 +4,7 @@ backend:
   branch: roadmap
   squash_merges: true
 
-publish_mode: editorial_workflow
+# publish_mode: editorial_workflow
 
 media_folder: "website/static/img" # Folder where user uploaded files should go
 public_folder: "img"

--- a/website/static/admin/config.yml
+++ b/website/static/admin/config.yml
@@ -1,7 +1,7 @@
 backend:
   name: github
   repo: netlify/netlify-cms
-  branch: master
+  branch: roadmap
   squash_merges: true
 
 publish_mode: editorial_workflow
@@ -21,7 +21,9 @@ collections: # A list of collections the CMS should be able to edit
           - { name: headline, label: Headline }
           - { name: subhead, label: Subheading, widget: markdown }
           - { name: primarycta, label: Call To Action, widget: markdown }
-          - { name: upcomingevent, label: Event Intro, widget: text }
+          - { name: upcomingevent, label: Event, widget: object, fields: [
+              { name: hook, label: Intro, widget: text }
+            ]}
           - { name: howitworks, label: How It Works, widget: text }
           - { name: howtojoin, label: How To Join, widget: markdown }
       - name: roadmap


### PR DESCRIPTION
Adding a roadmap to the docs site because:

- everyone asks about the roadmap
- it's more visible this way
- simple list format lends itself to effectively communicating high level goals
- more stable source of truth (GH project can be altered by an accidental click)
- everyone asks about the roadmap

This will always be a living document. Open to any and all feedback during WIP.

**todo**
- [ ] rewrite all of it (first commit is a rough outline)
- [ ] link GitHub issues
- [ ] provide links to create new issue where one does not exist
- [ ] change cms branch back to master
- [ ] turn editorial workflow back on