### PR TITLE
fix(netlify-cms-backend-github): Fix PR branchname to be prepended with collection name

### DIFF
--- a/packages/netlify-cms-backend-github/src/implementation.js
+++ b/packages/netlify-cms-backend-github/src/implementation.js
@@ -210,7 +210,7 @@ export default class GitHub {
   }
 
   unpublishedEntry(collection, slug) {
-    return this.api.readUnpublishedBranchFile(slug).then(data => {
+    return this.api.readUnpublishedBranchFile(slug, collection).then(data => {
       if (!data) return null;
       return {
         slug,


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines.

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first two fields are mandatory:
-->

**Summary**
Fixes https://github.com/netlify/netlify-cms/issues/1933 and https://github.com/netlify/netlify-cms/issues/1396.

The GitHub branch name formed was of the form `cms/slug`. This PR makes the branch name `cms/collectionName-slug`. This allows to have multiple PRs open when there are two files of the same name, for example, `a/intro` and `b/intro`. Previously, the branch names would be `cms/intro`, making it impossible to edit both files at once. Now, the branch names will be `cms/a-intro` and `cms/b-intro`.

**Note**:
To avoid making the new branch name scheme a breaking change, the branch names created will be of the new form, but branch names of both schemes will be read to ensure backwards compatibility.

**Test plan**

Ran a manual test plan. Used it with my own config and back-end and confirmed the editorial process works as it should.