### PR TITLE
Remove single quotes before creating slug

### DIFF
--- a/packages/netlify-cms-core/src/backend.js
+++ b/packages/netlify-cms-core/src/backend.js
@@ -69,6 +69,9 @@ const slugFormatter = (collection, entryData, slugConfig) => {
     // Convert slug to lower-case
     .toLocaleLowerCase()
 
+    // Remove single quotes.
+    .replace(/[']/g, '')
+
     // Replace periods with dashes.
     .replace(/[.]/g, '-');
 


### PR DESCRIPTION
Closes #1698 

<!--
Please provide enough information so that others can review your pull request.
The first two fields are mandatory:
-->

**Summary**

A single quote is a character that is commonly used in the middle of a word (don't, won't, can't, they're, etc).

When titles contain this character it becomes another hyphen in the slug which isn't ideal because letters get separated from the word that they're part of.

This PR strips quotes before creating the slug.

**Test plan**

<!--
Demonstrate the code is solid.
Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.
-->

The code changed is very simple and straightforward, no complex tests are necessary.

