### PR TITLE
webpack: only process current sources

### DIFF
--- a/packages/netlify-cms-core/webpack.config.js
+++ b/packages/netlify-cms-core/webpack.config.js
@@ -18,7 +18,7 @@ module.exports = {
         .map(([, rule]) => rule()),
       {
         test: /\.js$/,
-        exclude: /node_modules/,
+        include: path.join(__dirname, 'src'),
         use: {
           loader: 'babel-loader',
           options: {

--- a/scripts/webpack.js
+++ b/scripts/webpack.js
@@ -1,14 +1,15 @@
 const path = require('path');
 const webpack = require('webpack');
 const FriendlyErrorsWebpackPlugin = require('friendly-errors-webpack-plugin');
-const pkg = require(path.join(process.cwd(), 'package.json'));
+const modulePath = process.cwd();
+const pkg = require(path.join(modulePath, 'package.json'));
 
 const isProduction = process.env.NODE_ENV === 'production';
 
 const rules = () => ({
   js: () => ({
     test: /\.js$/,
-    exclude: /node_modules/,
+    include: path.resolve(`${modulePath}/src`),
     use: {
       loader: 'babel-loader',
       options: {


### PR DESCRIPTION

**Summary**

Exclude `node_modules` may not work on a mono-repo project. Indeed some higher packages like `netlify-cms-core` use others packages that are already builded. So pass them to the babel-loader is not necessary.
Skip babel for anything except the sources reduces (a little) the build time and suppress que babel warning:
`The code generator has deoptimised the styling of /netlify-cms/packages/netlify-cms-core/dist/netlify-cms-core.js as it exceeds the max of 500KB.`
