### PR TITLE
chore(netlify-cms-core): upgrade react-frame-component to 4.x

### DIFF
--- a/packages/netlify-cms-core/package.json
+++ b/packages/netlify-cms-core/package.json
@@ -44,7 +44,7 @@
     "react-dnd-html5-backend": "^7.0.0",
     "react-dom": "^16.0.0",
     "react-emotion": "^9.2.5",
-    "react-frame-component": "^2.0.0",
+    "react-frame-component": "^4.0.2",
     "react-hot-loader": "^4.0.0",
     "react-immutable-proptypes": "^2.1.0",
     "react-is": "16.3.1",

--- a/packages/netlify-cms-core/src/components/Editor/EditorPreviewPane/EditorPreviewContent.js
+++ b/packages/netlify-cms-core/src/components/Editor/EditorPreviewPane/EditorPreviewContent.js
@@ -2,6 +2,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { isElement } from 'react-is';
 import { ScrollSyncPane } from 'react-scroll-sync';
+import { FrameContextConsumer } from 'react-frame-component';
 
 /**
  * We need to create a lightweight component here so that we can access the
@@ -12,18 +13,18 @@ class PreviewContent extends React.Component {
   render() {
     const { previewComponent, previewProps } = this.props;
     return (
-      <ScrollSyncPane attachTo={this.context.document.scrollingElement}>
-        {isElement(previewComponent)
-          ? React.cloneElement(previewComponent, previewProps)
-          : React.createElement(previewComponent, previewProps)}
-      </ScrollSyncPane>
+      <FrameContextConsumer>
+        {context => (
+          <ScrollSyncPane attachTo={context.document.scrollingElement}>
+            {isElement(previewComponent)
+              ? React.cloneElement(previewComponent, previewProps)
+              : React.createElement(previewComponent, previewProps)}
+          </ScrollSyncPane>
+        )}
+      </FrameContextConsumer>
     );
   }
 }
-
-PreviewContent.contextTypes = {
-  document: PropTypes.any,
-};
 
 PreviewContent.propTypes = {
   previewComponent: PropTypes.func.isRequired,

--- a/yarn.lock
+++ b/yarn.lock
@@ -9548,10 +9548,10 @@ react-emotion@^9.2.5:
     babel-plugin-emotion "^9.2.6"
     create-emotion-styled "^9.2.6"
 
-react-frame-component@^2.0.0:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/react-frame-component/-/react-frame-component-2.0.2.tgz#e602a980e1d78f91f471531225b61cfdbf68e614"
-  integrity sha1-5gKpgOHXj5H0cVMSJbYc/b9o5hQ=
+react-frame-component@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/react-frame-component/-/react-frame-component-4.0.2.tgz#408f137ab4ba14cd13a5844b86ac972903dda021"
+  integrity sha512-846zt81ijEC0ul6sBWzxkI5EGIE39ft9EaNzQUcszV/WWWDnldFJ+tKU7Et2GhZ4OHT/cy1GHcjsLLsdiOXhBg==
 
 react-hot-loader@^4.0.0:
   version "4.3.4"


### PR DESCRIPTION
**Summary**

Upgrade `react-frame-component` to 4.x. No changelog available but I've skimmed through the  commits and the main change seems to be a migration to the new context API.

We are soon up-to-date with most of our dependencies 😄 

**Test plan**

Manual testing
