### PR TITLE
Examples: Add Jekyll feat Alembic theme starter

### DIFF
--- a/website/content/docs/examples.md
+++ b/website/content/docs/examples.md
@@ -15,6 +15,6 @@ Example | Tools | Type | Source | More info |
 [Bael](https://bael-theme.jake101.com/) | Vue, Nuxt | blog | [jake-101/bael-template](https://github.com/jake-101/bael-template) | [blog post](https://bael-theme.jake101.com/blog/2018-06-19-top-10-reasons-why)
 [Forest Garden Wales](https://www.forestgarden.wales/) | Hugo | blog | [forestgardenwales/forestgarden.wales](https://github.com/forestgardenwales/forestgarden.wales) | [blog post](https://www.forestgarden.wales/blog/now-using-netlify-cms/)
 [Jekyll Demo](https://jekyll-netlifycms.netlify.com/) | Jekyll, Gulp | demo | [NickStees/jekyll-cms](https://github.com/NickStees/jekyll-cms) | [read me](https://github.com/NickStees/jekyll-cms)
-[Jekyll feat Alembic theme Demo](https://alembic-kit-demo.netlify.com/) | Jekyll | demo | [DavidDarnes/alembic-netlifycms-kit](https://github.com/daviddarnes/alembic-netlifycms-kit) | [read me](https://github.com/daviddarnes/alembic-netlifycms-kit#starter-kit-for-alembic-with-netlify-cms)
+[Jekyll feat Alembic Theme Demo](https://alembic-kit-demo.netlify.com/) | Jekyll | demo | [DavidDarnes/alembic-netlifycms-kit](https://github.com/daviddarnes/alembic-netlifycms-kit) | [read me](https://github.com/daviddarnes/alembic-netlifycms-kit#starter-kit-for-alembic-with-netlify-cms)
 [Eleventy Starter Project](https://eleventy-netlify-boilerplate.netlify.com/) | Eleventy | demo | [danurbanowicz/eleventy-netlify-boilerplate](https://github.com/danurbanowicz/eleventy-netlify-boilerplate) | [read me](https://github.com/danurbanowicz/eleventy-netlify-boilerplate)
 

--- a/website/content/docs/examples.md
+++ b/website/content/docs/examples.md
@@ -15,5 +15,6 @@ Example | Tools | Type | Source | More info |
 [Bael](https://bael-theme.jake101.com/) | Vue, Nuxt | blog | [jake-101/bael-template](https://github.com/jake-101/bael-template) | [blog post](https://bael-theme.jake101.com/blog/2018-06-19-top-10-reasons-why)
 [Forest Garden Wales](https://www.forestgarden.wales/) | Hugo | blog | [forestgardenwales/forestgarden.wales](https://github.com/forestgardenwales/forestgarden.wales) | [blog post](https://www.forestgarden.wales/blog/now-using-netlify-cms/)
 [Jekyll Demo](https://jekyll-netlifycms.netlify.com/) | Jekyll, Gulp | demo | [NickStees/jekyll-cms](https://github.com/NickStees/jekyll-cms) | [read me](https://github.com/NickStees/jekyll-cms)
+[Jekyll feat Alembic theme Demo](https://alembic-kit-demo.netlify.com/) | Jekyll | demo | [DavidDarnes/alembic-netlifycms-kit](https://github.com/daviddarnes/alembic-netlifycms-kit) | [read me](https://github.com/daviddarnes/alembic-netlifycms-kit#starter-kit-for-alembic-with-netlify-cms)
 [Eleventy Starter Project](https://eleventy-netlify-boilerplate.netlify.com/) | Eleventy | demo | [danurbanowicz/eleventy-netlify-boilerplate](https://github.com/danurbanowicz/eleventy-netlify-boilerplate) | [read me](https://github.com/danurbanowicz/eleventy-netlify-boilerplate)
 


### PR DESCRIPTION
**Summary**
Add a new Jekyll example showing usage with a Jekyll theme gem, this example using Alembic Jekyll theme

**Test plan**
Click the read me, repo and demo links

[A picture of a cute animal (not mandatory but encouraged)](https://media1.tenor.com/images/3882df6ea78f476404d5dbb435f1d4a6/tenor.gif?itemid=3549289)
