### PR TITLE
Allow authentication with github using a query parameter instead of header

### DIFF
--- a/packages/netlify-cms-backend-github/src/API.js
+++ b/packages/netlify-cms-backend-github/src/API.js
@@ -15,6 +15,7 @@ export default class API {
     this.repoURL = `/repos/${this.repo}`;
     this.merge_method = config.squash_merges ? 'squash' : 'merge';
     this.initialWorkflowStatus = config.initialWorkflowStatus;
+    this.accessTokenParam = config.access_token_param || false;
   }
 
   user() {
@@ -57,6 +58,9 @@ export default class API {
   urlFor(path, options) {
     const cacheBuster = new Date().getTime();
     const params = [`ts=${cacheBuster}`];
+    if(this.accessTokenParam&&this.token){
+      params.push(`access_token=${this.token}`);
+    }
     if (options.params) {
       for (const key in options.params) {
         params.push(`${key}=${encodeURIComponent(options.params[key])}`);

--- a/packages/netlify-cms-backend-github/src/implementation.js
+++ b/packages/netlify-cms-backend-github/src/implementation.js
@@ -26,6 +26,7 @@ export default class GitHub {
     this.api_root = config.getIn(['backend', 'api_root'], 'https://api.github.com');
     this.token = '';
     this.squash_merges = config.getIn(['backend', 'squash_merges']);
+    this.access_token_param = config.getIn(['backend', 'access_token_param']);
   }
 
   authComponent() {
@@ -45,6 +46,7 @@ export default class GitHub {
       api_root: this.api_root,
       squash_merges: this.squash_merges,
       initialWorkflowStatus: this.options.initialWorkflowStatus,
+      access_token_param: this.access_token_param,
     });
     const user = await this.api.user();
     const isCollab = await this.api.hasWriteAccess().catch(error => {


### PR DESCRIPTION
Fixes #1976

**Summary**

Allows you to authenticate with github using a query parameter instead of header. This is a workaround for a problem from Safari. Optional because of potential security concerns of having access tokens in urls.

**Test plan**
Login. Network requests for github now also include a access_token query parameter.
![image](https://user-images.githubusercontent.com/7012739/50497460-ad5ffb00-0a2f-11e9-8365-799c890647e8.png)


**A picture of a cute animal (not mandatory but encouraged)**
![](https://c1.staticflickr.com/8/7765/17504565059_abdacbb015_h.jpg)