### PR TITLE
Set List Widget to use singular label if available

### DIFF
--- a/packages/netlify-cms-widget-list/src/ListControl.js
+++ b/packages/netlify-cms-widget-list/src/ListControl.js
@@ -277,7 +277,7 @@ export default class ListControl extends React.Component {
           allowAdd={field.get('allow_add', true)}
           onAdd={this.handleAdd}
           heading={`${items.size} ${listLabel}`}
-          label={listLabel}
+          label={labelSingular.toLowerCase() || listLabel}
           onCollapseToggle={this.handleCollapseAllToggle}
           collapsed={itemsCollapsed.every(val => val === true)}
         />

--- a/packages/netlify-cms-widget-list/src/ListControl.js
+++ b/packages/netlify-cms-widget-list/src/ListControl.js
@@ -277,7 +277,7 @@ export default class ListControl extends React.Component {
           allowAdd={field.get('allow_add', true)}
           onAdd={this.handleAdd}
           heading={`${items.size} ${listLabel}`}
-          label={labelSingular.toLowerCase() || listLabel}
+          label={labelSingular.toLowerCase()}
           onCollapseToggle={this.handleCollapseAllToggle}
           collapsed={itemsCollapsed.every(val => val === true)}
         />


### PR DESCRIPTION
Fixes #1684 

**Summary**

ListControl was sending listLabel to the ObjectWidgetTopBar component to use for the Add button. This label was being set to the plural form of the object if more than one were present on the list. However, the Add button would only add one object to the list at a time.

This PR will attempt to use the singular version of the label and will fallback to listLabel if singular doesn't exist.

**Test plan**

No test plan needed. Added a short-circuit evaluation.

**A picture of a cute animal (not mandatory but encouraged)**

![](https://media.giphy.com/media/h3vlT12YvJU8E/giphy.gif)