### PR TITLE
Update configSchema.js to allow arrays for frontmatter_delimiter

### DIFF
--- a/packages/netlify-cms-core/src/constants/configSchema.js
+++ b/packages/netlify-cms-core/src/constants/configSchema.js
@@ -96,7 +96,7 @@ const getConfigSchema = () => ({
           },
           format: { type: 'string', enum: Object.keys(formatExtensions) },
           extension: { type: 'string' },
-          frontmatter_delimiter: { type: 'string' },
+          frontmatter_delimiter: { type: ['string', 'array'] },
           fields: fieldsConfig,
         },
         required: ['name', 'label'],

--- a/packages/netlify-cms-core/src/constants/configSchema.js
+++ b/packages/netlify-cms-core/src/constants/configSchema.js
@@ -96,7 +96,14 @@ const getConfigSchema = () => ({
           },
           format: { type: 'string', enum: Object.keys(formatExtensions) },
           extension: { type: 'string' },
-          frontmatter_delimiter: { type: ['string', 'array'] },
+          frontmatter_delimiter: {
+            type: ['string', 'array'],
+            minItems: 2,
+            maxItems: 2,
+            items: {
+              type: 'string',
+            },
+          },
           fields: fieldsConfig,
         },
         required: ['name', 'label'],


### PR DESCRIPTION
This change aims to resolve #1996 in which array values for `frontmatter_delimiter` throw an error `'frontmatter_delimiter' should be string`

**Summary**

See #1996 for details. The schema validator appears not to have been updated in PRs #1064 & #1094 to allow for arrays per the documentation.

**Test plan**

Following development steps on CONTRIBUTING.md


