### PR TITLE
improvement(config) add the ability to reverse entries in folder

### DIFF
--- a/packages/netlify-cms-core/src/backend.js
+++ b/packages/netlify-cms-core/src/backend.js
@@ -185,6 +185,7 @@ class Backend {
 
   processEntries(loadedEntries, collection) {
     const collectionFilter = collection.get('filter');
+    const reverseOrder = collection.get('reverse');
     const entries = loadedEntries.map(loadedEntry =>
       createEntry(
         collection.get('name'),
@@ -193,11 +194,14 @@ class Backend {
         { raw: loadedEntry.data || '', label: loadedEntry.file.label },
       ),
     );
-    const formattedEntries = entries.map(this.entryWithFormat(collection));
+    const formattedEntries = reverseOrder
+      ? Array.reverse(entries.map(this.entryWithFormat(collection)))
+      : entries.map(this.entryWithFormat(collection));
     // If this collection has a "filter" property, filter entries accordingly
     const filteredEntries = collectionFilter
       ? this.filterEntries({ entries: formattedEntries }, collectionFilter)
       : formattedEntries;
+
     return filteredEntries;
   }
 


### PR DESCRIPTION
**Summary**
The GitHub API returns folder listing sorted by name and Netlify doesn't really let you control that. For cases where we're returning blog posts, most slugs will be `{{year}}-{{month}}-{{day}}-{{slug}}` meaning the newest posts are at the bottom. 

By passing a reverse property on a collection new posts will always be on top

**Test plan**
This has been a pretty simple change, my test plan was to check with/and without the new property and to note the order of items returned by github.

Without the reverse property the output remains the same.

