### PR TITLE
fix(netlify-cms-core): remove double focusable elements on profile menu button

### DIFF
--- a/packages/netlify-cms-core/src/components/UI/SettingsDropdown.js
+++ b/packages/netlify-cms-core/src/components/UI/SettingsDropdown.js
@@ -12,8 +12,8 @@ const styles = {
   `,
 };
 
-const AppHeaderAvatar = styled.button`
-  border: 0;
+const AvatarDropdownButton = styled(DropdownButton)`
+  display: inline-block;
   padding: 8px;
   cursor: pointer;
   color: #1e2532;
@@ -38,11 +38,8 @@ const AppHeaderSiteLink = styled.a`
   padding: 10px 16px;
 `;
 
-const Avatar = ({ imageUrl }) => (
-  <AppHeaderAvatar>
-    {imageUrl ? <AvatarImage src={imageUrl} /> : <AvatarPlaceholderIcon type="user" size="large" />}
-  </AppHeaderAvatar>
-);
+const Avatar = ({ imageUrl }) =>
+  imageUrl ? <AvatarImage src={imageUrl} /> : <AvatarPlaceholderIcon type="user" size="large" />;
 
 Avatar.propTypes = {
   imageUrl: PropTypes.string,
@@ -60,9 +57,9 @@ const SettingsDropdown = ({ displayUrl, imageUrl, onLogoutClick, t }) => (
       dropdownWidth="100px"
       dropdownPosition="right"
       renderButton={() => (
-        <DropdownButton>
+        <AvatarDropdownButton>
           <Avatar imageUrl={imageUrl} />
-        </DropdownButton>
+        </AvatarDropdownButton>
       )}
     >
       <DropdownItem label={t('ui.settingsDropdown.logOut')} onClick={onLogoutClick} />


### PR DESCRIPTION
**Summary**

Right now you can have focus on 2 different elements in the "profile menu button". That's because there is a tabIndex on the span and we have a nested button, so both can receive focus.

Before 

![image](https://user-images.githubusercontent.com/8997319/48904738-9f7eef00-ee5f-11e8-9d11-419ba5f1a357.png)

After

![image](https://user-images.githubusercontent.com/8997319/48904851-11573880-ee60-11e8-8caf-ed6743d65836.png)

**Test plan**

Manually tested

**Other**

Would you be interested in moving from `react-aria-menubutton` to something like [reach/menu-button](https://ui.reach.tech/menu-button) instead? The later seems to work better and provide a bit better a11y (like not using a span to emulate a button).