### PR TITLE
netlify-cms-backend: fix `function` prop-type

### DIFF
--- a/packages/netlify-cms-backend-github/src/AuthenticationPage.js
+++ b/packages/netlify-cms-backend-github/src/AuthenticationPage.js
@@ -17,7 +17,7 @@ export default class GitHubAuthenticationPage extends React.Component {
     siteId: PropTypes.string,
     authEndpoint: PropTypes.string,
     config: ImmutablePropTypes.map,
-    clearHash: PropTypes.function,
+    clearHash: PropTypes.func,
   };
 
   state = {};

--- a/packages/netlify-cms-backend-gitlab/src/AuthenticationPage.js
+++ b/packages/netlify-cms-backend-gitlab/src/AuthenticationPage.js
@@ -17,7 +17,7 @@ export default class GitLabAuthenticationPage extends React.Component {
     siteId: PropTypes.string,
     authEndpoint: PropTypes.string,
     config: ImmutablePropTypes.map,
-    clearHash: PropTypes.function,
+    clearHash: PropTypes.func,
   };
 
   state = {};


### PR DESCRIPTION

**Summary**

Use `PropTypes.func` instead of `PropTypes.function`. It removes the warning form React:
```
Failed prop type: GitLabAuthenticationPage: prop type `clearHash` is invalid; it must be a function, usually from the `prop-types` package, but received `undefined`.
```
