### PR TITLE
Add example of Netlify CMS website

### DIFF
--- a/website/content/docs/examples.md
+++ b/website/content/docs/examples.md
@@ -8,6 +8,7 @@ Do you have a great, open source example? Submit a pull request to this page!
 
 Example | Tools | Type | Source | More info |
 --- | --- | --- | --- | ---
+[Gatsby & Netlify CMS Meetup Group Template](https://github.com/robertcoopercode/gatsby-netlify-cms) | Gatsby | demo | [robertcoopercode/gatsby-netlify-cms](https://github.com/robertcoopercode/gatsby-netlify-cms) | [blog post](https://blog.logrocket.com/gatsby-netlify-cms-a-perfect-pairing-d50d59d16f67)
 [This Developing Journey](https://briandouglas.me) | middleman | blog | [bdougie/blog](https://github.com/bdougie/blog) | [blog post](https://www.netlify.com/blog/2017/04/20/creating-a-blog-with-middleman-and-netlify-cms/)
 [JAMstack Recipes](https://jamstack-cms.netlify.com) | Hugo, Azure | demo | [hlaueriksson/jamstack-cms](https://github.com/hlaueriksson/jamstack-cms) | [blog post](http://conductofcode.io/post/managing-content-for-a-jamstack-site-with-netlify-cms/)
 [The ragasirtahk Blog](https://www.ragasirtahk.tk/) | Hugo | blog | [ragasirtahk/the-ragasirtahk-blog](https://github.com/ragasirtahk/the-ragasirtahk-blog) | [blog post](https://www.ragasirtahk.tk/2018/01/setting-up-netlify-cms-on-hugo/)
@@ -15,3 +16,4 @@ Example | Tools | Type | Source | More info |
 [Forest Garden Wales](https://www.forestgarden.wales/) | Hugo | blog | [forestgardenwales/forestgarden.wales](https://github.com/forestgardenwales/forestgarden.wales) | [blog post](https://www.forestgarden.wales/blog/now-using-netlify-cms/)
 [Jekyll Demo](https://jekyll-netlifycms.netlify.com/) | Jekyll, Gulp | demo | [NickStees/jekyll-cms](https://github.com/NickStees/jekyll-cms) | [read me](https://github.com/NickStees/jekyll-cms)
 [Eleventy Starter Project](https://eleventy-netlify-boilerplate.netlify.com/) | Eleventy | demo | [danurbanowicz/eleventy-netlify-boilerplate](https://github.com/danurbanowicz/eleventy-netlify-boilerplate) | [read me](https://github.com/danurbanowicz/eleventy-netlify-boilerplate)
+


### PR DESCRIPTION
**Summary**

I've added an example of an [open source website](https://gatsby-netlify-cms-example.netlify.com/) that is built using Netlify CMS.

**A picture of a cute animal (not mandatory but encouraged)**
![1b270bf09bea7706fe6d115666805620](https://user-images.githubusercontent.com/16786990/49845195-b98f5b80-fd93-11e8-8ef3-5d3432593105.jpg)
