### PR TITLE
Changes for registerBackend compatibility (API)

### DIFF
--- a/packages/netlify-cms-core/src/actions/editorialWorkflow.js
+++ b/packages/netlify-cms-core/src/actions/editorialWorkflow.js
@@ -238,7 +238,7 @@ export function loadUnpublishedEntry(collection, slug) {
       .unpublishedEntry(collection, slug)
       .then(entry => dispatch(unpublishedEntryLoaded(collection, entry)))
       .catch(error => {
-        if (error instanceof EditorialWorkflowError && error.notUnderEditorialWorkflow) {
+        if (error.name === 'EDITORIAL_WORKFLOW_ERROR' && error.notUnderEditorialWorkflow) {
           dispatch(unpublishedEntryRedirected(collection, slug));
           dispatch(loadEntry(collection, slug));
         } else {

--- a/packages/netlify-cms-core/src/actions/editorialWorkflow.js
+++ b/packages/netlify-cms-core/src/actions/editorialWorkflow.js
@@ -6,7 +6,7 @@ import { currentBackend } from 'src/backend';
 import { getAsset } from 'Reducers';
 import { selectFields } from 'Reducers/collections';
 import { EDITORIAL_WORKFLOW } from 'Constants/publishModes';
-import { EditorialWorkflowError } from 'netlify-cms-lib-util';
+import { EDITORIAL_WORKFLOW_ERROR } from 'netlify-cms-lib-util';
 import { loadEntry } from './entries';
 import ValidationErrorTypes from 'Constants/validationErrorTypes';
 
@@ -238,7 +238,7 @@ export function loadUnpublishedEntry(collection, slug) {
       .unpublishedEntry(collection, slug)
       .then(entry => dispatch(unpublishedEntryLoaded(collection, entry)))
       .catch(error => {
-        if (error.name === 'EDITORIAL_WORKFLOW_ERROR' && error.notUnderEditorialWorkflow) {
+        if (error.name === EDITORIAL_WORKFLOW_ERROR && error.notUnderEditorialWorkflow) {
           dispatch(unpublishedEntryRedirected(collection, slug));
           dispatch(loadEntry(collection, slug));
         } else {

--- a/packages/netlify-cms-core/src/backend.js
+++ b/packages/netlify-cms-core/src/backend.js
@@ -449,7 +449,7 @@ class Backend {
     }
 
     const commitMessage = commitMessageFormatter('delete', config, { collection, slug, path });
-    return this.implementation.deleteFile(path, commitMessage);
+    return this.implementation.deleteFile(path, commitMessage, { collection, slug });
   }
 
   deleteMedia(config, path) {

--- a/packages/netlify-cms-lib-util/src/index.js
+++ b/packages/netlify-cms-lib-util/src/index.js
@@ -1,6 +1,6 @@
 export APIError from './APIError';
 export Cursor, { CURSOR_COMPATIBILITY_SYMBOL } from './Cursor';
-export EditorialWorkflowError from './EditorialWorkflowError';
+export EditorialWorkflowError, { EDITORIAL_WORKFLOW_ERROR } from './EditorialWorkflowError';
 export localForage from './localForage';
 export { resolvePath, basename, fileExtensionWithSeparator, fileExtension } from './path';
 export { filterPromises, resolvePromiseProperties, then } from './promise';


### PR DESCRIPTION
**Summary**

## Changes for registerBackend compatibility:

- allows for custom backends to use the collection and slug information to determine the file when not using only path information.
- fix editorial workflow `EditorialWorkflowError` instance check to be compatible with custom backends

- Stays backwards compatible
- ***Non Breaking*** change

**Test plan**

Tested on a custom backend.

**A picture of a cute animal (not mandatory but encouraged)**
🐥
