### PR TITLE
fix(netlify-cms-core): workflow status update

### DIFF
--- a/packages/netlify-cms-core/src/actions/editorialWorkflow.js
+++ b/packages/netlify-cms-core/src/actions/editorialWorkflow.js
@@ -366,6 +366,7 @@ export function persistUnpublishedEntry(collection, existingUnpublishedEntry) {
 
 export function updateUnpublishedEntryStatus(collection, slug, oldStatus, newStatus) {
   return (dispatch, getState) => {
+    if (oldStatus === newStatus) return;
     const state = getState();
     const backend = currentBackend(state.config);
     const transactionID = uuid();


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines.

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first two fields are mandatory:
-->

**Summary**
A simple fix to prevent unnecessary entry status update.
Currently on the workflow flow page when an entry is dragged and dropped back in the inital column and on the editor page clicking on the entry current status in the `set status` dropdown triggers the `updateUnpublishedEntryStatus` action.
<!--
Explain the **motivation** for making this change.
What existing problem does the pull request solve?
-->

<!--
Demonstrate the code is solid.
Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.
-->
