### PR TITLE
[WIP] New (Multi-)Relation Widget

### DIFF
--- a/dev-test/config.yml
+++ b/dev-test/config.yml
@@ -26,6 +26,15 @@ collections: # A list of collections the CMS should be able to edit
           timeFormat: 'HH:mm',
           format: 'YYYY-MM-DD HH:mm',
         }
+      - {
+          label: 'Relation v2',
+          name: 'relations',
+          widget: 'relation-v2',
+          collection: 'posts',
+          searchFields: ['title', 'body'],
+          required: false,
+          multiple: true,
+        }
       - label: 'Cover Image'
         name: 'image'
         widget: 'image'

--- a/packages/netlify-cms-core/src/components/Editor/EditorControlPane/EditorControl.js
+++ b/packages/netlify-cms-core/src/components/Editor/EditorControlPane/EditorControl.js
@@ -9,7 +9,7 @@ import { colors, colorsRaw, transitions, lengths, borders } from 'netlify-cms-ui
 import { resolveWidget, getEditorComponents } from 'Lib/registry';
 import { addAsset } from 'Actions/media';
 import { query, clearSearch } from 'Actions/search';
-import { loadEntry } from 'Actions/entries'
+import { loadEntry } from 'Actions/entries';
 import {
   openMediaLibrary,
   removeInsertedMedia,
@@ -268,8 +268,8 @@ const mapDispatchToProps = {
   addAsset,
   query,
   loadEntry: (collectionName, slug) => (dispatch, getState) => {
-    const collection = getState().collections.get(collectionName)
-    return loadEntry(collection, slug)(dispatch, getState)
+    const collection = getState().collections.get(collectionName);
+    return loadEntry(collection, slug)(dispatch, getState);
   },
   clearSearch,
 };

--- a/packages/netlify-cms-core/src/components/Editor/EditorControlPane/EditorControl.js
+++ b/packages/netlify-cms-core/src/components/Editor/EditorControlPane/EditorControl.js
@@ -9,6 +9,7 @@ import { colors, colorsRaw, transitions, lengths, borders } from 'netlify-cms-ui
 import { resolveWidget, getEditorComponents } from 'Lib/registry';
 import { addAsset } from 'Actions/media';
 import { query, clearSearch } from 'Actions/search';
+import { loadEntry } from 'Actions/entries'
 import {
   openMediaLibrary,
   removeInsertedMedia,
@@ -143,6 +144,7 @@ class EditorControl extends React.Component {
     queryHits: PropTypes.oneOfType([PropTypes.array, PropTypes.object]),
     isFetching: PropTypes.bool,
     clearSearch: PropTypes.func.isRequired,
+    loadEntry: PropTypes.func.isRequired,
     t: PropTypes.func.isRequired,
   };
 
@@ -172,6 +174,7 @@ class EditorControl extends React.Component {
       queryHits,
       isFetching,
       clearSearch,
+      loadEntry,
       t,
     } = this.props;
     const widgetName = field.get('widget');
@@ -234,6 +237,7 @@ class EditorControl extends React.Component {
           ref={processControlRef && partial(processControlRef, fieldName)}
           editorControl={ConnectedEditorControl}
           query={query}
+          loadEntry={loadEntry}
           queryHits={queryHits}
           clearSearch={clearSearch}
           isFetching={isFetching}
@@ -263,6 +267,10 @@ const mapDispatchToProps = {
   removeInsertedMedia,
   addAsset,
   query,
+  loadEntry: (collectionName, slug) => (dispatch, getState) => {
+    const collection = getState().collections.get(collectionName)
+    return loadEntry(collection, slug)(dispatch, getState)
+  },
   clearSearch,
 };
 

--- a/packages/netlify-cms-core/src/components/Editor/EditorControlPane/Widget.js
+++ b/packages/netlify-cms-core/src/components/Editor/EditorControlPane/Widget.js
@@ -49,6 +49,7 @@ export default class Widget extends Component {
     queryHits: PropTypes.oneOfType([PropTypes.array, PropTypes.object]),
     editorControl: PropTypes.func.isRequired,
     uniqueFieldId: PropTypes.string.isRequired,
+    loadEntry: PropTypes.func.isRequired,
     t: PropTypes.func.isRequired,
   };
 
@@ -223,6 +224,7 @@ export default class Widget extends Component {
       queryHits,
       clearSearch,
       isFetching,
+      loadEntry,
       t,
     } = this.props;
     return React.createElement(controlComponent, {
@@ -255,6 +257,7 @@ export default class Widget extends Component {
       queryHits,
       clearSearch,
       isFetching,
+      loadEntry,
       t,
     });
   }

--- a/packages/netlify-cms-widget-slug-relation/README.md
+++ b/packages/netlify-cms-widget-slug-relation/README.md
@@ -1,0 +1,11 @@
+# Docs coming soon!
+
+Netlify CMS was recently converted from a single npm package to a "monorepo" of over 20 packages.
+That's over 20 Readme's! We haven't created one for this package yet, but we will soon.
+
+In the meantime, you can:
+
+1. Check out the [main readme](https://github.com/netlify/netlify-cms/#readme) or the [documentation
+   site](https://www.netlifycms.org) for more info.
+2. Reach out to the [community chat](https://gitter.im/netlify/netlifycms/) if you need help.
+3. Help out and [write the readme yourself](https://github.com/netlify/netlify-cms/edit/master/packages/netlify-cms-widget-relation/README.md)!

--- a/packages/netlify-cms-widget-slug-relation/package.json
+++ b/packages/netlify-cms-widget-slug-relation/package.json
@@ -29,13 +29,11 @@
     "webpack-cli": "^3.1.0"
   },
   "peerDependencies": {
-    "emotion": "^9.2.6",
     "immutable": "^3.7.6",
     "lodash": "^4.17.10",
     "netlify-cms-ui-default": "^2.0.0",
     "prop-types": "^15.5.10",
     "react": "^16.4.1",
-    "react-emotion": "^9.2.5",
-    "uuid": "^3.1.0"
+    "react-immutable-proptypes": "^2.1.0"
   }
 }

--- a/packages/netlify-cms-widget-slug-relation/package.json
+++ b/packages/netlify-cms-widget-slug-relation/package.json
@@ -1,0 +1,41 @@
+{
+  "name": "netlify-cms-widget-slug-relation",
+  "description": "Widget for linking related entries in Netlify CMS.",
+  "version": "2.0.5",
+  "homepage": "https://www.netlifycms.org/docs/widgets/#slug-relation",
+  "repository": "https://github.com/netlify/netlify-cms/tree/master/packages/netlify-cms-widget-slug-relation",
+  "bugs": "https://github.com/netlify/netlify-cms/issues",
+  "main": "dist/netlify-cms-widget-slug-relation.js",
+  "license": "MIT",
+  "keywords": [
+    "netlify",
+    "netlify-cms",
+    "widget",
+    "slug-relation",
+    "link"
+  ],
+  "sideEffects": false,
+  "scripts": {
+    "watch": "webpack -w",
+    "develop": "npm run watch",
+    "build": "cross-env NODE_ENV=production webpack"
+  },
+  "dependencies": {
+    "react-select": "^2.1.1"
+  },
+  "devDependencies": {
+    "cross-env": "^5.2.0",
+    "webpack": "^4.16.1",
+    "webpack-cli": "^3.1.0"
+  },
+  "peerDependencies": {
+    "emotion": "^9.2.6",
+    "immutable": "^3.7.6",
+    "lodash": "^4.17.10",
+    "netlify-cms-ui-default": "^2.0.0",
+    "prop-types": "^15.5.10",
+    "react": "^16.4.1",
+    "react-emotion": "^9.2.5",
+    "uuid": "^3.1.0"
+  }
+}

--- a/packages/netlify-cms-widget-slug-relation/src/EntryLoader.js
+++ b/packages/netlify-cms-widget-slug-relation/src/EntryLoader.js
@@ -2,14 +2,12 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 
-const selectEntry = (state, collection, slug) => (
-  state.getIn(['entities', `${collection}.${slug}`])
-)
+const selectEntry = (state, collection, slug) => state.getIn(['entities', `${collection}.${slug}`]);
 
 const toJS = object => {
-  if(typeof object.toJS === 'function') return object.toJS()
-  return object
-}
+  if (typeof object.toJS === 'function') return object.toJS();
+  return object;
+};
 
 class EntryLoaderComponent extends React.Component {
   static propTypes = {
@@ -26,46 +24,46 @@ class EntryLoaderComponent extends React.Component {
     bypass: PropTypes.bool,
     children: PropTypes.func,
     render: PropTypes.func,
+  };
+  static defaultProps = { entry: {}, bypass: false };
+  componentDidMount() {
+    this.fetch();
   }
-  static defaultProps = {entry: {}, bypass: false}
-  componentDidMount(){
-    this.fetch()
+  componentDidUpdate() {
+    this.fetch();
   }
-  componentDidUpdate(){
-    this.fetch()
-  }
-  shouldComponentUpdate(nextProps){
-    if(this.props.collection !== nextProps.collection) return true
-    if(this.props.slug !== nextProps.slug) return true
-    if(this.props.entry !== nextProps.entry) return true
-    return false
+  shouldComponentUpdate(nextProps) {
+    if (this.props.collection !== nextProps.collection) return true;
+    if (this.props.slug !== nextProps.slug) return true;
+    if (this.props.entry !== nextProps.entry) return true;
+    return false;
   }
   fetch = () => {
-    if(this.props.bypass) return
-    const {entry: _e, loadEntry, collection, slug} = this.props
-    const entry = toJS(_e)
-    const isCached = entry.data && !entry.isFetching
-    const isUpdate = entry.slug !== slug || entry.collection !== collection
-    if(!isUpdate && isCached) return
-    loadEntry(collection, slug)
-  }
-  render(){
-    const {children, render = children} = this.props
-    const {isFetching, data, error} = toJS(this.props.entry)
-    return render({...data, isFetching, error})
+    if (this.props.bypass) return;
+    const { entry: _e, loadEntry, collection, slug } = this.props;
+    const entry = toJS(_e);
+    const isCached = entry.data && !entry.isFetching;
+    const isUpdate = entry.slug !== slug || entry.collection !== collection;
+    if (!isUpdate && isCached) return;
+    loadEntry(collection, slug);
+  };
+  render() {
+    const { children, render = children } = this.props;
+    const { isFetching, data, error } = toJS(this.props.entry);
+    return render({ ...data, isFetching, error });
   }
 }
 
-const mapStateToProps = ({entries}, {collection, slug, entry}) => ({
-  entry: entry ? {data: entry} : selectEntry(entries, collection, slug),
+const mapStateToProps = ({ entries }, { collection, slug, entry }) => ({
+  entry: entry ? { data: entry } : selectEntry(entries, collection, slug),
   bypass: !!entry,
-})
+});
 
-const EntryLoader = connect(mapStateToProps)(EntryLoaderComponent)
+const EntryLoader = connect(mapStateToProps)(EntryLoaderComponent);
 
 EntryLoader.propTypes = {
   collection: PropTypes.string,
   slug: PropTypes.string,
-}
+};
 
-export default EntryLoader
+export default EntryLoader;

--- a/packages/netlify-cms-widget-slug-relation/src/EntryLoader.js
+++ b/packages/netlify-cms-widget-slug-relation/src/EntryLoader.js
@@ -1,0 +1,71 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+
+const selectEntry = (state, collection, slug) => (
+  state.getIn(['entities', `${collection}.${slug}`])
+)
+
+const toJS = object => {
+  if(typeof object.toJS === 'function') return object.toJS()
+  return object
+}
+
+class EntryLoaderComponent extends React.Component {
+  static propTypes = {
+    loadEntry: PropTypes.func,
+    collection: PropTypes.string,
+    slug: PropTypes.string,
+    entry: PropTypes.shape({
+      isFetching: PropTypes.bool,
+      error: PropTypes.string,
+      data: PropTypes.object,
+      collection: PropTypes.string,
+      slug: PropTypes.string,
+    }).isRequired,
+    bypass: PropTypes.bool,
+    children: PropTypes.func,
+    render: PropTypes.func,
+  }
+  static defaultProps = {entry: {}, bypass: false}
+  componentDidMount(){
+    this.fetch()
+  }
+  componentDidUpdate(){
+    this.fetch()
+  }
+  shouldComponentUpdate(nextProps){
+    if(this.props.collection !== nextProps.collection) return true
+    if(this.props.slug !== nextProps.slug) return true
+    if(this.props.entry !== nextProps.entry) return true
+    return false
+  }
+  fetch = () => {
+    if(this.props.bypass) return
+    const {entry: _e, loadEntry, collection, slug} = this.props
+    const entry = toJS(_e)
+    const isCached = entry.data && !entry.isFetching
+    const isUpdate = entry.slug !== slug || entry.collection !== collection
+    if(!isUpdate && isCached) return
+    loadEntry(collection, slug)
+  }
+  render(){
+    const {children, render = children} = this.props
+    const {isFetching, data, error} = toJS(this.props.entry)
+    return render({...data, isFetching, error})
+  }
+}
+
+const mapStateToProps = ({entries}, {collection, slug, entry}) => ({
+  entry: entry ? {data: entry} : selectEntry(entries, collection, slug),
+  bypass: !!entry,
+})
+
+const EntryLoader = connect(mapStateToProps)(EntryLoaderComponent)
+
+EntryLoader.propTypes = {
+  collection: PropTypes.string,
+  slug: PropTypes.string,
+}
+
+export default EntryLoader

--- a/packages/netlify-cms-widget-slug-relation/src/SlugRelationControl.js
+++ b/packages/netlify-cms-widget-slug-relation/src/SlugRelationControl.js
@@ -7,55 +7,53 @@ import Select from 'react-select/lib/Async';
 import BaseOption from 'react-select/lib/components/Option';
 import BaseSingleValue from 'react-select/lib/components/SingleValue';
 import { colors } from 'netlify-cms-ui-default';
-import EntryLoader from './EntryLoader'
+import EntryLoader from './EntryLoader';
 
-const getOptionValue = option => option && (option.value || option.slug || option)
+const getOptionValue = option => option && (option.value || option.slug || option);
 
 // TODO: add support for setting custom identifier field #1543
 // TODO: export a factory to create custom Option UI
-const Option = ({data = {}, ...props}) => (
-  <BaseOption {...props}>{data.title}</BaseOption>
-)
-Option.propTypes = {data: PropTypes.object}
+const Option = ({ data = {}, ...props }) => <BaseOption {...props}>{data.title}</BaseOption>;
+Option.propTypes = { data: PropTypes.object };
 
 const toJS = object => {
-  if(object && typeof object.toJS === 'function') return object.toJS()
-  return object
-}
+  if (object && typeof object.toJS === 'function') return object.toJS();
+  return object;
+};
 
 // TODO: add support for setting custom identifier field #1543
 // TODO: export a factory to create custom Value UI
 const ValueRenderer = props => (
   <EntryLoader {...props}>
-    {({isLoading, isFetching, title, error}) => {
-      if(isLoading || isFetching) return '...'
-      if(error) return error
-      return title || 'Unknown Entity'
+    {({ isLoading, isFetching, title, error }) => {
+      if (isLoading || isFetching) return '...';
+      if (error) return error;
+      return title || 'Unknown Entity';
     }}
   </EntryLoader>
-)
+);
 
-ValueRenderer.propTypes = {...EntryLoader.propTypes}
+ValueRenderer.propTypes = { ...EntryLoader.propTypes };
 
-const MultiValueLabel = ({children: entry, innerProps}) => (
+const MultiValueLabel = ({ children: entry, innerProps }) => (
   <div {...innerProps}>
-    <ValueRenderer {...entry}/>
+    <ValueRenderer {...entry} />
   </div>
-)
+);
 
 MultiValueLabel.propTypes = {
   children: PropTypes.object,
   innerProps: PropTypes.object,
-}
+};
 
-const SingleValue = ({children: entry, ...props}) => (
+const SingleValue = ({ children: entry, ...props }) => (
   <BaseSingleValue {...props}>
-    <ValueRenderer {...entry}/>
+    <ValueRenderer {...entry} />
   </BaseSingleValue>
-)
+);
 
-SingleValue.propTypes = {children: PropTypes.object}
-const components = {SingleValue, MultiValueLabel, Option}
+SingleValue.propTypes = { children: PropTypes.object };
+const components = { SingleValue, MultiValueLabel, Option };
 
 const styles = {
   control: styles => ({
@@ -98,23 +96,20 @@ const styles = {
       backgroundColor: colors.errorBackground,
     },
   }),
-}
+};
 
-const entryMapper = ({data, slug}) => ({...data, value: slug, type: 'option'})
-const getSlug = value => value && (value.value || value)
+const entryMapper = ({ data, slug }) => ({ ...data, value: slug, type: 'option' });
+const getSlug = value => value && (value.value || value);
 
 export default class RelationControl extends React.Component {
   static defaultProps = {
     queryHits: Map(),
-  }
+  };
   static propTypes = {
     onChange: PropTypes.func.isRequired,
     forID: PropTypes.string.isRequired,
     queryHits: ImmutablePropTypes.map.isRequired,
-    value: PropTypes.oneOfType([
-      ImmutablePropTypes.list.isRequired,
-      PropTypes.string,
-    ]),
+    value: PropTypes.oneOfType([ImmutablePropTypes.list.isRequired, PropTypes.string]),
     field: ImmutablePropTypes.map.isRequired,
     classNameWrapper: PropTypes.string.isRequired,
     query: PropTypes.func.isRequired,
@@ -122,32 +117,31 @@ export default class RelationControl extends React.Component {
     clearSearch: PropTypes.func.isRequired,
     setActiveStyle: PropTypes.func.isRequired,
     setInactiveStyle: PropTypes.func.isRequired,
-  }
+  };
 
-  componentDidUpdate(prevProps){
-    if(!this.callback) return
-    if(
+  componentDidUpdate(prevProps) {
+    if (!this.callback) return;
+    if (
       this.props.queryHits !== prevProps.queryHits &&
       this.props.queryHits.get(this.props.forID)
-    ){
-      const queryHits = this.props.queryHits.get(this.props.forID, [])
-      return this.callback(queryHits.map(entryMapper))
+    ) {
+      const queryHits = this.props.queryHits.get(this.props.forID, []);
+      return this.callback(queryHits.map(entryMapper));
     }
   }
 
-  handleChange = (value) => this.props.onChange(
-    Array.isArray(value) ? List(value.map(getSlug)) : getSlug(value)
-  )
+  handleChange = value =>
+    this.props.onChange(Array.isArray(value) ? List(value.map(getSlug)) : getSlug(value));
 
   loadOptions = debounce((term, callback) => {
     const { field, forID } = this.props;
     const collection = field.get('collection');
     const searchFields = field.get('searchFields').toJS();
     this.callback = value => {
-      callback(value)
-      this.callback = null
-    }
-    this.props.query(forID, collection, searchFields, term)
+      callback(value);
+      this.callback = null;
+    };
+    this.props.query(forID, collection, searchFields, term);
   }, 250);
 
   handleMenuClose = () => {
@@ -155,25 +149,26 @@ export default class RelationControl extends React.Component {
     this.callback = null;
   };
 
-  formatOptionLabel = (value, {context}) => {
-    if(context === 'menu') return value
-    if(typeof value === 'string') return {
-      slug: value,
-      collection: this.props.field.get('collection'),
-      loadEntry: this.props.loadEntry,
-    }
-    return {entry: value}
-  }
+  formatOptionLabel = (value, { context }) => {
+    if (context === 'menu') return value;
+    if (typeof value === 'string')
+      return {
+        slug: value,
+        collection: this.props.field.get('collection'),
+        loadEntry: this.props.loadEntry,
+      };
+    return { entry: value };
+  };
 
-  shouldComponentUpdate(){
-    return true
+  shouldComponentUpdate() {
+    return true;
   }
 
   render() {
     const { field, value, forID, classNameWrapper, setActiveStyle, setInactiveStyle } = this.props;
     const isMultiple = field.get('multiple', false);
     const isClearable = !field.get('required', true) || isMultiple;
-    const defaultValue = castArray(toJS(value))
+    const defaultValue = castArray(toJS(value));
 
     return (
       <Select
@@ -197,4 +192,3 @@ export default class RelationControl extends React.Component {
     );
   }
 }
-

--- a/packages/netlify-cms-widget-slug-relation/src/SlugRelationControl.js
+++ b/packages/netlify-cms-widget-slug-relation/src/SlugRelationControl.js
@@ -1,0 +1,193 @@
+import React, { createRef } from 'react';
+import PropTypes from 'prop-types';
+import ImmutablePropTypes from 'react-immutable-proptypes';
+import uuid from 'uuid/v4';
+import { List, Map } from 'immutable';
+import { debounce } from 'lodash';
+import styled from 'react-emotion';
+import AsyncSelect from 'react-select/lib/Async';
+import BaseOption from 'react-select/lib/components/Option';
+import BaseSingleValue from 'react-select/lib/components/SingleValue';
+import EntryLoader from './EntryLoader'
+
+const getOptionValue = option => option.value || option.slug || option
+
+// TODO: add support for setting custom identifier field #1543
+// TODO: export a factory to create custom Option UI
+const Option = ({data = {}, ...props}) => (
+  <BaseOption {...props}>{data.title}</BaseOption>
+)
+Option.propTypes = {data: PropTypes.object}
+
+const toJS = object => {
+  if(object && typeof object.toJS === 'function') return object.toJS()
+  return object
+}
+
+// TODO: add support for setting custom identifier field #1543
+// TODO: export a factory to create custom Value UI
+const ValueRenderer = props => (
+  <EntryLoader {...props}>
+    {({isLoading, title, error}) => {
+      if(isLoading) return '...'
+      if(error) return error
+      return title || 'Unknown Entity'
+    }}
+  </EntryLoader>
+)
+
+ValueRenderer.propTypes = {...EntryLoader.propTypes}
+
+const MultiValueLabel = ({children: entry, innerProps}) => (
+  <div {...innerProps}>
+    <ValueRenderer {...entry}/>
+  </div>
+)
+
+MultiValueLabel.propTypes = {
+  children: PropTypes.object,
+  innerProps: PropTypes.object,
+}
+
+const SingleValue = ({children: entry, ...props}) => (
+  <BaseSingleValue {...props}>
+    <ValueRenderer {...entry}/>
+  </BaseSingleValue>
+)
+
+SingleValue.propTypes = {children: PropTypes.object}
+
+const Select = styled(AsyncSelect)`z-index: 2;`
+const Wrapper = styled.div`padding: 0 !important;`
+
+const styles = {
+  control: (provided) => ({
+    ...provided,
+    border: '0px solid transparent',
+    borderRadius: '3px',
+    borderTopLeftRadius: '0',
+    boxShadow: 'none',
+    minHeight: '54px',
+  }),
+  valueContainer: (provided) => ({
+    ...provided,
+    padding: '8px 14px',
+  }),
+}
+
+const IndicatorSeparator = () => null
+const DropdownIndicator = () => null
+const entryMapper = ({data, slug}) => ({...data, value: slug, type: 'option'})
+const getSlug = value => (value.value || value)
+
+export default class RelationControl extends React.Component {
+  static defaultProps = {
+    queryHits: Map(),
+  }
+  static propTypes = {
+    onChange: PropTypes.func.isRequired,
+    forID: PropTypes.string,
+    queryHits: ImmutablePropTypes.map.isRequired,
+    value: PropTypes.oneOfType([
+      ImmutablePropTypes.list.isRequired,
+      PropTypes.string,
+    ]),
+    field: ImmutablePropTypes.map.isRequired,
+    classNameWrapper: PropTypes.string.isRequired,
+    query: PropTypes.func.isRequired,
+    loadEntry: PropTypes.func.isRequired,
+    clearSearch: PropTypes.func.isRequired,
+    setActiveStyle: PropTypes.func.isRequired,
+    setInactiveStyle: PropTypes.func.isRequired,
+  }
+
+  controlID = uuid();
+  select = createRef();
+
+  componentDidUpdate(prevProps){
+    if(!this.callback) return
+    if(
+      this.props.queryHits !== prevProps.queryHits &&
+      this.props.queryHits.get(this.controlID)
+    ){
+      const queryHits = this.props.queryHits.get(this.controlID, [])
+      return this.callback(queryHits.map(entryMapper))
+    }
+  }
+
+  handleChange = (value) => this.props.onChange(
+    Array.isArray(value) ? List(value.map(getSlug)) : getSlug(value)
+  )
+
+  loadOptions = debounce((term, callback) => {
+    const { field } = this.props;
+    const collection = field.get('collection');
+    const searchFields = field.get('searchFields').toJS();
+    this.callback = value => {
+      callback(value)
+      this.callback = null
+    }
+    this.props.query(this.controlID, collection, searchFields, term)
+  }, 250);
+
+  handleMenuClose = () => {
+    this.props.clearSearch();
+    this.callback = null;
+  };
+
+  formatOptionLabel = (value, {context}) => {
+    if(context === 'menu') return value
+    if(typeof value === 'string') return {
+      slug: value,
+      collection: this.props.field.get('collection'),
+      loadEntry: this.props.loadEntry,
+    }
+    return {entry: value}
+  }
+
+  shouldComponentUpdate(prevProps){
+    const current = this.props.queryHits.get(this.controlID);
+    const previous = prevProps.queryHits.get(this.controlID);
+    if(current !== previous) return true
+    if(prevProps.forID !== this.props.forID) return true
+    if(prevProps.classNameWrapper !== this.props.classNameWrapper) return true
+    return false
+  }
+
+  render() {
+    const {forID, classNameWrapper, value} = this.props;
+    const {setActiveStyle, setInactiveStyle} = this.props;
+    const multiple = !!this.props.field.get('multiple');
+    const defaultValue = toJS(value) || multiple ? [] : '';
+
+    return (
+      <Wrapper className={classNameWrapper}>
+        <Select
+          isMulti={multiple}
+          innerRef={this.select}
+          defaultValue={defaultValue}
+          onChange={this.handleChange}
+          openMenuOnFocus={false}
+          openMenuOnClick={false}
+          isClearable={false}
+          components={{
+            IndicatorSeparator,
+            DropdownIndicator,
+            Option,
+            MultiValueLabel,
+            SingleValue,
+          }}
+          styles={styles}
+          cacheOptions={forID}
+          onFocus={setActiveStyle}
+          onBlur={setInactiveStyle}
+          formatOptionLabel={this.formatOptionLabel}
+          getOptionValue={getOptionValue}
+          onMenuClose={this.handleMenuClose}
+          loadOptions={this.loadOptions}
+        />
+      </Wrapper>
+    );
+  }
+}
+

--- a/packages/netlify-cms-widget-slug-relation/src/SlugRelationControl.js
+++ b/packages/netlify-cms-widget-slug-relation/src/SlugRelationControl.js
@@ -1,16 +1,15 @@
-import React, { createRef } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import ImmutablePropTypes from 'react-immutable-proptypes';
-import uuid from 'uuid/v4';
 import { List, Map } from 'immutable';
-import { debounce } from 'lodash';
-import styled from 'react-emotion';
-import AsyncSelect from 'react-select/lib/Async';
+import { debounce, castArray } from 'lodash';
+import Select from 'react-select/lib/Async';
 import BaseOption from 'react-select/lib/components/Option';
 import BaseSingleValue from 'react-select/lib/components/SingleValue';
+import { colors } from 'netlify-cms-ui-default';
 import EntryLoader from './EntryLoader'
 
-const getOptionValue = option => option.value || option.slug || option
+const getOptionValue = option => option && (option.value || option.slug || option)
 
 // TODO: add support for setting custom identifier field #1543
 // TODO: export a factory to create custom Option UI
@@ -28,8 +27,8 @@ const toJS = object => {
 // TODO: export a factory to create custom Value UI
 const ValueRenderer = props => (
   <EntryLoader {...props}>
-    {({isLoading, title, error}) => {
-      if(isLoading) return '...'
+    {({isLoading, isFetching, title, error}) => {
+      if(isLoading || isFetching) return '...'
       if(error) return error
       return title || 'Unknown Entity'
     }}
@@ -56,29 +55,53 @@ const SingleValue = ({children: entry, ...props}) => (
 )
 
 SingleValue.propTypes = {children: PropTypes.object}
-
-const Select = styled(AsyncSelect)`z-index: 2;`
-const Wrapper = styled.div`padding: 0 !important;`
+const components = {SingleValue, MultiValueLabel, Option}
 
 const styles = {
-  control: (provided) => ({
-    ...provided,
-    border: '0px solid transparent',
-    borderRadius: '3px',
-    borderTopLeftRadius: '0',
+  control: styles => ({
+    ...styles,
+    border: 0,
     boxShadow: 'none',
-    minHeight: '54px',
+    padding: '9px 0 9px 12px',
   }),
-  valueContainer: (provided) => ({
-    ...provided,
-    padding: '8px 14px',
+  option: (styles, state) => ({
+    ...styles,
+    backgroundColor: state.isSelected
+      ? `${colors.active}`
+      : state.isFocused
+        ? `${colors.activeBackground}`
+        : 'transparent',
+    paddingLeft: '22px',
+  }),
+  menu: styles => ({ ...styles, right: 0, zIndex: 2 }),
+  container: styles => ({ ...styles, padding: '0 !important' }),
+  indicatorSeparator: (styles, state) =>
+    state.hasValue && state.selectProps.isClearable
+      ? { ...styles, backgroundColor: `${colors.textFieldBorder}` }
+      : { display: 'none' },
+  dropdownIndicator: styles => ({ ...styles, color: `${colors.controlLabel}` }),
+  clearIndicator: styles => ({ ...styles, color: `${colors.controlLabel}` }),
+  multiValue: styles => ({
+    ...styles,
+    backgroundColor: colors.background,
+  }),
+  multiValueLabel: styles => ({
+    ...styles,
+    color: colors.textLead,
+    fontWeight: 500,
+  }),
+  multiValueRemove: styles => ({
+    ...styles,
+    color: colors.controlLabel,
+    ':hover': {
+      color: colors.errorText,
+      backgroundColor: colors.errorBackground,
+    },
   }),
 }
 
-const IndicatorSeparator = () => null
-const DropdownIndicator = () => null
 const entryMapper = ({data, slug}) => ({...data, value: slug, type: 'option'})
-const getSlug = value => (value.value || value)
+const getSlug = value => value && (value.value || value)
 
 export default class RelationControl extends React.Component {
   static defaultProps = {
@@ -86,7 +109,7 @@ export default class RelationControl extends React.Component {
   }
   static propTypes = {
     onChange: PropTypes.func.isRequired,
-    forID: PropTypes.string,
+    forID: PropTypes.string.isRequired,
     queryHits: ImmutablePropTypes.map.isRequired,
     value: PropTypes.oneOfType([
       ImmutablePropTypes.list.isRequired,
@@ -101,16 +124,13 @@ export default class RelationControl extends React.Component {
     setInactiveStyle: PropTypes.func.isRequired,
   }
 
-  controlID = uuid();
-  select = createRef();
-
   componentDidUpdate(prevProps){
     if(!this.callback) return
     if(
       this.props.queryHits !== prevProps.queryHits &&
-      this.props.queryHits.get(this.controlID)
+      this.props.queryHits.get(this.props.forID)
     ){
-      const queryHits = this.props.queryHits.get(this.controlID, [])
+      const queryHits = this.props.queryHits.get(this.props.forID, [])
       return this.callback(queryHits.map(entryMapper))
     }
   }
@@ -120,14 +140,14 @@ export default class RelationControl extends React.Component {
   )
 
   loadOptions = debounce((term, callback) => {
-    const { field } = this.props;
+    const { field, forID } = this.props;
     const collection = field.get('collection');
     const searchFields = field.get('searchFields').toJS();
     this.callback = value => {
       callback(value)
       this.callback = null
     }
-    this.props.query(this.controlID, collection, searchFields, term)
+    this.props.query(forID, collection, searchFields, term)
   }, 250);
 
   handleMenuClose = () => {
@@ -145,48 +165,35 @@ export default class RelationControl extends React.Component {
     return {entry: value}
   }
 
-  shouldComponentUpdate(prevProps){
-    const current = this.props.queryHits.get(this.controlID);
-    const previous = prevProps.queryHits.get(this.controlID);
-    if(current !== previous) return true
-    if(prevProps.forID !== this.props.forID) return true
-    if(prevProps.classNameWrapper !== this.props.classNameWrapper) return true
-    return false
+  shouldComponentUpdate(){
+    return true
   }
 
   render() {
-    const {forID, classNameWrapper, value} = this.props;
-    const {setActiveStyle, setInactiveStyle} = this.props;
-    const multiple = !!this.props.field.get('multiple');
-    const defaultValue = toJS(value) || multiple ? [] : '';
+    const { field, value, forID, classNameWrapper, setActiveStyle, setInactiveStyle } = this.props;
+    const isMultiple = field.get('multiple', false);
+    const isClearable = !field.get('required', true) || isMultiple;
+    const defaultValue = castArray(toJS(value))
 
     return (
-      <Wrapper className={classNameWrapper}>
-        <Select
-          isMulti={multiple}
-          innerRef={this.select}
-          defaultValue={defaultValue}
-          onChange={this.handleChange}
-          openMenuOnFocus={false}
-          openMenuOnClick={false}
-          isClearable={false}
-          components={{
-            IndicatorSeparator,
-            DropdownIndicator,
-            Option,
-            MultiValueLabel,
-            SingleValue,
-          }}
-          styles={styles}
-          cacheOptions={forID}
-          onFocus={setActiveStyle}
-          onBlur={setInactiveStyle}
-          formatOptionLabel={this.formatOptionLabel}
-          getOptionValue={getOptionValue}
-          onMenuClose={this.handleMenuClose}
-          loadOptions={this.loadOptions}
-        />
-      </Wrapper>
+      <Select
+        inputId={forID}
+        className={classNameWrapper}
+        isMulti={isMultiple}
+        defaultValue={defaultValue}
+        onChange={this.handleChange}
+        openMenuOnClick={false}
+        isClearable={isClearable}
+        components={components}
+        styles={styles}
+        cacheOptions={forID}
+        onFocus={setActiveStyle}
+        onBlur={setInactiveStyle}
+        formatOptionLabel={this.formatOptionLabel}
+        getOptionValue={getOptionValue}
+        onMenuClose={this.handleMenuClose}
+        loadOptions={this.loadOptions}
+      />
     );
   }
 }

--- a/packages/netlify-cms-widget-slug-relation/src/SlugRelationPreview.js
+++ b/packages/netlify-cms-widget-slug-relation/src/SlugRelationPreview.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { WidgetPreviewContainer } from 'netlify-cms-ui-default';
 
-const stringify = (value = null) => Array.isArray(value) ? value.join(', ') : value
+const stringify = (value = null) => (Array.isArray(value) ? value.join(', ') : value);
 const SlugRelationPreview = ({ value } = {}) => (
   <WidgetPreviewContainer>{stringify(value)}</WidgetPreviewContainer>
 );

--- a/packages/netlify-cms-widget-slug-relation/src/SlugRelationPreview.js
+++ b/packages/netlify-cms-widget-slug-relation/src/SlugRelationPreview.js
@@ -2,8 +2,8 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { WidgetPreviewContainer } from 'netlify-cms-ui-default';
 
-const stringify = value => Array.isArray(value) ? value.join(', ') : value
-const SlugRelationPreview = ({ value }) => (
+const stringify = (value = null) => Array.isArray(value) ? value.join(', ') : value
+const SlugRelationPreview = ({ value } = {}) => (
   <WidgetPreviewContainer>{stringify(value)}</WidgetPreviewContainer>
 );
 

--- a/packages/netlify-cms-widget-slug-relation/src/SlugRelationPreview.js
+++ b/packages/netlify-cms-widget-slug-relation/src/SlugRelationPreview.js
@@ -1,0 +1,14 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { WidgetPreviewContainer } from 'netlify-cms-ui-default';
+
+const stringify = value => Array.isArray(value) ? value.join(', ') : value
+const SlugRelationPreview = ({ value }) => (
+  <WidgetPreviewContainer>{stringify(value)}</WidgetPreviewContainer>
+);
+
+SlugRelationPreview.propTypes = {
+  value: PropTypes.array,
+};
+
+export default SlugRelationPreview;

--- a/packages/netlify-cms-widget-slug-relation/src/index.js
+++ b/packages/netlify-cms-widget-slug-relation/src/index.js
@@ -1,0 +1,2 @@
+export SlugRelationControl from './SlugRelationControl';
+export SlugRelationPreview from './SlugRelationPreview';

--- a/packages/netlify-cms-widget-slug-relation/webpack.config.js
+++ b/packages/netlify-cms-widget-slug-relation/webpack.config.js
@@ -1,0 +1,3 @@
+const { getConfig } = require('../../scripts/webpack.js');
+
+module.exports = getConfig();

--- a/packages/netlify-cms/package.json
+++ b/packages/netlify-cms/package.json
@@ -38,6 +38,7 @@
     "netlify-cms-widget-image": "^2.1.0",
     "netlify-cms-widget-list": "^2.0.7",
     "netlify-cms-widget-markdown": "^2.0.10",
+    "netlify-cms-widget-slug-relation": "^2.0.5",
     "netlify-cms-widget-number": "^2.0.5",
     "netlify-cms-widget-object": "^2.0.5",
     "netlify-cms-widget-relation": "^2.0.5",

--- a/packages/netlify-cms/src/widgets.js
+++ b/packages/netlify-cms/src/widgets.js
@@ -11,6 +11,7 @@ import { MarkdownControl, MarkdownPreview } from 'netlify-cms-widget-markdown/sr
 import { ListControl, ListPreview } from 'netlify-cms-widget-list/src';
 import { ObjectControl, ObjectPreview } from 'netlify-cms-widget-object/src';
 import { RelationControl, RelationPreview } from 'netlify-cms-widget-relation/src';
+import { SlugRelationControl, SlugRelationPreview } from 'netlify-cms-widget-slug-relation/src';
 import { BooleanControl } from 'netlify-cms-widget-boolean/src';
 
 const { registerWidget } = cms;
@@ -27,4 +28,5 @@ registerWidget('datetime', DateTimeControl, DateTimePreview);
 registerWidget('select', SelectControl, SelectPreview);
 registerWidget('object', ObjectControl, ObjectPreview);
 registerWidget('relation', RelationControl, RelationPreview);
+registerWidget('relation-v2', SlugRelationControl, SlugRelationPreview);
 registerWidget('boolean', BooleanControl);


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines.

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first two fields are mandatory:
-->

## Summary

<!--
Explain the **motivation** for making this change.
What existing problem does the pull request solve?
-->
Add a new `relation`-like widget capable of selecting multiple entries (also support single).

It's based on `react-select`, as the new `select` from #1901.

### **Motivation** (TLDR; we need a multi-relation widget)

I'm working on my [college campus newspaper website](https://github.com/fac-unb/campus-online), and using `NetlifyCMS` to manage it's contents. It's working great! I'm really glad this awesome project is being maintained (:

The journalism students from a dedicated online news course are the ones editing it, It currently uses an [**extended version**](https://github.com/leonardodino/netlify-cms/commit/e1cc5d5662f662fb9b8d479949b273aab0d54d0a) of the relation widget for selecting author and the category. It's a bit hacky, especially considering it saves an object (title + slug), although it can only select a single author. **The most requested feature was multi-author attribution in the posts**.

| ![current relation UI hack](https://user-images.githubusercontent.com/8649362/49325348-f05daa00-f527-11e8-97fa-ddf30ddc4d3e.gif) | [![current relation data hack](https://user-images.githubusercontent.com/8649362/49325351-04a1a700-f528-11e8-9f44-b0634b4f1519.png)](https://github.com/fac-unb/campus-online/blob/38d2e6494b74f842ebc11ebe863fb245a7026f29/packages/campus-online-frontend/src/pages/materias/2018-11-15-sus-oferece-atendimento-especializado-em-saude-trans-em-11-hospitais-federais.md) | 
|:-:|:-:| 
| UI hacks, `relation` widget | data model before this `PR` |

I'm saving the `title` so it's more readable in the CMS UI, although that complicates a lot linking the files in Gatsby, and adds potentially stale data.
The ideal for this case is an array of slugs, but requires that the CMS can resolve slugs back to data to have a nice UI, hence exporting `loadEntry` action, and persisting only `slugs` (incompatible with current `relation`).

### **How it looks**

All of the styling work is directly borrowed from the recent update in the `select` field by @alexandernanberg (:
It should, probably, be de-duplicated later by exporting it from `netlify-cms-ui-default` or something like that.

| ![single-relation](https://user-images.githubusercontent.com/8649362/49325336-cc01cd80-f527-11e8-8ece-4a3737986186.gif) | ![multi-relation](https://user-images.githubusercontent.com/8649362/49325340-d754f900-f527-11e8-9717-dac3a9d67b86.gif) |
|:-:|:-:| 
| single relation | multiple relation |

### **How it works**

It saves the related entry slug, or array of slugs, and pulls it back when displaying it. The autocomplete list still renders from the `queryHits`, as in the original `relation`.

Based on my limited knowledge of `SSG` (mostly [`Gatsby`](https://gatsbyjs.org) and [`harp`](https://github.com/sintaxi/harp)), and file based CMS ([`kirby`](https://getkirby.com/) and [`stacey`](https://github.com/kolber/stacey)), linking by the slug, granted it's stable as in NetlifyCMS, is the least painful method of linking entries together.

### **Caveats**

**It is incompatible with the current `relation`**, because there's no `valueField` option.
`displayFields` is possible but not implemented, as a `js` constructor or composing seems a better way to configure it, as demonstrated in the motivation image.

## Test plan

<!--
Demonstrate the code is solid.
Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.
-->

**`[WIP]`** probably will do something based of the `select` widget as well.

## this is WIP

### **I've opened it here for discussion.** 
It seems to be working right now, but it lacks tests, and it could be improved in some ways.
Also, it's not compatible with current `relation` widget, _and probably never will_.

- [x] multiple slug relation array (that was implemented first)
- [x] working single slug relation (was little work on top)
- [ ] ~**naming** (`SlugRelation` is a bad name, need suggestions)~ will extend current `relation`
- [ ] add support for custom identifier field (re: #1543)
- [ ] add backwards compatibility with current `relation` widget (re: @erquhart)
- [ ] docs update (thanks for reminding @verythorough)
- [ ] tests!
- [ ] better UX (when loading or not searching it shows "no options" text)
- [ ] remove [copy-pasted style code](https://github.com/netlify/netlify-cms/blob/01fade7f814ef4430a655eb912f668864adbc081/packages/netlify-cms-widget-slug-relation/src/SlugRelationControl.js#L58-L99) from `select`. (move to `netlify-cms-ui-default`, probably another PR)
- [ ] export a factory method to create custom UI (maybe another PR)
- [x] code style (the lint passes, ~but I'm sure it's not consistent~ **prettier** 🎉)

<br><br>

**A picture of a cute animal (not mandatory but encouraged)**

![](https://media1.tenor.com/images/6db1f26063aec49ee3403972512451c9/tenor.gif?itemid=7454481)