### PR TITLE
[docs] Add description option to collections docs

### DIFF
--- a/website/content/docs/configuration-options.md
+++ b/website/content/docs/configuration-options.md
@@ -123,8 +123,9 @@ The `collections` setting is the heart of your Netlify CMS configuration, as it 
 `collections` accepts a list of collection objects, each with the following options:
 
 - `name` (required): unique identifier for the collection, used as the key when referenced in other contexts (like the [relation widget](../widgets/#relation))
-- `Label`: label for the collection in the editor UI; defaults to the value of `name`
+- `label`: label for the collection in the editor UI; defaults to the value of `name`
 - `label_singular`: singular label for certain elements in the editor; defaults to the value of `label`
+- `description`: optional text, displayed below the label when viewing a collection
 - `file` or `folder` (requires one of these): specifies the collection type and location; details in [Collection Types](../collection-types)
 - `filter`: optional filter for `folder` collections; details in [Collection Types](../collection-types)
 - `create`: for `folder` collections only; `true` allows users to create new items in the collection; defaults to `false`


### PR DESCRIPTION
Add  `description` option for collections which went undocumented somehow, despite it being pretty useful for client work