### PR TITLE
Fix extra leading replacement generated on slugs

### DIFF
--- a/packages/netlify-cms-core/src/lib/__tests__/urlHelper.spec.js
+++ b/packages/netlify-cms-core/src/lib/__tests__/urlHelper.spec.js
@@ -105,6 +105,10 @@ describe('sanitizeSlug', () => {
     expect(sanitizeSlug('test   test   ')).toEqual('test-test');
   });
 
+  it('removes leading replacemenets', () => {
+    expect(sanitizeSlug('"test"    test')).toEqual('test-test');
+  });
+
   it('uses alternate replacements', () => {
     expect(sanitizeSlug('test   test   ', Map({ sanitize_replacement: '_' }))).toEqual('test_test');
   });

--- a/packages/netlify-cms-core/src/lib/__tests__/urlHelper.spec.js
+++ b/packages/netlify-cms-core/src/lib/__tests__/urlHelper.spec.js
@@ -101,11 +101,11 @@ describe('sanitizeSlug', () => {
     expect(sanitizeSlug('test   test')).toEqual('test-test');
   });
 
-  it('removes trailing replacemenets', () => {
+  it('removes trailing replacements', () => {
     expect(sanitizeSlug('test   test   ')).toEqual('test-test');
   });
 
-  it('removes leading replacemenets', () => {
+  it('removes leading replacements', () => {
     expect(sanitizeSlug('"test"    test')).toEqual('test-test');
   });
 

--- a/packages/netlify-cms-core/src/lib/urlHelper.js
+++ b/packages/netlify-cms-core/src/lib/urlHelper.js
@@ -86,8 +86,11 @@ export function sanitizeSlug(str, options = Map()) {
   // Remove any doubled or trailing replacement characters (that were added in the sanitizers).
   const doubleReplacement = new RegExp(`(?:${escapeRegExp(replacement)})+`, 'g');
   const trailingReplacment = new RegExp(`${escapeRegExp(replacement)}$`);
+  const leadingReplacment = new RegExp(`^${escapeRegExp(replacement)}`);
+
   const normalizedSlug = sanitizedSlug
     .replace(doubleReplacement, replacement)
+    .replace(leadingReplacment, '')
     .replace(trailingReplacment, '');
 
   return normalizedSlug;

--- a/packages/netlify-cms-core/src/lib/urlHelper.js
+++ b/packages/netlify-cms-core/src/lib/urlHelper.js
@@ -83,7 +83,7 @@ export function sanitizeSlug(str, options = Map()) {
     partialRight(sanitizeFilename, { replacement }),
   ])(str);
 
-  // Remove any doubled or trailing replacement characters (that were added in the sanitizers).
+  // Remove any doubled or leading/trailing replacement characters (that were added in the sanitizers).
   const doubleReplacement = new RegExp(`(?:${escapeRegExp(replacement)})+`, 'g');
   const trailingReplacment = new RegExp(`${escapeRegExp(replacement)}$`);
   const leadingReplacment = new RegExp(`^${escapeRegExp(replacement)}`);


### PR DESCRIPTION
Fixes #1963.

When title of a collection (i.e. posts) starts with an escapable character (as described in the issue), and the `slug` was configured to start with the sanitized name, a replacement separator was being placed at the beginning.

```yaml
collections:
  - name: "post"
    ...
    slug: "{{slug}}"
```

```markup
'"post" title'
// should produce -> "post-title", not "-post-title"
```

I have added the same kind of replacement that is being made at the end of the slug sanitization. And to be clearer, in different RegExps.

I found this issue thanks to `npx good-first-issue netlify` and [Tierney Cyren](https://twitter.com/bitandbang/status/1066839970428653570).

**Test plan**

Added companion test.

**A picture of a cute animal (not mandatory but encouraged)**

Look at this [happy fellah](https://imgur.com/t/aww/C1dRBhG), just like me after submitting my first PR to netlify-cms 😅.
