### PR TITLE
fix(config): stop throwing on config.yml 404, fix manual init

### DIFF
--- a/packages/netlify-cms-core/src/actions/config.js
+++ b/packages/netlify-cms-core/src/actions/config.js
@@ -56,10 +56,10 @@ function parseConfig(data) {
 }
 
 async function getConfig(file, isPreloaded) {
-  const response = await fetch(file, { credentials: 'same-origin' });
-  if (response.status !== 200) {
+  const response = await fetch(file, { credentials: 'same-origin' }).catch(err => err);
+  if (response instanceof Error || response.status !== 200) {
     if (isPreloaded) return parseConfig('');
-    throw new Error(`Failed to load config.yml (${response.status})`);
+    throw new Error(`Failed to load config.yml (${response.status || response})`);
   }
   const contentType = response.headers.get('Content-Type') || 'Not-Found';
   const isYaml = contentType.indexOf('yaml') !== -1;


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines.

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first two fields are mandatory:
-->

**Summary**

<!--
Explain the **motivation** for making this change.
What existing problem does the pull request solve?
-->

We weren't catching the error when config.yml fetch errored, so manual init without a config file wasn't possible in those situations. Ran into this trying to spin up Netlify CMS on Codepen, where CORS headers disallowed the CMS from attempting to access local files.
