### PR TITLE
Document test repo backend

### DIFF
--- a/website/content/docs/authentication-backends.md
+++ b/website/content/docs/authentication-backends.md
@@ -126,6 +126,16 @@ To enable it:
       repo: owner-name/repo-name # Path to your Bitbucket repository
     ```
 
+## Test Repo Backend
+You can use the `test-repo` backend to try out Netlify CMS without connecting to a Git repo. With this backend, you can write and publish content normally, but nothing will be saved. Any changes will disapear when you reload the page. This backend powers the Netlify CMS [demo site](https://cms-demo.netlify.com/).
+
+To enable this backend, add the following line to your Netlify CMS `config.yml` file:
+
+```
+backend:
+  name: test-repo
+```
+
 ## External OAuth Clients
 
 If you would like to facilitate your own OAuth authentication rather than use Netlify's service or implicit grant, you can use one of the community-maintained projects below. Feel free to [submit a pull request](https://github.com/netlify/netlify-cms/blob/master/CONTRIBUTING.md) if you'd like to add yours!

--- a/website/content/docs/authentication-backends.md
+++ b/website/content/docs/authentication-backends.md
@@ -127,7 +127,7 @@ To enable it:
     ```
 
 ## Test Repo Backend
-You can use the `test-repo` backend to try out Netlify CMS without connecting to a Git repo. With this backend, you can write and publish content normally, but nothing will be saved. Any changes will disapear when you reload the page. This backend powers the Netlify CMS [demo site](https://cms-demo.netlify.com/).
+You can use the `test-repo` backend to try out Netlify CMS without connecting to a Git repo. With this backend, you can write and publish content normally, but any changes will disapear when you reload the page. This backend powers the Netlify CMS [demo site](https://cms-demo.netlify.com/).
 
 To enable this backend, add the following lines to your Netlify CMS `config.yml` file:
 

--- a/website/content/docs/authentication-backends.md
+++ b/website/content/docs/authentication-backends.md
@@ -129,7 +129,7 @@ To enable it:
 ## Test Repo Backend
 You can use the `test-repo` backend to try out Netlify CMS without connecting to a Git repo. With this backend, you can write and publish content normally, but nothing will be saved. Any changes will disapear when you reload the page. This backend powers the Netlify CMS [demo site](https://cms-demo.netlify.com/).
 
-To enable this backend, add the following line to your Netlify CMS `config.yml` file:
+To enable this backend, add the following lines to your Netlify CMS `config.yml` file:
 
 ```
 backend:


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines.

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first two fields are mandatory:
-->

**Summary**
Netlify CMS supports a `test-repo` backend that can be used for trying out the CMS without pushing any changes to Git. This PR adds documentation for this feature. More info: https://github.com/netlify/netlify-cms/issues/1085#issuecomment-444908882

The demo site also includes [default content](https://github.com/netlify/netlify-cms/blob/88bf2872212779b4a23ea4e1a3e0213f70a8eaa9/dev-test/index.html#L8), but I didn't document this feature because `window.repoFiles._posts` looks like a private API.

**Test plan**
I followed these instructions on a local Netlify CMS site, made some changes, and ensured that they weren't pushed to git.

**A picture of a cute animal (not mandatory but encouraged)**
![dog](https://user-images.githubusercontent.com/1299370/49669380-371f3880-fa2f-11e8-807d-18613373b4fa.jpg)
