### PR TITLE
fix(netlify-cms-core): duplicate key warning

### DIFF
--- a/packages/netlify-cms-core/src/components/Workflow/WorkflowList.js
+++ b/packages/netlify-cms-core/src/components/Workflow/WorkflowList.js
@@ -170,7 +170,7 @@ class WorkflowList extends React.Component {
     }
     return (
       <div>
-        {entries.map(entry => {
+        {entries.map((entry, idx) => {
           const timestamp = moment(entry.getIn(['metaData', 'timeStamp'])).format('MMMM D');
           const editLink = `collections/${entry.getIn([
             'metaData',
@@ -184,7 +184,7 @@ class WorkflowList extends React.Component {
           return (
             <DragSource
               namespace={DNDNamespace}
-              key={slug}
+              key={idx}
               slug={slug}
               collection={collection}
               ownStatus={ownStatus}


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines.

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first two fields are mandatory:
-->

**Summary**
Fix the console warning on the workflow page

 `Warning: Encountered two children with the same key, .... Keys should be unique so that components maintain their identity across updates. Non-unique keys may cause children to be duplicated and/or omitted — the behavior is unsupported and could change in a future version.` 

that shows up when two entry from different collections both have the same slug.
<!--
Explain the **motivation** for making this change.
What existing problem does the pull request solve?
-->

<!--
Demonstrate the code is solid.
Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.
-->
