### PR TITLE
fix: MediaLibraryHeader CloseButton style

### DIFF
--- a/packages/netlify-cms-core/src/components/MediaLibrary/MediaLibraryHeader.js
+++ b/packages/netlify-cms-core/src/components/MediaLibrary/MediaLibraryHeader.js
@@ -1,9 +1,10 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import styled from 'react-emotion';
-import { Icon, shadows, colors } from 'netlify-cms-ui-default';
+import { Icon, shadows, colors, buttons } from 'netlify-cms-ui-default';
 
 const CloseButton = styled.button`
+  ${buttons.button};
   ${shadows.dropMiddle};
   position: absolute;
   margin-right: -40px;


### PR DESCRIPTION
**Summary**

Remove default style from `CloseButton`

Before
<img width="146" alt="image" src="https://user-images.githubusercontent.com/8997319/48660921-39165d00-ea6a-11e8-93e8-edece48838d3.png">

After
<img width="157" alt="image" src="https://user-images.githubusercontent.com/8997319/48660940-7844ae00-ea6a-11e8-9c87-051392d2d67e.png">


**Test plan**

N/A

