### PR TITLE
Move window/UMD bridge in `netlify-cms` instead of `netlify-cms-core`

### DIFF
--- a/packages/netlify-cms-core/package.json
+++ b/packages/netlify-cms-core/package.json
@@ -21,7 +21,6 @@
   "dependencies": {
     "ajv": "^6.4.0",
     "ajv-errors": "^1.0.0",
-    "create-react-class": "^15.6.0",
     "diacritics": "^1.3.0",
     "emotion": "^9.2.6",
     "fuzzy": "^0.1.1",

--- a/packages/netlify-cms-core/src/index.js
+++ b/packages/netlify-cms-core/src/index.js
@@ -1,25 +1,4 @@
-import React from 'react';
 import bootstrap from './bootstrap';
 import registry from 'Lib/registry';
-import createReactClass from 'create-react-class';
-
-/**
- * Load Netlify CMS automatically if `window.CMS_MANUAL_INIT` is set.
- */
-if (!window.CMS_MANUAL_INIT) {
-  bootstrap();
-} else {
-  console.log('`window.CMS_MANUAL_INIT` flag set, skipping automatic initialization.');
-}
-
-/**
- * Add extension hooks to global scope.
- */
-if (typeof window !== 'undefined') {
-  window.CMS = registry;
-  window.initCMS = bootstrap;
-  window.createClass = window.createClass || createReactClass;
-  window.h = window.h || React.createElement;
-}
 
 export { registry as default, bootstrap as init };

--- a/packages/netlify-cms/package.json
+++ b/packages/netlify-cms/package.json
@@ -21,6 +21,7 @@
   ],
   "license": "MIT",
   "dependencies": {
+    "create-react-class": "^15.6.0",
     "emotion": "^9.2.6",
     "netlify-cms-backend-bitbucket": "^2.0.7",
     "netlify-cms-backend-git-gateway": "^2.0.8",

--- a/packages/netlify-cms/src/index.js
+++ b/packages/netlify-cms/src/index.js
@@ -1,7 +1,28 @@
+import createReactClass from 'create-react-class';
+import React from 'react';
 import CMS, { init } from 'netlify-cms-core/src';
 import './backends';
 import './widgets';
 import './editor-components';
 import './media-libraries';
+
+/**
+ * Load Netlify CMS automatically if `window.CMS_MANUAL_INIT` is set.
+ */
+if (!window.CMS_MANUAL_INIT) {
+  init();
+} else {
+  console.log('`window.CMS_MANUAL_INIT` flag set, skipping automatic initialization.');
+}
+
+/**
+ * Add extension hooks to global scope.
+ */
+if (typeof window !== 'undefined') {
+  window.CMS = CMS;
+  window.initCMS = init;
+  window.createClass = window.createClass || createReactClass;
+  window.h = window.h || React.createElement;
+}
 
 export { CMS as default, init };


### PR DESCRIPTION
**Summary**

`netlify-cms` package is responsible to make NetlifyCMS easy to use. It is bundled with the UMD wrapper and is used as script tag. It imports all widgets and backends...
It makes sense that `netlify-cms` should handle whole aspects about this "window bridge"... and keep `netlify-cms-core` as a clean ESM module.

It will make `netlify-cms-core` easy to use as a standalone ESM module:
```
import { init } from "netlify-cms-core"
init({})
```

Without this PR, a `window.CMS_MANUAL_INIT` should be set before the `import` is done.

<!--
Explain the **motivation** for making this change.
What existing problem does the pull request solve?
-->
