### PR TITLE
Fix entry saved message

### DIFF
--- a/packages/netlify-cms-core/src/actions/entries.js
+++ b/packages/netlify-cms-core/src/actions/entries.js
@@ -446,7 +446,7 @@ export function persistEntry(collection) {
         dispatch(
           notifSend({
             message: {
-              key: 'ui.toast.missingRequiredField',
+              key: 'ui.toast.entrySaved',
             },
             kind: 'success',
             dismissAfter: 4000,


### PR DESCRIPTION
**Summary**

When **not* using editorial workflow, publishing a change shows incorrect message:
![image](https://user-images.githubusercontent.com/784848/48676226-b8626a00-eb18-11e8-9cf6-05b518853c84.png)

Caused by this commit: https://github.com/netlify/netlify-cms/commit/c2e21ff9db954c1bdec25531ee2132bd31453b78#diff-b80adfd8b33beb6f0d8d25d454a2d6deR452

**Test plan**

Change demo to not use editorial_workflow.
Save a change and publish.
Should see the correct message

**A picture of a cute animal (not mandatory but encouraged)**
🐖