### PR TITLE
feat(netlify-cms-core): expose loadEntry action to Widgets

### DIFF
--- a/packages/netlify-cms-core/src/components/Editor/EditorControlPane/EditorControl.js
+++ b/packages/netlify-cms-core/src/components/Editor/EditorControlPane/EditorControl.js
@@ -9,6 +9,7 @@ import { colors, colorsRaw, transitions, lengths, borders } from 'netlify-cms-ui
 import { resolveWidget, getEditorComponents } from 'Lib/registry';
 import { addAsset } from 'Actions/media';
 import { query, clearSearch } from 'Actions/search';
+import { loadEntry } from 'Actions/entries';
 import {
   openMediaLibrary,
   removeInsertedMedia,
@@ -143,6 +144,7 @@ class EditorControl extends React.Component {
     queryHits: PropTypes.oneOfType([PropTypes.array, PropTypes.object]),
     isFetching: PropTypes.bool,
     clearSearch: PropTypes.func.isRequired,
+    loadEntry: PropTypes.func.isRequired,
     t: PropTypes.func.isRequired,
   };
 
@@ -172,6 +174,7 @@ class EditorControl extends React.Component {
       queryHits,
       isFetching,
       clearSearch,
+      loadEntry,
       t,
     } = this.props;
     const widgetName = field.get('widget');
@@ -235,6 +238,7 @@ class EditorControl extends React.Component {
           ref={processControlRef && partial(processControlRef, fieldName)}
           editorControl={ConnectedEditorControl}
           query={query}
+          loadEntry={loadEntry}
           queryHits={queryHits}
           clearSearch={clearSearch}
           isFetching={isFetching}
@@ -264,6 +268,10 @@ const mapDispatchToProps = {
   removeInsertedMedia,
   addAsset,
   query,
+  loadEntry: (collectionName, slug) => (dispatch, getState) => {
+    const collection = getState().collections.get(collectionName);
+    return loadEntry(collection, slug)(dispatch, getState);
+  },
   clearSearch,
 };
 

--- a/packages/netlify-cms-core/src/components/Editor/EditorControlPane/Widget.js
+++ b/packages/netlify-cms-core/src/components/Editor/EditorControlPane/Widget.js
@@ -49,6 +49,7 @@ export default class Widget extends Component {
     queryHits: PropTypes.oneOfType([PropTypes.array, PropTypes.object]),
     editorControl: PropTypes.func.isRequired,
     uniqueFieldId: PropTypes.string.isRequired,
+    loadEntry: PropTypes.func.isRequired,
     t: PropTypes.func.isRequired,
   };
 
@@ -223,6 +224,7 @@ export default class Widget extends Component {
       queryHits,
       clearSearch,
       isFetching,
+      loadEntry,
       t,
     } = this.props;
     return React.createElement(controlComponent, {
@@ -255,6 +257,7 @@ export default class Widget extends Component {
       queryHits,
       clearSearch,
       isFetching,
+      loadEntry,
       t,
     });
   }


### PR DESCRIPTION
**Summary**

As [commented](https://github.com/netlify/netlify-cms/pull/1928#issuecomment-454897329) on #1928 this is an attempt to break down the work needed to implement that feature on the `"userland"`, this lifts the backwards-compatible requirement for implementing it.
As there are not many tests on that feature is hard to implement it right now as it changes the underlying implementation besides adding the new feature.

I intend to provide a third-party module for achieving what is described on the PR, including the custom UI, it's also a better way to test the API before committing to it on the `core` (:

**PS**: the contents of this PR are rebased and linted changes made originally on 974fc3d

**A picture of a cute animal (not mandatory but encouraged)**

![](https://media.giphy.com/media/qPuhFBQt8xLEY/giphy.gif)