### PR TITLE
fix null on markdown image alt

### DIFF
--- a/packages/netlify-cms-widget-markdown/src/__tests__/__snapshots__/renderer.spec.js.snap
+++ b/packages/netlify-cms-widget-markdown/src/__tests__/__snapshots__/renderer.spec.js.snap
@@ -71,7 +71,8 @@ exports[`Markdown Preview renderer Markdown rendering General should render mark
 <p><a href=\\"http://google.com\\">link title</a></p>
 <h5>H5</h5>
 <p>![alt text](https://pbs.twimg.com/profile_images/678903331176214528/TQTdqGwD.jpg)</p>
-<h6>H6</h6>",
+<h6>H6</h6>
+<p>![](https://pbs.twimg.com/profile_images/678903331176214528/TQTdqGwD.jpg)</p>",
     }
   }
 />

--- a/packages/netlify-cms-widget-markdown/src/__tests__/renderer.spec.js
+++ b/packages/netlify-cms-widget-markdown/src/__tests__/renderer.spec.js
@@ -33,6 +33,8 @@ Text with **bold** & _em_ elements
 ![alt text](https://pbs.twimg.com/profile_images/678903331176214528/TQTdqGwD.jpg)
 
 ###### H6
+
+![](https://pbs.twimg.com/profile_images/678903331176214528/TQTdqGwD.jpg)
 `;
         expect(
           renderer.create(<MarkdownPreview value={markdownToHtml(value)} />).toJSON(),

--- a/packages/netlify-cms-widget-markdown/src/serializers/remarkImagesToText.js
+++ b/packages/netlify-cms-widget-markdown/src/serializers/remarkImagesToText.js
@@ -15,8 +15,8 @@ export default function remarkImagesToText() {
         child.children.length === 1 &&
         child.children[0].type === 'image'
       ) {
-        const { alt, url, title } = child.children[0];
-        const value = `![${alt || ''}](${url || ''}${title ? ' title' : ''})`;
+        const { alt, url } = child.children[0];
+        const value = `![${alt || ''}](${url || ''})`;
         child.children = [{ type: 'text', value }];
       }
       return child;

--- a/packages/netlify-cms-widget-markdown/src/serializers/remarkImagesToText.js
+++ b/packages/netlify-cms-widget-markdown/src/serializers/remarkImagesToText.js
@@ -15,8 +15,8 @@ export default function remarkImagesToText() {
         child.children.length === 1 &&
         child.children[0].type === 'image'
       ) {
-        const { alt = '', url = '', title = '' } = child.children[0];
-        const value = `![${alt}](${url}${title ? ' title' : ''})`;
+        const { alt, url, title } = child.children[0];
+        const value = `![${alt || ''}](${url || ''}${title ? ' title' : ''})`;
         child.children = [{ type: 'text', value }];
       }
       return child;


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines.

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first two fields are mandatory:
-->

**Summary**

<!--
Explain the **motivation** for making this change.
What existing problem does the pull request solve?
-->

closes #956
was getting `![null](url)` on my markdowns, when not entering any text 🐛 
made the one of the [image serializers](https://github.com/netlify/netlify-cms/blob/a262bcef530532d710540af16d83e9a9dcaaa597/packages/netlify-cms-widget-markdown/src/serializers/remarkImagesToText.js#L19) mirror [another one](https://github.com/netlify/netlify-cms/blob/a262bcef530532d710540af16d83e9a9dcaaa597/packages/netlify-cms-editor-component-image/src/index.js#L11
), from this very repository.

**Test plan**

1. manually added markdown line and snapshot.
2. `yarn jest`, it breaks (sending `null` as when empty)
3. fixed it! 💪 

before:
```diff
@@ -22,9 +22,9 @@
- <p>![](https://pbs.twimg.com/profile_images/678903331176214528/TQTdqGwD.jpg)</p>",
+ <p>![null](https://pbs.twimg.com/profile_images/678903331176214528/TQTdqGwD.jpg)</p>",
```

after: **passes**.

<!--
Demonstrate the code is solid.
Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.
-->

**A picture of a cute animal (not mandatory but encouraged)**

![null](https://media.giphy.com/media/vsGnvQD0ZcQco/giphy.gif)