### PR TITLE
Fixup mimetype for svgs returned from gitlab api

### DIFF
--- a/packages/netlify-cms-backend-gitlab/src/implementation.js
+++ b/packages/netlify-cms-backend-gitlab/src/implementation.js
@@ -152,6 +152,13 @@ export default class GitLab {
             sem.take(() =>
               this.api
                 .readFile(path, id, { parseText: false })
+                .then(blob => {
+                  // svgs are returned with mimetype "text/plain" by gitlab
+                  if (blob.type === 'text/plain' && name.match(/\.svg$/i)) {
+                    return new window.Blob([blob], { type: 'image/svg+xml' });
+                  }
+                  return blob;
+                })
                 .then(resolve, reject)
                 .finally(() => sem.leave()),
             ),


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines.

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first two fields are mandatory:
-->

**Summary**

If the gitlab api returns `text/plain` and the media items name ends in `.svg` we pin the mime type to `image/svg+xml`.

Closes #1945 

**Test plan**

1. Setup a project using the gitlab backend
1. Go to media library
1. Upload an svg
1. Clear indexed db and reload the page (not sure if that is necessary)

Behavior before: The svg shows as a broken image
Behavior after: The image shows a preview