### PR TITLE
feat(netlify-cms-core)  add slug customization support

### DIFF
--- a/dev-test/config.yml
+++ b/dev-test/config.yml
@@ -15,11 +15,9 @@ collections: # A list of collections the CMS should be able to edit
       guidelines that are specific to a collection.
     folder: '_posts'
     slug: '{{year}}-{{month}}-{{day}}-{{slug}}'
-    slug_field: 'slug'
     create: true # Allow users to create new documents in this collection
     fields: # The fields each document in this collection have
       - { label: 'Title', name: 'title', widget: 'string', tagname: 'h1' }
-      - { label: 'Slug', name: 'slug', widget: 'string', tagname: 'h1' }
       - {
           label: 'Publish Date',
           name: 'date',
@@ -41,9 +39,11 @@ collections: # A list of collections the CMS should be able to edit
   - name: 'faq' # Used in routes, ie.: /admin/collections/:slug/edit
     label: 'FAQ' # Used in the UI
     folder: '_faqs'
+    slug_field: 'slug'
     create: true # Allow users to create new documents in this collection
     fields: # The fields each document in this collection have
       - { label: 'Question', name: 'title', widget: 'string', tagname: 'h1' }
+      - { label: 'Slug', name: 'slug', widget: 'string', tagname: 'h1' }
       - { label: 'Answer', name: 'body', widget: 'markdown' }
 
   - name: 'settings'

--- a/dev-test/config.yml
+++ b/dev-test/config.yml
@@ -15,9 +15,11 @@ collections: # A list of collections the CMS should be able to edit
       guidelines that are specific to a collection.
     folder: '_posts'
     slug: '{{year}}-{{month}}-{{day}}-{{slug}}'
+    slug_field: 'slug'
     create: true # Allow users to create new documents in this collection
     fields: # The fields each document in this collection have
       - { label: 'Title', name: 'title', widget: 'string', tagname: 'h1' }
+      - { label: 'Slug', name: 'slug', widget: 'string', tagname: 'h1' }
       - {
           label: 'Publish Date',
           name: 'date',

--- a/packages/netlify-cms-backend-gitlab/src/API.js
+++ b/packages/netlify-cms-backend-gitlab/src/API.js
@@ -264,7 +264,10 @@ export default class API {
   persistFiles = (files, { commitMessage, newEntry }) =>
     Promise.all(
       files.map(file =>
-        this.uploadAndCommit(file, { commitMessage, updateFile: newEntry === false }),
+        this.uploadAndCommit(file, {
+          commitMessage,
+          updateFile: newEntry === false && file.slugChanged === false,
+        }),
       ),
     );
 

--- a/packages/netlify-cms-backend-test/src/implementation.js
+++ b/packages/netlify-cms-backend-test/src/implementation.js
@@ -141,14 +141,15 @@ export default class TestRepo {
     const existingEntryIndex = unpubStore.findIndex(
       e => e.metaData.collection === collection && e.slug === slug,
     );
-    unpubStore.splice(existingEntryIndex, 1);
+    if (existingEntryIndex >= 0) {
+      unpubStore.splice(existingEntryIndex, 1);
+    }
     return Promise.resolve();
   }
 
-  persistEntry({ path, raw, slug }, mediaFiles, options = {}) {
+  persistEntry({ path, raw, slug, oldPath, oldSlug }, mediaFiles, options = {}) {
     if (options.useWorkflow) {
       const unpubStore = window.repoFilesUnpublished;
-      const oldPath = options.oldPath;
       const existingPath = oldPath || path;
       const existingEntryIndex = unpubStore.findIndex(e => e.file.path === existingPath);
       if (existingEntryIndex >= 0) {
@@ -170,6 +171,8 @@ export default class TestRepo {
             status: this.options.initialWorkflowStatus,
             title: options.parsedData && options.parsedData.title,
             description: options.parsedData && options.parsedData.description,
+            parentSlug: oldSlug || slug,
+            parentPath: oldPath || path,
           },
           slug,
         };
@@ -186,11 +189,6 @@ export default class TestRepo {
     if (newEntry) {
       window.repoFiles[folder][fileName] = { content: raw };
     } else {
-      if (options.oldPath) {
-        const oldFileName = options.oldPath.substring(path.lastIndexOf('/') + 1);
-        window.repoFiles[folder][fileName] = window.repoFiles[folder][oldFileName];
-        delete window.repoFiles[folder][oldFileName];
-      }
       window.repoFiles[folder][fileName].content = raw;
     }
     return Promise.resolve();

--- a/packages/netlify-cms-backend-test/src/implementation.js
+++ b/packages/netlify-cms-backend-test/src/implementation.js
@@ -148,11 +148,16 @@ export default class TestRepo {
   persistEntry({ path, raw, slug }, mediaFiles, options = {}) {
     if (options.useWorkflow) {
       const unpubStore = window.repoFilesUnpublished;
-      const existingEntryIndex = unpubStore.findIndex(e => e.file.path === path);
+      const oldPath = options.oldPath;
+      const existingPath = oldPath || path;
+      const existingEntryIndex = unpubStore.findIndex(e => e.file.path === existingPath);
       if (existingEntryIndex >= 0) {
         const unpubEntry = { ...unpubStore[existingEntryIndex], data: raw };
-        unpubEntry.title = options.parsedData && options.parsedData.title;
-        unpubEntry.description = options.parsedData && options.parsedData.description;
+        if (oldPath) {
+          Object.assign(unpubEntry, { file: { path }, slug });
+        }
+        unpubEntry.metaData.title = options.parsedData && options.parsedData.title;
+        unpubEntry.metaData.description = options.parsedData && options.parsedData.description;
         unpubStore.splice(existingEntryIndex, 1, unpubEntry);
       } else {
         const unpubEntry = {
@@ -181,6 +186,11 @@ export default class TestRepo {
     if (newEntry) {
       window.repoFiles[folder][fileName] = { content: raw };
     } else {
+      if (options.oldPath) {
+        const oldFileName = options.oldPath.substring(path.lastIndexOf('/') + 1);
+        window.repoFiles[folder][fileName] = window.repoFiles[folder][oldFileName];
+        delete window.repoFiles[folder][oldFileName];
+      }
       window.repoFiles[folder][fileName].content = raw;
     }
     return Promise.resolve();

--- a/packages/netlify-cms-core/src/__tests__/backend.spec.js
+++ b/packages/netlify-cms-core/src/__tests__/backend.spec.js
@@ -1,6 +1,5 @@
-import { resolveBackend, generateUniqueSlug } from '../backend';
+import { resolveBackend } from '../backend';
 import registry from 'Lib/registry';
-import { Map } from 'immutable';
 
 jest.mock('Lib/registry');
 
@@ -107,15 +106,6 @@ describe('Backend', () => {
       );
 
       expect(result.length).toBe(1);
-    });
-  });
-
-  describe('uniqueSlug', () => {
-    it('generates unique slug', () => {
-      expect(generateUniqueSlug('title', Map(), ['title'])).toEqual('title-1');
-      expect(generateUniqueSlug('title', Map({ sanitize_replacement: '_' }), ['title'])).toEqual(
-        'title_1',
-      );
     });
   });
 });

--- a/packages/netlify-cms-core/src/__tests__/backend.spec.js
+++ b/packages/netlify-cms-core/src/__tests__/backend.spec.js
@@ -1,5 +1,6 @@
-import { resolveBackend } from '../backend';
+import { resolveBackend, generateUniqueSlug } from '../backend';
 import registry from 'Lib/registry';
+import { Map } from 'immutable';
 
 jest.mock('Lib/registry');
 
@@ -106,6 +107,15 @@ describe('Backend', () => {
       );
 
       expect(result.length).toBe(1);
+    });
+  });
+
+  describe('uniqueSlug', () => {
+    it('generates unique slug', () => {
+      expect(generateUniqueSlug('title', Map(), ['title'])).toEqual('title-1');
+      expect(generateUniqueSlug('title', Map({ sanitize_replacement: '_' }), ['title'])).toEqual(
+        'title_1',
+      );
     });
   });
 });

--- a/packages/netlify-cms-core/src/actions/editorialWorkflow.js
+++ b/packages/netlify-cms-core/src/actions/editorialWorkflow.js
@@ -1,7 +1,6 @@
 import uuid from 'uuid/v4';
 import { actions as notifActions } from 'redux-notifications';
 import { BEGIN, COMMIT, REVERT } from 'redux-optimist';
-import { last } from 'lodash';
 import { serializeValues } from 'Lib/serializeEntryValues';
 import { currentBackend } from 'src/backend';
 import { getAsset } from 'Reducers';
@@ -291,8 +290,13 @@ export function persistUnpublishedEntry(collection, existingUnpublishedEntry) {
     const state = getState();
     const entryDraft = state.entryDraft;
     const fieldsErrors = entryDraft.get('fieldsErrors');
-    const unpublishedSlugs = selectUnpublishedSlugEntriesByCollection(state.editorialWorkflow, collection.get('name'));
-    const unavailableSlugs = selectSlugEntries(state.entries, collection.get('name')).concat(unpublishedSlugs);
+    const unpublishedSlugs = selectUnpublishedSlugEntriesByCollection(
+      state.editorialWorkflow,
+      collection.get('name'),
+    );
+    const unavailableSlugs = selectSlugEntries(state.entries, collection.get('name')).concat(
+      unpublishedSlugs,
+    );
 
     // Early return if draft contains validation errors
     if (!fieldsErrors.isEmpty()) {

--- a/packages/netlify-cms-core/src/actions/editorialWorkflow.js
+++ b/packages/netlify-cms-core/src/actions/editorialWorkflow.js
@@ -3,10 +3,8 @@ import { actions as notifActions } from 'redux-notifications';
 import { BEGIN, COMMIT, REVERT } from 'redux-optimist';
 import { serializeValues } from 'Lib/serializeEntryValues';
 import { currentBackend } from 'src/backend';
-import { getAsset, selectUnpublishedEntry } from 'Reducers';
+import { getAsset, selectSlugs, selectUnpublishedEntry } from 'Reducers';
 import { selectFields, selectSlugField } from 'Reducers/collections';
-import { selectSlugEntries } from 'Reducers/entries';
-import { selectUnpublishedSlugEntriesByCollection } from 'Reducers/editorialWorkflow';
 import { EDITORIAL_WORKFLOW } from 'Constants/publishModes';
 import { EDITORIAL_WORKFLOW_ERROR } from 'netlify-cms-lib-util';
 import { loadEntry, deleteEntry } from './entries';
@@ -292,13 +290,7 @@ export function persistUnpublishedEntry(collection, existingUnpublishedEntry) {
     const state = getState();
     const entryDraft = state.entryDraft;
     const fieldsErrors = entryDraft.get('fieldsErrors');
-    const unpublishedSlugs = selectUnpublishedSlugEntriesByCollection(
-      state.editorialWorkflow,
-      collection.get('name'),
-    );
-    const unavailableSlugs = selectSlugEntries(state.entries, collection.get('name')).concat(
-      unpublishedSlugs,
-    );
+    const unavailableSlugs = selectSlugs(state, collection.get('name'));
 
     // Early return if draft contains validation errors
     if (!fieldsErrors.isEmpty()) {

--- a/packages/netlify-cms-core/src/actions/entries.js
+++ b/packages/netlify-cms-core/src/actions/entries.js
@@ -410,6 +410,7 @@ export function persistEntry(collection) {
     const state = getState();
     const entryDraft = state.entryDraft;
     const fieldsErrors = entryDraft.get('fieldsErrors');
+    const publishedIds = state.entries.getIn(['pages', collection.get('name'), 'ids']);
 
     // Early return if draft contains validation errors
     if (!fieldsErrors.isEmpty()) {
@@ -446,7 +447,14 @@ export function persistEntry(collection) {
     const serializedEntryDraft = entryDraft.set('entry', serializedEntry);
     dispatch(entryPersisting(collection, serializedEntry));
     return backend
-      .persistEntry(state.config, collection, serializedEntryDraft, assetProxies.toJS())
+      .persistEntry(
+        state.config,
+        collection,
+        serializedEntryDraft,
+        assetProxies.toJS(),
+        state.integrations,
+        publishedIds,
+      )
       .then(slug => {
         dispatch(
           notifSend({

--- a/packages/netlify-cms-core/src/actions/entries.js
+++ b/packages/netlify-cms-core/src/actions/entries.js
@@ -1,10 +1,11 @@
 import { fromJS, List, Map } from 'immutable';
 import { actions as notifActions } from 'redux-notifications';
 import { serializeValues } from 'Lib/serializeEntryValues';
-import { currentBackend } from 'src/backend';
+import { currentBackend, slugFormatter } from 'src/backend';
 import { getIntegrationProvider } from 'Integrations';
 import { getAsset, selectIntegration } from 'Reducers';
 import { selectFields } from 'Reducers/collections';
+import { selectSlugEntries } from 'Reducers/entries';
 import { selectCollectionEntriesCursor } from 'Reducers/cursors';
 import { Cursor } from 'netlify-cms-lib-util';
 import { createEntry } from 'ValueObjects/Entry';
@@ -410,7 +411,7 @@ export function persistEntry(collection) {
     const state = getState();
     const entryDraft = state.entryDraft;
     const fieldsErrors = entryDraft.get('fieldsErrors');
-    const publishedIds = state.entries.getIn(['pages', collection.get('name'), 'ids']);
+    const unavailableSlugs = selectSlugEntries(state.entries, collection.get('name'));
 
     // Early return if draft contains validation errors
     if (!fieldsErrors.isEmpty()) {
@@ -453,7 +454,7 @@ export function persistEntry(collection) {
         serializedEntryDraft,
         assetProxies.toJS(),
         state.integrations,
-        publishedIds,
+        unavailableSlugs,
       )
       .then(slug => {
         dispatch(
@@ -510,4 +511,10 @@ export function deleteEntry(collection, slug) {
         return Promise.reject(dispatch(entryDeleteFail(collection, slug, error)));
       });
   };
+}
+
+export function formatedSlugValue(collection) {
+  return (entryData, config, unavailableSlugs) => {
+    return slugFormatter(collection, entryData, config, unavailableSlugs);
+  }
 }

--- a/packages/netlify-cms-core/src/actions/entries.js
+++ b/packages/netlify-cms-core/src/actions/entries.js
@@ -4,7 +4,7 @@ import { serializeValues } from 'Lib/serializeEntryValues';
 import { currentBackend, slugFormatter } from 'src/backend';
 import { getIntegrationProvider } from 'Integrations';
 import { getAsset, selectIntegration } from 'Reducers';
-import { selectFields } from 'Reducers/collections';
+import { selectFields, selectSlugField } from 'Reducers/collections';
 import { selectSlugEntries } from 'Reducers/entries';
 import { selectCollectionEntriesCursor } from 'Reducers/cursors';
 import { Cursor } from 'netlify-cms-lib-util';
@@ -122,7 +122,7 @@ export function entryPersisted(collection, entry, slug) {
     payload: {
       collectionName: collection.get('name'),
       entrySlug: entry.get('slug'),
-
+      slugField: selectSlugField(collection),
       /**
        * Pass slug from backend for newly created entries.
        */
@@ -513,8 +513,8 @@ export function deleteEntry(collection, slug) {
   };
 }
 
-export function formatedSlugValue(collection) {
+export function autoSlugValue(collection) {
   return (entryData, config, unavailableSlugs) => {
     return slugFormatter(collection, entryData, config, unavailableSlugs);
-  }
+  };
 }

--- a/packages/netlify-cms-core/src/actions/entries.js
+++ b/packages/netlify-cms-core/src/actions/entries.js
@@ -1,11 +1,10 @@
 import { fromJS, List, Map } from 'immutable';
 import { actions as notifActions } from 'redux-notifications';
 import { serializeValues } from 'Lib/serializeEntryValues';
-import { currentBackend, slugFormatter } from 'src/backend';
+import { currentBackend } from 'src/backend';
 import { getIntegrationProvider } from 'Integrations';
-import { getAsset, selectIntegration } from 'Reducers';
+import { getAsset, selectSlugEntries, selectIntegration } from 'Reducers';
 import { selectFields, selectSlugField } from 'Reducers/collections';
-import { selectSlugEntries } from 'Reducers/entries';
 import { selectCollectionEntriesCursor } from 'Reducers/cursors';
 import { Cursor } from 'netlify-cms-lib-util';
 import { createEntry } from 'ValueObjects/Entry';
@@ -410,7 +409,7 @@ export function persistEntry(collection) {
     const state = getState();
     const entryDraft = state.entryDraft;
     const fieldsErrors = entryDraft.get('fieldsErrors');
-    const unavailableSlugs = selectSlugEntries(state.entries, collection.get('name'));
+    const unavailableSlugs = selectSlugEntries(state, collection.get('name'));
 
     // Early return if draft contains validation errors
     if (!fieldsErrors.isEmpty()) {
@@ -520,11 +519,5 @@ export function deleteEntry(collection, slug) {
         console.error(error);
         return Promise.reject(dispatch(entryDeleteFail(collection, slug, error)));
       });
-  };
-}
-
-export function getSlug(collection) {
-  return (entryData, config, unavailableSlugs) => {
-    return slugFormatter(collection, entryData, config, unavailableSlugs);
   };
 }

--- a/packages/netlify-cms-core/src/backend.js
+++ b/packages/netlify-cms-core/src/backend.js
@@ -635,13 +635,13 @@ class Backend {
         throw new Error('Not allowed to create new entries in this collection');
       }
 
-      const slug = 
+      const slug =
         selectedSlug ||
         (await this.getSlug(
           collection,
           entryDraft.getIn(['entry', 'data']),
           config.get('slug'),
-          unavailableSlugs
+          unavailableSlugs,
         ));
       const path = selectEntryPath(collection, slug);
       entryObj = {

--- a/packages/netlify-cms-core/src/backend.js
+++ b/packages/netlify-cms-core/src/backend.js
@@ -301,6 +301,15 @@ class Backend {
 
   getToken = () => this.implementation.getToken();
 
+  generateUniqueSlug(slugConfig, slug, publishedOrDraftIds) {
+    let i = 1;
+    let uniqueSlug = slug;
+    while (publishedOrDraftIds.includes(uniqueSlug)) {
+      uniqueSlug = sanitizeSlug(`${slug} ${i++}`, slugConfig);
+    }
+    return uniqueSlug;
+  }
+
   processEntries(loadedEntries, collection) {
     const collectionFilter = collection.get('filter');
     const entries = loadedEntries.map(loadedEntry =>
@@ -560,7 +569,15 @@ class Backend {
     };
   }
 
-  persistEntry(config, collection, entryDraft, MediaFiles, integrations, options = {}) {
+  persistEntry(
+    config,
+    collection,
+    entryDraft,
+    MediaFiles,
+    integrations,
+    publishedOrDraftIds,
+    options = {},
+  ) {
     const newEntry = entryDraft.getIn(['entry', 'newRecord']) || false;
 
     const parsedData = {
@@ -578,10 +595,11 @@ class Backend {
         entryDraft.getIn(['entry', 'data']),
         config.get('slug'),
       );
-      const path = selectEntryPath(collection, slug);
+      const uniqueSlug = this.generateUniqueSlug(config.get('slug'), slug, publishedOrDraftIds);
+      const path = selectEntryPath(collection, uniqueSlug);
       entryObj = {
         path,
-        slug,
+        slug: uniqueSlug,
         raw: this.entryToRaw(collection, entryDraft.get('entry')),
       };
     } else {

--- a/packages/netlify-cms-core/src/components/Collection/Collection.js
+++ b/packages/netlify-cms-core/src/components/Collection/Collection.js
@@ -10,6 +10,7 @@ import CollectionTop from './CollectionTop';
 import EntriesCollection from './Entries/EntriesCollection';
 import EntriesSearch from './Entries/EntriesSearch';
 import { VIEW_STYLE_LIST } from 'Constants/collectionViews';
+import { selectUnpublishedEntryByParentSlug } from 'Reducers';
 
 const CollectionContainer = styled.div`
   margin: ${lengths.pageMargin};
@@ -33,13 +34,25 @@ class Collection extends React.Component {
   };
 
   renderEntriesCollection = () => {
-    const { collection } = this.props;
-    return <EntriesCollection collection={collection} viewStyle={this.state.viewStyle} />;
+    const { collection, unpublishedChildEntry } = this.props;
+    return (
+      <EntriesCollection
+        collection={collection}
+        viewStyle={this.state.viewStyle}
+        unpublishedChildEntry={unpublishedChildEntry}
+      />
+    );
   };
 
   renderEntriesSearch = () => {
-    const { searchTerm, collections } = this.props;
-    return <EntriesSearch collections={collections} searchTerm={searchTerm} />;
+    const { searchTerm, collections, unpublishedChildEntry } = this.props;
+    return (
+      <EntriesSearch
+        collections={collections}
+        searchTerm={searchTerm}
+        unpublishedChildEntry={unpublishedChildEntry}
+      />
+    );
   };
 
   handleChangeViewStyle = viewStyle => {
@@ -77,7 +90,15 @@ function mapStateToProps(state, ownProps) {
   const { isSearchResults, match } = ownProps;
   const { name, searchTerm } = match.params;
   const collection = name ? collections.get(name) : collections.first();
-  return { collection, collections, collectionName: name, isSearchResults, searchTerm };
+  const unpublishedChildEntry = selectUnpublishedEntryByParentSlug.bind(null, state);
+  return {
+    collection,
+    collections,
+    collectionName: name,
+    isSearchResults,
+    searchTerm,
+    unpublishedChildEntry,
+  };
 }
 
 export default connect(mapStateToProps)(Collection);

--- a/packages/netlify-cms-core/src/components/Collection/Entries/Entries.js
+++ b/packages/netlify-cms-core/src/components/Collection/Entries/Entries.js
@@ -12,6 +12,7 @@ const Entries = ({
   isFetching,
   viewStyle,
   cursor,
+  unpublishedChildEntry,
   handleCursorActions,
   t,
 }) => {
@@ -29,6 +30,7 @@ const Entries = ({
         publicFolder={publicFolder}
         viewStyle={viewStyle}
         cursor={cursor}
+        unpublishedChildEntry={unpublishedChildEntry}
         handleCursorActions={handleCursorActions}
       />
     );

--- a/packages/netlify-cms-core/src/components/Collection/Entries/EntriesCollection.js
+++ b/packages/netlify-cms-core/src/components/Collection/Entries/EntriesCollection.js
@@ -8,9 +8,11 @@ import {
   loadEntries as actionLoadEntries,
   traverseCollectionCursor as actionTraverseCollectionCursor,
 } from 'Actions/entries';
+import { loadUnpublishedEntries as actionLoadUnpublishedEntries } from 'Actions/editorialWorkflow';
 import { selectEntries } from 'Reducers';
 import { selectCollectionEntriesCursor } from 'Reducers/cursors';
 import Entries from './Entries';
+import { EDITORIAL_WORKFLOW } from 'Constants/publishModes';
 
 class EntriesCollection extends React.Component {
   static propTypes = {
@@ -25,9 +27,21 @@ class EntriesCollection extends React.Component {
   };
 
   componentDidMount() {
-    const { collection, entriesLoaded, loadEntries } = this.props;
+    const {
+      collection,
+      entriesLoaded,
+      loadEntries,
+      collections,
+      isEditorialWorkflow,
+      loadUnpublishedEntries,
+    } = this.props;
+
     if (collection && !entriesLoaded) {
       loadEntries(collection);
+    }
+
+    if (isEditorialWorkflow) {
+      loadUnpublishedEntries(collections);
     }
   }
 
@@ -44,7 +58,15 @@ class EntriesCollection extends React.Component {
   };
 
   render() {
-    const { collection, entries, publicFolder, isFetching, viewStyle, cursor } = this.props;
+    const {
+      collection,
+      entries,
+      publicFolder,
+      isFetching,
+      viewStyle,
+      cursor,
+      unpublishedChildEntry,
+    } = this.props;
 
     return (
       <Entries
@@ -55,6 +77,7 @@ class EntriesCollection extends React.Component {
         collectionName={collection.get('label')}
         viewStyle={viewStyle}
         cursor={cursor}
+        unpublishedChildEntry={unpublishedChildEntry}
         handleCursorActions={partial(this.handleCursorActions, cursor)}
       />
     );
@@ -63,7 +86,7 @@ class EntriesCollection extends React.Component {
 
 function mapStateToProps(state, ownProps) {
   const { collection, viewStyle } = ownProps;
-  const { config } = state;
+  const { config, collections } = state;
   const publicFolder = config.get('public_folder');
   const page = state.entries.getIn(['pages', collection.get('name'), 'page']);
 
@@ -73,13 +96,26 @@ function mapStateToProps(state, ownProps) {
 
   const rawCursor = selectCollectionEntriesCursor(state.cursors, collection.get('name'));
   const cursor = Cursor.create(rawCursor).clearData();
+  const isEditorialWorkflow = state.config.get('publish_mode') === EDITORIAL_WORKFLOW;
 
-  return { publicFolder, collection, page, entries, entriesLoaded, isFetching, viewStyle, cursor };
+  return {
+    publicFolder,
+    collection,
+    page,
+    entries,
+    entriesLoaded,
+    isFetching,
+    viewStyle,
+    cursor,
+    collections,
+    isEditorialWorkflow,
+  };
 }
 
 const mapDispatchToProps = {
   loadEntries: actionLoadEntries,
   traverseCollectionCursor: actionTraverseCollectionCursor,
+  loadUnpublishedEntries: actionLoadUnpublishedEntries,
 };
 
 export default connect(

--- a/packages/netlify-cms-core/src/components/Collection/Entries/EntriesSearch.js
+++ b/packages/netlify-cms-core/src/components/Collection/Entries/EntriesSearch.js
@@ -53,7 +53,7 @@ class EntriesSearch extends React.Component {
   };
 
   render() {
-    const { collections, entries, publicFolder, isFetching } = this.props;
+    const { collections, entries, publicFolder, isFetching, unpublishedChildEntry } = this.props;
     return (
       <Entries
         cursor={this.getCursor()}
@@ -62,6 +62,7 @@ class EntriesSearch extends React.Component {
         entries={entries}
         publicFolder={publicFolder}
         isFetching={isFetching}
+        unpublishedChildEntry={unpublishedChildEntry}
       />
     );
   }

--- a/packages/netlify-cms-core/src/components/Collection/Entries/EntryCard.js
+++ b/packages/netlify-cms-core/src/components/Collection/Entries/EntryCard.js
@@ -93,8 +93,8 @@ const EntryCard = ({
   const slug = entry.get('slug');
   const title = label || entry.getIn(['data', inferedFields.titleField]);
   const childEntry = unpublishedChildEntry(collection.get('name'), slug);
-  const selectedSlug = (childEntry && childEntry.get('slug')) || slug;
-  const path = `/collections/${collection.get('name')}/entries/${selectedSlug}`;
+  const entrySlug = (childEntry && childEntry.get('slug')) || slug;
+  const path = `/collections/${collection.get('name')}/entries/${entrySlug}`;
   let image = entry.getIn(['data', inferedFields.imageField]);
   image = resolvePath(image, publicFolder);
   if (image) {

--- a/packages/netlify-cms-core/src/components/Collection/Entries/EntryCard.js
+++ b/packages/netlify-cms-core/src/components/Collection/Entries/EntryCard.js
@@ -86,11 +86,15 @@ const EntryCard = ({
   inferedFields,
   publicFolder,
   collectionLabel,
+  unpublishedChildEntry,
   viewStyle = VIEW_STYLE_LIST,
 }) => {
   const label = entry.get('label');
+  const slug = entry.get('slug');
   const title = label || entry.getIn(['data', inferedFields.titleField]);
-  const path = `/collections/${collection.get('name')}/entries/${entry.get('slug')}`;
+  const childEntry = unpublishedChildEntry(collection.get('name'), slug);
+  const selectedSlug = (childEntry && childEntry.get('slug')) || slug;
+  const path = `/collections/${collection.get('name')}/entries/${selectedSlug}`;
   let image = entry.getIn(['data', inferedFields.imageField]);
   image = resolvePath(image, publicFolder);
   if (image) {

--- a/packages/netlify-cms-core/src/components/Collection/Entries/EntryListing.js
+++ b/packages/netlify-cms-core/src/components/Collection/Entries/EntryListing.js
@@ -44,20 +44,33 @@ export default class EntryListing extends React.Component {
   };
 
   renderCardsForSingleCollection = () => {
-    const { collections, entries, publicFolder, viewStyle } = this.props;
+    const { collections, entries, publicFolder, viewStyle, unpublishedChildEntry } = this.props;
     const inferedFields = this.inferFields(collections);
-    const entryCardProps = { collection: collections, inferedFields, publicFolder, viewStyle };
+    const entryCardProps = {
+      collection: collections,
+      inferedFields,
+      publicFolder,
+      viewStyle,
+      unpublishedChildEntry,
+    };
     return entries.map((entry, idx) => <EntryCard {...entryCardProps} entry={entry} key={idx} />);
   };
 
   renderCardsForMultipleCollections = () => {
-    const { collections, entries, publicFolder } = this.props;
+    const { collections, entries, publicFolder, unpublishedChildEntry } = this.props;
     return entries.map((entry, idx) => {
       const collectionName = entry.get('collection');
       const collection = collections.find(coll => coll.get('name') === collectionName);
       const collectionLabel = collection.get('label');
       const inferedFields = this.inferFields(collection);
-      const entryCardProps = { collection, entry, inferedFields, publicFolder, collectionLabel };
+      const entryCardProps = {
+        collection,
+        entry,
+        inferedFields,
+        publicFolder,
+        collectionLabel,
+        unpublishedChildEntry,
+      };
       return <EntryCard {...entryCardProps} key={idx} />;
     });
   };

--- a/packages/netlify-cms-core/src/components/Editor/Editor.js
+++ b/packages/netlify-cms-core/src/components/Editor/Editor.js
@@ -14,7 +14,7 @@ import {
   discardDraft,
   changeDraftField,
   changeDraftFieldValidation,
-  autoSlugValue,
+  getSlug,
   persistEntry,
   deleteEntry,
 } from 'Actions/entries';
@@ -166,10 +166,13 @@ class Editor extends React.Component {
      * correct url using the slug.
      */
     const newSlug = this.props.entryDraft && this.props.entryDraft.getIn(['entry', 'slug']);
+    const currentPath = history.location.pathname;
     if (
       (!prevProps.slug && newSlug && this.props.newEntry) ||
       (prevProps.slug && newSlug && prevProps.slug != newSlug)
     ) {
+      if (currentPath.split('/').pop() === newSlug) return;
+
       navigateToEntry(prevProps.collection.get('name'), newSlug);
       return this.props.loadEntry(this.props.collection, newSlug);
     }
@@ -313,7 +316,7 @@ class Editor extends React.Component {
       indentifierField,
       slugField,
       boundGetAsset,
-      autoSlug,
+      getAutoSlug,
       collection,
       changeDraftField,
       changeDraftFieldValidation,
@@ -359,7 +362,7 @@ class Editor extends React.Component {
         fieldsErrors={entryDraft.get('fieldsErrors')}
         indentifierField={indentifierField}
         slugField={slugField}
-        autoSlug={autoSlug}
+        getAutoSlug={getAutoSlug}
         onChange={changeDraftField}
         onValidate={changeDraftFieldValidation}
         onPersist={this.handlePersistEntry}
@@ -392,7 +395,7 @@ function mapStateToProps(state, ownProps) {
   const collectionName = collection.get('name');
   const newEntry = ownProps.newRecord === true;
   const fields = selectFields(collection, slug);
-  const indentifierField = selectIdentifier(collection);
+  const indentifierField = selectIdentifier(collection, slug);
   const slugField = selectSlugField(collection);
   const entry = newEntry ? null : selectEntry(state, collectionName, slug);
   const boundGetAsset = getAsset.bind(null, state);
@@ -408,14 +411,14 @@ function mapStateToProps(state, ownProps) {
   const unpublishedSlugs = selectUnpublishedSlugEntriesByCollection(state, collectionName);
   const publishedSlugs = selectSlugEntries(state, collectionName);
   const unavailableSlugs = hasWorkflow ? publishedSlugs.concat(unpublishedSlugs) : publishedSlugs;
-  const autoSlug = autoSlugValue(collection); console.log(entryDraft.toJS());
+  const getAutoSlug = getSlug(collection);
   return {
     collection,
     collections,
     newEntry,
     entryDraft,
     boundGetAsset,
-    autoSlug,
+    getAutoSlug,
     fields,
     indentifierField,
     slugField,

--- a/packages/netlify-cms-core/src/components/Editor/Editor.js
+++ b/packages/netlify-cms-core/src/components/Editor/Editor.js
@@ -14,7 +14,6 @@ import {
   discardDraft,
   changeDraftField,
   changeDraftFieldValidation,
-  getSlug,
   persistEntry,
   deleteEntry,
 } from 'Actions/entries';
@@ -25,15 +24,8 @@ import {
 } from 'Actions/editorialWorkflow';
 import { loadDeployPreview } from 'Actions/deploys';
 import { deserializeValues } from 'Lib/serializeEntryValues';
-import {
-  selectEntry,
-  selectUnpublishedEntry,
-  selectDeployPreview,
-  getAsset,
-  selectSlugEntries,
-  selectUnpublishedSlugEntriesByCollection,
-} from 'Reducers';
-import { selectFields, selectIdentifier, selectSlugField } from 'Reducers/collections';
+import { selectEntry, selectUnpublishedEntry, selectDeployPreview, getAsset } from 'Reducers';
+import { selectFields } from 'Reducers/collections';
 import { status } from 'Constants/publishModes';
 import { EDITORIAL_WORKFLOW } from 'Constants/publishModes';
 import EditorInterface from './EditorInterface';
@@ -313,10 +305,7 @@ class Editor extends React.Component {
       entry,
       entryDraft,
       fields,
-      indentifierField,
-      slugField,
       boundGetAsset,
-      getAutoSlug,
       collection,
       changeDraftField,
       changeDraftFieldValidation,
@@ -328,7 +317,6 @@ class Editor extends React.Component {
       newEntry,
       isModification,
       currentStatus,
-      unavailableSlugs,
       logoutUser,
       deployPreview,
       loadDeployPreview,
@@ -360,9 +348,6 @@ class Editor extends React.Component {
         fields={fields}
         fieldsMetaData={entryDraft.get('fieldsMetaData')}
         fieldsErrors={entryDraft.get('fieldsErrors')}
-        indentifierField={indentifierField}
-        slugField={slugField}
-        getAutoSlug={getAutoSlug}
         onChange={changeDraftField}
         onValidate={changeDraftFieldValidation}
         onPersist={this.handlePersistEntry}
@@ -379,7 +364,6 @@ class Editor extends React.Component {
         isNewEntry={newEntry}
         isModification={isModification}
         currentStatus={currentStatus}
-        unavailableSlugs={unavailableSlugs}
         onLogoutClick={logoutUser}
         deployPreview={deployPreview}
         loadDeployPreview={opts => loadDeployPreview(collection, slug, entry, isPublished, opts)}
@@ -395,8 +379,6 @@ function mapStateToProps(state, ownProps) {
   const collectionName = collection.get('name');
   const newEntry = ownProps.newRecord === true;
   const fields = selectFields(collection, slug);
-  const indentifierField = selectIdentifier(collection, slug);
-  const slugField = selectSlugField(collection);
   const entry = newEntry ? null : selectEntry(state, collectionName, slug);
   const boundGetAsset = getAsset.bind(null, state);
   const user = auth && auth.get('user');
@@ -408,20 +390,13 @@ function mapStateToProps(state, ownProps) {
   const unpublishedEntry = selectUnpublishedEntry(state, collectionName, slug);
   const currentStatus = unpublishedEntry && unpublishedEntry.getIn(['metaData', 'status']);
   const deployPreview = selectDeployPreview(state, collectionName, slug);
-  const unpublishedSlugs = selectUnpublishedSlugEntriesByCollection(state, collectionName);
-  const publishedSlugs = selectSlugEntries(state, collectionName);
-  const unavailableSlugs = hasWorkflow ? publishedSlugs.concat(unpublishedSlugs) : publishedSlugs;
-  const getAutoSlug = getSlug(collection);
   return {
     collection,
     collections,
     newEntry,
     entryDraft,
     boundGetAsset,
-    getAutoSlug,
     fields,
-    indentifierField,
-    slugField,
     slug,
     entry,
     user,
@@ -432,7 +407,6 @@ function mapStateToProps(state, ownProps) {
     collectionEntriesLoaded,
     currentStatus,
     deployPreview,
-    unavailableSlugs,
   };
 }
 

--- a/packages/netlify-cms-core/src/components/Editor/Editor.js
+++ b/packages/netlify-cms-core/src/components/Editor/Editor.js
@@ -14,7 +14,7 @@ import {
   discardDraft,
   changeDraftField,
   changeDraftFieldValidation,
-  formatedSlugValue,
+  autoSlugValue,
   persistEntry,
   deleteEntry,
 } from 'Actions/entries';
@@ -32,7 +32,7 @@ import {
   getAsset,
   selectSlugEntries,
   selectUnpublishedSlugEntriesByCollection,
-}from 'Reducers';
+} from 'Reducers';
 import { selectFields, selectIdentifier, selectSlugField } from 'Reducers/collections';
 import { status } from 'Constants/publishModes';
 import { EDITORIAL_WORKFLOW } from 'Constants/publishModes';
@@ -162,13 +162,16 @@ class Editor extends React.Component {
   componentDidUpdate(prevProps) {
     /**
      * If the old slug is empty and the new slug is not, a new entry was just
-     * saved, and we need to update navigation to the correct url using the
-     * slug.
+     * saved, or if slug entry was changed, we need to update navigation to the
+     * correct url using the slug.
      */
     const newSlug = this.props.entryDraft && this.props.entryDraft.getIn(['entry', 'slug']);
-    if (!prevProps.slug && newSlug && this.props.newEntry) {
+    if (
+      (!prevProps.slug && newSlug && this.props.newEntry) ||
+      (prevProps.slug && newSlug && prevProps.slug != newSlug)
+    ) {
       navigateToEntry(prevProps.collection.get('name'), newSlug);
-      this.props.loadEntry(this.props.collection, newSlug);
+      return this.props.loadEntry(this.props.collection, newSlug);
     }
 
     if (prevProps.entry === this.props.entry) return;
@@ -310,7 +313,7 @@ class Editor extends React.Component {
       indentifierField,
       slugField,
       boundGetAsset,
-      formatedSlug,
+      autoSlug,
       collection,
       changeDraftField,
       changeDraftFieldValidation,
@@ -356,7 +359,7 @@ class Editor extends React.Component {
         fieldsErrors={entryDraft.get('fieldsErrors')}
         indentifierField={indentifierField}
         slugField={slugField}
-        formatedSlug={formatedSlug}
+        autoSlug={autoSlug}
         onChange={changeDraftField}
         onValidate={changeDraftFieldValidation}
         onPersist={this.handlePersistEntry}
@@ -405,15 +408,14 @@ function mapStateToProps(state, ownProps) {
   const unpublishedSlugs = selectUnpublishedSlugEntriesByCollection(state, collectionName);
   const publishedSlugs = selectSlugEntries(state, collectionName);
   const unavailableSlugs = hasWorkflow ? publishedSlugs.concat(unpublishedSlugs) : publishedSlugs;
-  const formatedSlug = formatedSlugValue(collection);
-
+  const autoSlug = autoSlugValue(collection); console.log(entryDraft.toJS());
   return {
     collection,
     collections,
     newEntry,
     entryDraft,
     boundGetAsset,
-    formatedSlug,
+    autoSlug,
     fields,
     indentifierField,
     slugField,

--- a/packages/netlify-cms-core/src/components/Editor/EditorControlPane/EditorControl.js
+++ b/packages/netlify-cms-core/src/components/Editor/EditorControlPane/EditorControl.js
@@ -230,9 +230,6 @@ class EditorControl extends React.Component {
       clearSearch,
       clearFieldErrors,
       loadEntry,
-      slugField,
-      entrySlug,
-      isNewEntry,
       t,
     } = this.props;
     const widgetName = field.get('widget');
@@ -243,7 +240,6 @@ class EditorControl extends React.Component {
     const onValidateObject = onValidate;
     const metadata = fieldsMetaData && fieldsMetaData.get(fieldName);
     const errors = fieldsErrors && fieldsErrors.get(this.uniqueFieldId);
-	const fieldValue = ((fieldName == slugField) && !value && !isNewEntry) ? entrySlug : value;
     return (
       <ControlContainer>
         <ControlErrorsList>

--- a/packages/netlify-cms-core/src/components/Editor/EditorControlPane/EditorControl.js
+++ b/packages/netlify-cms-core/src/components/Editor/EditorControlPane/EditorControl.js
@@ -157,20 +157,43 @@ class EditorControl extends React.Component {
 
   uniqueFieldId = uniqueId(`${this.props.field.get('name')}-field-`);
 
+  componentDidUpdate() {
+    const { field, value, onChange, slugField, entrySlug, isNewEntry } = this.props;
+    const fieldName = field.get('name');
+    if (fieldName == slugField && !value && !isNewEntry) {
+      setTimeout(() => {
+        onChange(slugField, entrySlug);
+      }, 0);
+    }
+  }
+
   handleSetInactiveStyle = () => {
-    const { field, value, config, entryData, indentifierField, formatedSlug, onChange, slugField, unavailableSlugs } = this.props;
+    const {
+      field,
+      value,
+      config,
+      entryData,
+      entrySlug,
+      indentifierField,
+      autoSlug,
+      onChange,
+      slugField,
+      unavailableSlugs,
+    } = this.props;
     const fieldName = field.get('name');
     const slugValue = entryData.get(slugField);
 
     this.setState({ styleActive: false });
-    if ((fieldName == indentifierField) && value && !slugValue) {
-      onChange(slugField, formatedSlug(entryData, config, unavailableSlugs));
+    if (fieldName == indentifierField && value && !slugValue) {
+      onChange(slugField, autoSlug(entryData, config, unavailableSlugs));
     }
 
-    if ((fieldName == slugField) && value ) {
-      onChange(slugField, generateUniqueSlug(value, config, unavailableSlugs));
+    if (fieldName == slugField && value) {
+      // Remove current entry slug from the list
+      const slugs = unavailableSlugs.filter(item => item !== entrySlug);
+      onChange(slugField, generateUniqueSlug(value, config, slugs));
     }
-  }
+  };
 
   render() {
     const {
@@ -244,7 +267,7 @@ class EditorControl extends React.Component {
           controlComponent={widget.control}
           field={field}
           uniqueFieldId={this.uniqueFieldId}
-          value={fieldValue}
+          value={value}
           mediaPaths={mediaPaths}
           metadata={metadata}
           onChange={(newValue, newMetadata) => onChange(fieldName, newValue, newMetadata)}

--- a/packages/netlify-cms-core/src/components/Editor/EditorControlPane/EditorControl.js
+++ b/packages/netlify-cms-core/src/components/Editor/EditorControlPane/EditorControl.js
@@ -182,14 +182,14 @@ class EditorControl extends React.Component {
     const entryData = entry.get('data');
     const unavailableSlugs = boundSelectSlugs(collection.get('name'));
     const availableSlugs = [entry.get('slug'), entry.getIn(['metaData', 'parentSlug'])];
-    const indentifierField = collection && selectIdentifier(collection);
+    const identifierField = collection && selectIdentifier(collection);
     const slugField = collection && selectSlugField(collection);
     const slugValue = entry.getIn(['data', slugField]);
     const backend = currentBackend(config);
 
     this.setState({ styleActive: false });
 
-    if (fieldName == indentifierField && value && !slugValue && collection) {
+    if (fieldName == identifierField && value && !slugValue && collection) {
       onChange(slugField, await backend.getSlug(collection, entryData, config, unavailableSlugs));
     }
 

--- a/packages/netlify-cms-core/src/components/Editor/EditorControlPane/EditorControlPane.js
+++ b/packages/netlify-cms-core/src/components/Editor/EditorControlPane/EditorControlPane.js
@@ -42,7 +42,7 @@ export default class ControlPane extends React.Component {
       indentifierField,
       entry,
       slugField,
-      formatedSlug,
+      autoSlug,
       fieldsMetaData,
       fieldsErrors,
       onChange,
@@ -72,7 +72,7 @@ export default class ControlPane extends React.Component {
                 fieldsErrors={fieldsErrors}
                 indentifierField={indentifierField}
                 slugField={slugField}
-                formatedSlug={formatedSlug}
+                autoSlug={autoSlug}
                 onChange={onChange}
                 onValidate={onValidate}
                 processControlRef={this.controlRef.bind(this)}

--- a/packages/netlify-cms-core/src/components/Editor/EditorControlPane/EditorControlPane.js
+++ b/packages/netlify-cms-core/src/components/Editor/EditorControlPane/EditorControlPane.js
@@ -39,15 +39,11 @@ export default class ControlPane extends React.Component {
     const {
       collection,
       fields,
-      indentifierField,
       entry,
-      slugField,
-      getAutoSlug,
       fieldsMetaData,
       fieldsErrors,
       onChange,
       onValidate,
-      unavailableSlugs,
       isNewEntry,
     } = this.props;
 
@@ -65,14 +61,12 @@ export default class ControlPane extends React.Component {
           (field, i) =>
             field.get('widget') === 'hidden' ? null : (
               <EditorControl
+                collection={collection}
                 key={i}
                 field={field}
                 value={entry.getIn(['data', field.get('name')])}
                 fieldsMetaData={fieldsMetaData}
                 fieldsErrors={fieldsErrors}
-                indentifierField={indentifierField}
-                slugField={slugField}
-                getAutoSlug={getAutoSlug}
                 onChange={onChange}
                 onValidate={onValidate}
                 processControlRef={this.controlRef.bind(this)}

--- a/packages/netlify-cms-core/src/components/Editor/EditorControlPane/EditorControlPane.js
+++ b/packages/netlify-cms-core/src/components/Editor/EditorControlPane/EditorControlPane.js
@@ -39,11 +39,16 @@ export default class ControlPane extends React.Component {
     const {
       collection,
       fields,
+      indentifierField,
       entry,
+      slugField,
+      formatedSlug,
       fieldsMetaData,
       fieldsErrors,
       onChange,
       onValidate,
+      unavailableSlugs,
+      isNewEntry,
     } = this.props;
 
     if (!collection || !fields) {
@@ -65,10 +70,15 @@ export default class ControlPane extends React.Component {
                 value={entry.getIn(['data', field.get('name')])}
                 fieldsMetaData={fieldsMetaData}
                 fieldsErrors={fieldsErrors}
+                indentifierField={indentifierField}
+                slugField={slugField}
+                formatedSlug={formatedSlug}
                 onChange={onChange}
                 onValidate={onValidate}
                 processControlRef={this.controlRef.bind(this)}
                 controlRef={this.controlRef}
+                unavailableSlugs={unavailableSlugs}
+                isNewEntry={isNewEntry}
               />
             ),
         )}

--- a/packages/netlify-cms-core/src/components/Editor/EditorControlPane/EditorControlPane.js
+++ b/packages/netlify-cms-core/src/components/Editor/EditorControlPane/EditorControlPane.js
@@ -42,7 +42,7 @@ export default class ControlPane extends React.Component {
       indentifierField,
       entry,
       slugField,
-      autoSlug,
+      getAutoSlug,
       fieldsMetaData,
       fieldsErrors,
       onChange,
@@ -72,7 +72,7 @@ export default class ControlPane extends React.Component {
                 fieldsErrors={fieldsErrors}
                 indentifierField={indentifierField}
                 slugField={slugField}
-                autoSlug={autoSlug}
+                getAutoSlug={getAutoSlug}
                 onChange={onChange}
                 onValidate={onValidate}
                 processControlRef={this.controlRef.bind(this)}

--- a/packages/netlify-cms-core/src/components/Editor/EditorControlPane/EditorControlPane.js
+++ b/packages/netlify-cms-core/src/components/Editor/EditorControlPane/EditorControlPane.js
@@ -71,7 +71,6 @@ export default class ControlPane extends React.Component {
                 onValidate={onValidate}
                 processControlRef={this.controlRef.bind(this)}
                 controlRef={this.controlRef}
-                unavailableSlugs={unavailableSlugs}
                 isNewEntry={isNewEntry}
               />
             ),

--- a/packages/netlify-cms-core/src/components/Editor/EditorInterface.js
+++ b/packages/netlify-cms-core/src/components/Editor/EditorInterface.js
@@ -152,6 +152,9 @@ class EditorInterface extends Component {
       fields,
       fieldsMetaData,
       fieldsErrors,
+      indentifierField,
+      slugField,
+      formatedSlug,
       getAsset,
       onChange,
       showDelete,
@@ -168,6 +171,7 @@ class EditorInterface extends Component {
       isNewEntry,
       isModification,
       currentStatus,
+      unavailableSlugs,
       onLogoutClick,
       loadDeployPreview,
       deployPreview,
@@ -185,8 +189,13 @@ class EditorInterface extends Component {
           fields={fields}
           fieldsMetaData={fieldsMetaData}
           fieldsErrors={fieldsErrors}
+          indentifierField={indentifierField}
+          slugField ={slugField}
+          formatedSlug={formatedSlug}
           onChange={onChange}
           onValidate={onValidate}
+          unavailableSlugs={unavailableSlugs}
+          isNewEntry={isNewEntry}
           ref={c => (this.controlPaneRef = c)}
         />
       </ControlPaneContainer>

--- a/packages/netlify-cms-core/src/components/Editor/EditorInterface.js
+++ b/packages/netlify-cms-core/src/components/Editor/EditorInterface.js
@@ -152,9 +152,6 @@ class EditorInterface extends Component {
       fields,
       fieldsMetaData,
       fieldsErrors,
-      indentifierField,
-      slugField,
-      getAutoSlug,
       getAsset,
       onChange,
       showDelete,
@@ -171,7 +168,6 @@ class EditorInterface extends Component {
       isNewEntry,
       isModification,
       currentStatus,
-      unavailableSlugs,
       onLogoutClick,
       loadDeployPreview,
       deployPreview,
@@ -189,12 +185,8 @@ class EditorInterface extends Component {
           fields={fields}
           fieldsMetaData={fieldsMetaData}
           fieldsErrors={fieldsErrors}
-          indentifierField={indentifierField}
-          slugField={slugField}
-          getAutoSlug={getAutoSlug}
           onChange={onChange}
           onValidate={onValidate}
-          unavailableSlugs={unavailableSlugs}
           isNewEntry={isNewEntry}
           ref={c => (this.controlPaneRef = c)}
         />

--- a/packages/netlify-cms-core/src/components/Editor/EditorInterface.js
+++ b/packages/netlify-cms-core/src/components/Editor/EditorInterface.js
@@ -154,7 +154,7 @@ class EditorInterface extends Component {
       fieldsErrors,
       indentifierField,
       slugField,
-      autoSlug,
+      getAutoSlug,
       getAsset,
       onChange,
       showDelete,
@@ -191,7 +191,7 @@ class EditorInterface extends Component {
           fieldsErrors={fieldsErrors}
           indentifierField={indentifierField}
           slugField={slugField}
-          autoSlug={autoSlug}
+          getAutoSlug={getAutoSlug}
           onChange={onChange}
           onValidate={onValidate}
           unavailableSlugs={unavailableSlugs}

--- a/packages/netlify-cms-core/src/components/Editor/EditorInterface.js
+++ b/packages/netlify-cms-core/src/components/Editor/EditorInterface.js
@@ -154,7 +154,7 @@ class EditorInterface extends Component {
       fieldsErrors,
       indentifierField,
       slugField,
-      formatedSlug,
+      autoSlug,
       getAsset,
       onChange,
       showDelete,
@@ -190,8 +190,8 @@ class EditorInterface extends Component {
           fieldsMetaData={fieldsMetaData}
           fieldsErrors={fieldsErrors}
           indentifierField={indentifierField}
-          slugField ={slugField}
-          formatedSlug={formatedSlug}
+          slugField={slugField}
+          autoSlug={autoSlug}
           onChange={onChange}
           onValidate={onValidate}
           unavailableSlugs={unavailableSlugs}

--- a/packages/netlify-cms-core/src/lib/urlHelper.js
+++ b/packages/netlify-cms-core/src/lib/urlHelper.js
@@ -91,15 +91,7 @@ export function sanitizeSlug(str, options = Map()) {
   const normalizedSlug = sanitizedSlug
     .replace(doubleReplacement, replacement)
     .replace(leadingReplacment, '')
-    .replace(trailingReplacment, '')
-    // Remove single quotes.
-    .replace(/[']/g, '')
-
-    // Replace periods with dashes.
-    .replace(/[.]/g, '-')
-
-    // Convert slug to lower-case
-    .toLocaleLowerCase();
+    .replace(trailingReplacment, '');
 
   return normalizedSlug;
 }

--- a/packages/netlify-cms-core/src/lib/urlHelper.js
+++ b/packages/netlify-cms-core/src/lib/urlHelper.js
@@ -91,7 +91,15 @@ export function sanitizeSlug(str, options = Map()) {
   const normalizedSlug = sanitizedSlug
     .replace(doubleReplacement, replacement)
     .replace(leadingReplacment, '')
-    .replace(trailingReplacment, '');
+    .replace(trailingReplacment, '')
+    // Remove single quotes.
+    .replace(/[']/g, '')
+
+    // Replace periods with dashes.
+    .replace(/[.]/g, '-')
+
+    // Convert slug to lower-case
+    .toLocaleLowerCase();
 
   return normalizedSlug;
 }

--- a/packages/netlify-cms-core/src/reducers/collections.js
+++ b/packages/netlify-cms-core/src/reducers/collections.js
@@ -112,10 +112,10 @@ export const selectAllowDeletion = collection =>
   selectors[collection.get('type')].allowDeletion(collection);
 export const selectTemplateName = (collection, slug) =>
   selectors[collection.get('type')].templateName(collection, slug);
-export const selectIdentifier = collection => {
+export const selectIdentifier = (collection, slug) => {
   const identifier = collection.get('identifier_field');
   const identifierFields = identifier ? [identifier, ...IDENTIFIER_FIELDS] : IDENTIFIER_FIELDS;
-  const fieldNames = collection.get('fields').map(field => field.get('name'));
+  const fieldNames = selectFields(collection, slug).map(field => field.get('name'));
   return identifierFields.find(id =>
     fieldNames.find(name => name.toLowerCase().trim() === id.toLowerCase().trim()),
   );

--- a/packages/netlify-cms-core/src/reducers/collections.js
+++ b/packages/netlify-cms-core/src/reducers/collections.js
@@ -121,7 +121,7 @@ export const selectIdentifier = collection => {
   );
 };
 export const selectSlugField = collection => {
-  return  collection.get('slug_field');
+  return collection.get('slug_field');
 };
 export const selectInferedField = (collection, fieldName) => {
   if (fieldName === 'title' && collection.get('identifier_field')) {

--- a/packages/netlify-cms-core/src/reducers/collections.js
+++ b/packages/netlify-cms-core/src/reducers/collections.js
@@ -120,6 +120,9 @@ export const selectIdentifier = collection => {
     fieldNames.find(name => name.toLowerCase().trim() === id.toLowerCase().trim()),
   );
 };
+export const selectSlugField = collection => {
+  return  collection.get('slug_field');
+};
 export const selectInferedField = (collection, fieldName) => {
   if (fieldName === 'title' && collection.get('identifier_field')) {
     return selectIdentifier(collection);

--- a/packages/netlify-cms-core/src/reducers/collections.js
+++ b/packages/netlify-cms-core/src/reducers/collections.js
@@ -112,10 +112,10 @@ export const selectAllowDeletion = collection =>
   selectors[collection.get('type')].allowDeletion(collection);
 export const selectTemplateName = (collection, slug) =>
   selectors[collection.get('type')].templateName(collection, slug);
-export const selectIdentifier = (collection, slug) => {
+export const selectIdentifier = collection => {
   const identifier = collection.get('identifier_field');
   const identifierFields = identifier ? [identifier, ...IDENTIFIER_FIELDS] : IDENTIFIER_FIELDS;
-  const fieldNames = selectFields(collection, slug).map(field => field.get('name'));
+  const fieldNames = collection.get('fields').map(field => field.get('name'));
   return identifierFields.find(id =>
     fieldNames.find(name => name.toLowerCase().trim() === id.toLowerCase().trim()),
   );

--- a/packages/netlify-cms-core/src/reducers/editorialWorkflow.js
+++ b/packages/netlify-cms-core/src/reducers/editorialWorkflow.js
@@ -1,4 +1,5 @@
 import { Map, List, fromJS } from 'immutable';
+import { startsWith } from 'lodash';
 import { EDITORIAL_WORKFLOW } from 'Constants/publishModes';
 import {
   UNPUBLISHED_ENTRY_REQUEST,
@@ -143,7 +144,7 @@ export const selectUnpublishedEntryByParentSlug = (state, collection, slug) => {
   if (!state.get('entities')) return null;
   return state
     .get('entities')
-    .filter((v, k) => k.includes(collection))
+    .filter((v, k) => startsWith(k, `${collection}.`))
     .find(entry => entry.getIn(['metaData', 'parentSlug']) === slug);
 };
 
@@ -151,7 +152,7 @@ export const selectUnpublishedSlugEntriesByCollection = (state, collection) => {
   if (!state.get('entities')) return null;
   return state
     .get('entities')
-    .filter((v, k) => k.includes(collection))
+    .filter((v, k) => startsWith(k, `${collection}.`))
     .map(entry => entry.get('slug'))
     .valueSeq();
 };

--- a/packages/netlify-cms-core/src/reducers/editorialWorkflow.js
+++ b/packages/netlify-cms-core/src/reducers/editorialWorkflow.js
@@ -83,11 +83,21 @@ const unpublishedEntries = (state = Map(), action) => {
 
     case UNPUBLISHED_ENTRY_PERSIST_SUCCESS:
       // Update Optimistically
-      return state.deleteIn([
-        'entities',
-        `${action.payload.collection}.${action.payload.entry.get('slug')}`,
-        'isPersisting',
-      ]);
+      return state.withMutations(map => {
+        if (action.payload.entry.get('slug') != action.payload.slug) {
+          // Slug changed, delete old slug entities
+          map.deleteIn([
+            'entities',
+            `${action.payload.collection}.${action.payload.entry.get('slug')}`,
+          ]);
+        } else {
+          map.deleteIn([
+            'entities',
+            `${action.payload.collection}.${action.payload.entry.get('slug')}`,
+            'isPersisting',
+          ]);
+        }
+      });
 
     case UNPUBLISHED_ENTRY_STATUS_CHANGE_REQUEST:
       // Update Optimistically

--- a/packages/netlify-cms-core/src/reducers/editorialWorkflow.js
+++ b/packages/netlify-cms-core/src/reducers/editorialWorkflow.js
@@ -140,4 +140,13 @@ export const selectUnpublishedEntriesByStatus = (state, status) => {
     .valueSeq();
 };
 
+export const selectUnpublishedSlugEntriesByCollection = (state, collection) => {
+  if (!state.get('entities')) return null;
+  return state
+    .get('entities')
+    .filter((v, k) => k.includes(collection))
+    .map(entry => entry.get('slug'))
+    .valueSeq();
+};
+
 export default unpublishedEntries;

--- a/packages/netlify-cms-core/src/reducers/entries.js
+++ b/packages/netlify-cms-core/src/reducers/entries.js
@@ -104,8 +104,11 @@ const entries = (state = Map({ entities: Map(), pages: Map() }), action) => {
 export const selectEntry = (state, collection, slug) =>
   state.getIn(['entities', `${collection}.${slug}`]);
 
+export const selectSlugEntries = (state, collection) =>
+  state.getIn(['pages', collection, 'ids'], List())
+
 export const selectEntries = (state, collection) => {
-  const slugs = state.getIn(['pages', collection, 'ids']);
+  const slugs = selectSlugEntries(state, collection);
   return slugs && slugs.map(slug => selectEntry(state, collection, slug));
 };
 

--- a/packages/netlify-cms-core/src/reducers/entries.js
+++ b/packages/netlify-cms-core/src/reducers/entries.js
@@ -105,7 +105,7 @@ export const selectEntry = (state, collection, slug) =>
   state.getIn(['entities', `${collection}.${slug}`]);
 
 export const selectSlugEntries = (state, collection) =>
-  state.getIn(['pages', collection, 'ids'], List())
+  state.getIn(['pages', collection, 'ids'], List());
 
 export const selectEntries = (state, collection) => {
   const slugs = selectSlugEntries(state, collection);

--- a/packages/netlify-cms-core/src/reducers/entryDraft.js
+++ b/packages/netlify-cms-core/src/reducers/entryDraft.js
@@ -57,7 +57,9 @@ const entryDraftReducer = (state = Map(), action) => {
       return state.withMutations(state => {
         state.setIn(['entry', 'data', action.payload.field], action.payload.value);
         state.mergeDeepIn(['fieldsMetaData'], fromJS(action.payload.metadata));
-        state.set('hasChanged', true);
+        if (action.payload.hasChanged) {
+          state.set('hasChanged', true);
+        }
       });
 
     case DRAFT_VALIDATION_ERRORS:
@@ -86,10 +88,9 @@ const entryDraftReducer = (state = Map(), action) => {
       return state.withMutations(state => {
         state.deleteIn(['entry', 'isPersisting']);
         state.set('hasChanged', false);
-        if (state.getIn(['entry', 'slug']) != action.payload.slug) {
+        if (state.getIn(['entry', 'slug']) !== action.payload.slug) {
           state.setIn(['entry', 'slug'], action.payload.slug);
         }
-        state.deleteIn(['entry', 'data', action.payload.slugField]);
       });
 
     case ENTRY_DELETE_SUCCESS:

--- a/packages/netlify-cms-core/src/reducers/entryDraft.js
+++ b/packages/netlify-cms-core/src/reducers/entryDraft.js
@@ -86,9 +86,10 @@ const entryDraftReducer = (state = Map(), action) => {
       return state.withMutations(state => {
         state.deleteIn(['entry', 'isPersisting']);
         state.set('hasChanged', false);
-        if (!state.getIn(['entry', 'slug'])) {
+        if (state.getIn(['entry', 'slug']) != action.payload.slug) {
           state.setIn(['entry', 'slug'], action.payload.slug);
         }
+        state.deleteIn(['entry', 'data', action.payload.slugField]);
       });
 
     case ENTRY_DELETE_SUCCESS:

--- a/packages/netlify-cms-core/src/reducers/index.js
+++ b/packages/netlify-cms-core/src/reducers/index.js
@@ -62,7 +62,10 @@ export const selectUnpublishedEntriesByStatus = (state, status) =>
   fromEditorialWorkflow.selectUnpublishedEntriesByStatus(state.editorialWorkflow, status);
 
 export const selectUnpublishedSlugEntriesByCollection = (state, collection) =>
-  fromEditorialWorkflow.selectUnpublishedSlugEntriesByCollection(state.editorialWorkflow, collection);
+  fromEditorialWorkflow.selectUnpublishedSlugEntriesByCollection(
+    state.editorialWorkflow,
+    collection,
+  );
 
 export const selectIntegration = (state, collection, hook) =>
   fromIntegrations.selectIntegration(state.integrations, collection, hook);

--- a/packages/netlify-cms-core/src/reducers/index.js
+++ b/packages/netlify-cms-core/src/reducers/index.js
@@ -58,6 +58,13 @@ export const selectDeployPreview = (state, collection, slug) =>
 export const selectUnpublishedEntry = (state, collection, slug) =>
   fromEditorialWorkflow.selectUnpublishedEntry(state.editorialWorkflow, collection, slug);
 
+export const selectUnpublishedEntryByParentSlug = (state, collection, slug) =>
+  fromEditorialWorkflow.selectUnpublishedEntryByParentSlug(
+    state.editorialWorkflow,
+    collection,
+    slug,
+  );
+
 export const selectUnpublishedEntriesByStatus = (state, status) =>
   fromEditorialWorkflow.selectUnpublishedEntriesByStatus(state.editorialWorkflow, status);
 

--- a/packages/netlify-cms-core/src/reducers/index.js
+++ b/packages/netlify-cms-core/src/reducers/index.js
@@ -39,6 +39,9 @@ export const selectEntry = (state, collection, slug) =>
 export const selectEntries = (state, collection) =>
   fromEntries.selectEntries(state.entries, collection);
 
+export const selectSlugEntries = (state, collection) =>
+  fromEntries.selectSlugEntries(state.entries, collection);
+
 export const selectSearchedEntries = state => {
   const searchItems = state.search.get('entryIds');
   return (
@@ -57,6 +60,9 @@ export const selectUnpublishedEntry = (state, collection, slug) =>
 
 export const selectUnpublishedEntriesByStatus = (state, status) =>
   fromEditorialWorkflow.selectUnpublishedEntriesByStatus(state.editorialWorkflow, status);
+
+export const selectUnpublishedSlugEntriesByCollection = (state, collection) =>
+  fromEditorialWorkflow.selectUnpublishedSlugEntriesByCollection(state.editorialWorkflow, collection);
 
 export const selectIntegration = (state, collection, hook) =>
   fromIntegrations.selectIntegration(state.integrations, collection, hook);

--- a/packages/netlify-cms-core/src/reducers/index.js
+++ b/packages/netlify-cms-core/src/reducers/index.js
@@ -74,6 +74,12 @@ export const selectUnpublishedSlugEntriesByCollection = (state, collection) =>
     collection,
   );
 
+export const selectSlugs = (state, collection) => {
+  const unpublishedSlugs = selectUnpublishedSlugEntriesByCollection(state, collection);
+  const publishedSlugs = selectSlugEntries(state, collection);
+  return unpublishedSlugs ? publishedSlugs.concat(unpublishedSlugs) : publishedSlugs;
+};
+
 export const selectIntegration = (state, collection, hook) =>
   fromIntegrations.selectIntegration(state.integrations, collection, hook);
 

--- a/website/content/docs/beta-features.md
+++ b/website/content/docs/beta-features.md
@@ -86,6 +86,27 @@ sections:
       - images/image06.png
 ```
 
+## Slug Customization
+This feature makes it possible to edit slug entries. To enable this feature, add a config collection setting `slug_field` with the value pointing to the name of a field widget preferable a `string` widget, this widget will be used as the slug field.
+
+The value of the slug field is not saved in the frontmatter. The slug value is used internally by the CMS for entry navigation, to generate entry filename, etc.
+And If there is a slug change for any published or unpublished entry, a new slug entry is created, and the old slug entry is deleted.
+
+### Example Configuration
+```yaml
+collections:
+  - name: "blog"
+    label: "Blog"
+    folder: "content/blog"
+    create: true
+    slug_field: 'slug'
+    slug: "{{year}}-{{month}}-{{day}}-{{slug}}"
+    fields:
+      - { label: "Title", name: "title", widget: "string" }
+      - { label: "Slug", name: "slug", widget: "string" }
+      - { label: 'Body', name: 'body', widget: 'markdown' }
+```
+
 ## Custom Mount Element
 Netlify CMS always creates its own DOM element for mounting the application, which means it always takes over the entire page, and is generally inflexible if you're trying to do something creative, like injecting it into a shared context.
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines.

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first two fields are mandatory:
-->

**Summary**
Closes   #1164  #445 

Picks up where #1239 left off, but instead of throwing an error for duplicate slug, it tries to generate a unique slug by append a number just like the way WordPress does it. For example assuming we already have a slug entry `title` and a sanitize_replacement option value as `-` trying to create  another entry with slug string `title` would generate a slug `title-1` , `title-2` and so on.

To enable slug customization, add a config collection setting `slug_field` with value pointing to the name of the widget field preferrable a  `string` widget. A couple of things to note regarding the slug field behaviour. On new entry, once the identifier field looses focus, if the slug field is blank, the normal automatic slug string is generated and set as value of the slug field. Also when the slug field looses focus, the input value is sanitized immediately and value updated. The slug field value is not saved in frontmatter.
So if there is a slug change for any published or unpublished entry, a new entry is created using the new slug and the old slug entry is deleted.

Tested changes with the `test-repo`, ` github`,`gitlab` and `bitbucket`  backend.

<!--
Explain the **motivation** for making this change.
What existing problem does the pull request solve?
-->

<!--
Demonstrate the code is solid.
Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.
-->

