### PR TITLE
Fix broken image previews for non-image media

### DIFF
--- a/packages/netlify-cms-core/src/components/MediaLibrary/MediaLibraryCardGrid.js
+++ b/packages/netlify-cms-core/src/components/MediaLibrary/MediaLibraryCardGrid.js
@@ -46,7 +46,7 @@ const MediaLibraryCardGrid = ({
           width={cardWidth}
           margin={cardMargin}
           isPrivate={isPrivate}
-          displayURL={getDisplayURL(file)}
+          displayURL={file.isViewableImage && getDisplayURL(file)}
         />
       ))}
       {!canLoadMore ? null : <Waypoint onEnter={onLoadMore} />}


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines.

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first two fields are mandatory:
-->

**Summary**

<!--
Explain the **motivation** for making this change.
What existing problem does the pull request solve?
-->

Fixes broken images displaying for non-image media in media library.

I think this got lost in [83d2adc0befccc04ec39c680591894a0e995d5b1](https://github.com/netlify/netlify-cms/commit/83d2adc0befccc04ec39c680591894a0e995d5b1#diff-e7761d31229d6dc3c50cb2b99a56332a)

This also saves a bunch of API requests on initial page load as the raw content for the affected files wont be fetched.

**Test plan**

1. Open media library
1. Upload non-image file, e.g. a pdf

<!--
Demonstrate the code is solid.
Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.
-->
