### PR TITLE
Display optional status in widget labels

### DIFF
--- a/packages/netlify-cms-core/src/components/Editor/EditorControlPane/EditorControl.js
+++ b/packages/netlify-cms-core/src/components/Editor/EditorControlPane/EditorControl.js
@@ -201,7 +201,7 @@ class EditorControl extends React.Component {
           )}
           htmlFor={this.uniqueFieldId}
         >
-          {`${field.get('label', field.get('name'))}${isFieldOptional ? ' [optional]' : ''}`}
+          {`${field.get('label', field.get('name'))}${isFieldOptional ? ' (optional)' : ''}`}
           </label>
         <Widget
           classNameWrapper={cx(

--- a/packages/netlify-cms-core/src/components/Editor/EditorControlPane/EditorControl.js
+++ b/packages/netlify-cms-core/src/components/Editor/EditorControlPane/EditorControl.js
@@ -178,6 +178,7 @@ class EditorControl extends React.Component {
     const widget = resolveWidget(widgetName);
     const fieldName = field.get('name');
     const fieldHint = field.get('hint');
+    const isFieldOptional = field.get('required') === false;
     const metadata = fieldsMetaData && fieldsMetaData.get(fieldName);
     const errors = fieldsErrors && fieldsErrors.get(fieldName);
     return (
@@ -200,8 +201,8 @@ class EditorControl extends React.Component {
           )}
           htmlFor={this.uniqueFieldId}
         >
-          {field.get('label', field.get('name'))}
-        </label>
+          {`${field.get('label', field.get('name'))}${isFieldOptional ? ' [optional]' : ''}`}
+          </label>
         <Widget
           classNameWrapper={cx(
             styles.widget,

--- a/packages/netlify-cms-core/src/components/Editor/EditorControlPane/EditorControl.js
+++ b/packages/netlify-cms-core/src/components/Editor/EditorControlPane/EditorControl.js
@@ -202,7 +202,7 @@ class EditorControl extends React.Component {
           htmlFor={this.uniqueFieldId}
         >
           {`${field.get('label', field.get('name'))}${isFieldOptional ? ' (optional)' : ''}`}
-          </label>
+        </label>
         <Widget
           classNameWrapper={cx(
             styles.widget,


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines.

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first two fields are mandatory:
-->

**Summary**

Widgets input is required by default, but if one is made optional there is no visual indication. This PR solves this problem in the most basic way possible I think. It simply adds `[optional]` as a postfix to the label.

I picked square brackets because I think it looks better with the interface 😄 

<!--
Explain the **motivation** for making this change.
What existing problem does the pull request solve?
-->

**Test plan**

<!--
Demonstrate the code is solid.
Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.
-->

<img width="979" alt="screenshot 2018-12-11 19 22 52" src="https://user-images.githubusercontent.com/1193520/49821681-598cbb00-fd7b-11e8-94d6-38c9b3cfb8da.png">
