### PR TITLE
fix(netlify-cms-widget-text): set correct font family

### DIFF
--- a/packages/netlify-cms-widget-text/src/TextControl.js
+++ b/packages/netlify-cms-widget-text/src/TextControl.js
@@ -45,6 +45,7 @@ export default class TextControl extends React.Component {
         onFocus={setActiveStyle}
         onBlur={setInactiveStyle}
         style={{ minHeight: '140px' }}
+        css={{ fontFamily: 'inherit' }}
         onChange={e => onChange(e.target.value)}
       />
     );


### PR DESCRIPTION
**Summary**

Use the same font family in the `textarea` as in other widgets

**Test plan**

Before

<img width="426" alt="image" src="https://user-images.githubusercontent.com/8997319/49100192-a0ef5380-f273-11e8-9512-e0e07066322e.png">

After

<img width="440" alt="image" src="https://user-images.githubusercontent.com/8997319/49100161-8b7a2980-f273-11e8-8706-b6a6af932eb0.png">


**A picture of a cute animal (not mandatory but encouraged)**
