### PR TITLE
Note that validation doesn't work on nested fields

### DIFF
--- a/website/content/docs/widgets.md
+++ b/website/content/docs/widgets.md
@@ -25,5 +25,6 @@ The following options are available on all fields:
           widget: "string"
           pattern: [".{12,}", "Must have at least 12 characters"]
         ```
+  - **Note:** Currently validation doesn't work on nested fields
 
 ## Default widgets


### PR DESCRIPTION
Add a note indicating that field validation doesn't currently work on nested fields.


<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines.

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first two fields are mandatory:
-->

**Summary**
Help others figure out quickly that validation doesn't work on nested fields. I spent a few days on and off until I figured it out :)

<!--
Explain the **motivation** for making this change.
What existing problem does the pull request solve?
-->

<!--
Demonstrate the code is solid.
Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.
-->

**A picture of a cute animal (not mandatory but encouraged)**
![koala3-e1475113901297](https://user-images.githubusercontent.com/1545577/47673438-68d0f400-db93-11e8-90b1-9de3a3894ab6.jpg)
