### PR TITLE
fix(netlify-cms-core): fix identifier field validation

### DIFF
--- a/packages/netlify-cms-core/src/reducers/collections.js
+++ b/packages/netlify-cms-core/src/reducers/collections.js
@@ -114,9 +114,9 @@ export const selectTemplateName = (collection, slug) =>
   selectors[collection.get('type')].templateName(collection, slug);
 export const selectIdentifier = collection => {
   const identifier = collection.get('identifier_field');
-  const indentifierFields = identifier ? [identifier, ...IDENTIFIER_FIELDS] : IDENTIFIER_FIELDS;
+  const identifierFields = identifier ? [identifier, ...IDENTIFIER_FIELDS] : IDENTIFIER_FIELDS;
   const fieldNames = collection.get('fields').map(field => field.get('name'));
-  return indentifierFields.find(id => fieldNames.find(name => name.toLowerCase().trim() === id));
+  return identifierFields.find(id => fieldNames.find(name => name.toLowerCase().trim() === id.toLowerCase().trim()));
 };
 export const selectInferedField = (collection, fieldName) => {
   const inferableField = INFERABLE_FIELDS[fieldName];

--- a/packages/netlify-cms-core/src/reducers/collections.js
+++ b/packages/netlify-cms-core/src/reducers/collections.js
@@ -116,7 +116,9 @@ export const selectIdentifier = collection => {
   const identifier = collection.get('identifier_field');
   const identifierFields = identifier ? [identifier, ...IDENTIFIER_FIELDS] : IDENTIFIER_FIELDS;
   const fieldNames = collection.get('fields').map(field => field.get('name'));
-  return identifierFields.find(id => fieldNames.find(name => name.toLowerCase().trim() === id.toLowerCase().trim()));
+  return identifierFields.find(id =>
+    fieldNames.find(name => name.toLowerCase().trim() === id.toLowerCase().trim()),
+  );
 };
 export const selectInferedField = (collection, fieldName) => {
   const inferableField = INFERABLE_FIELDS[fieldName];


### PR DESCRIPTION
**Describe the bug**
Follow-on to #1543 and #1878. Attempting to use the identifier_field feature introduced in 2.2.0 with an identifier that is not all *lowercase* causes the backend (On Save) error: 'Collection must have a field name that is a valid entry identifier, or must have `identifier_field` set'.

**To Reproduce**
Specify an identifier_field that has uppercase characters and then attempt to create and save an entry.

**Expected behavior**
The CMS saves without throwing an error.

**Minor Refactor**
Also fix spelling of local variable in the `selectIdentifier` function.