### PR TITLE
Wrong path on link for Collection Types in documentation

### DIFF
--- a/website/content/docs/configuration-options.md
+++ b/website/content/docs/configuration-options.md
@@ -126,8 +126,8 @@ The `collections` setting is the heart of your Netlify CMS configuration, as it 
 - `label`: label for the collection in the editor UI; defaults to the value of `name`
 - `label_singular`: singular label for certain elements in the editor; defaults to the value of `label`
 - `description`: optional text, displayed below the label when viewing a collection
-- `file` or `folder` (requires one of these): specifies the collection type and location; details in [Collection Types](../collection-types)
-- `filter`: optional filter for `folder` collections; details in [Collection Types](../collection-types)
+- `file` or `folder` (requires one of these): specifies the collection type and location; details in [Collection Types](../docs/collection-types)
+- `filter`: optional filter for `folder` collections; details in [Collection Types](../docs/collection-types)
 - `create`: for `folder` collections only; `true` allows users to create new items in the collection; defaults to `false`
 - `delete`: `false` prevents users from deleting items in a collection; defaults to `true`
 - `extension`: see detailed description below


### PR DESCRIPTION
**Summary**
While reading the documentation I noticed the path on the "Content Types" link was incorrect. Just a quick fix.

**Test plan**
It point to the correct page!

