### PR TITLE
Re-enable conversion of markdown URLs to links

### DIFF
--- a/packages/netlify-cms-widget-markdown/src/serializers/index.js
+++ b/packages/netlify-cms-widget-markdown/src/serializers/index.js
@@ -65,7 +65,6 @@ export const markdownToRemark = markdown => {
    */
   const parsed = unified()
     .use(markdownToRemarkPlugin, { fences: true, commonmark: true })
-    .use(markdownToRemarkRemoveTokenizers, { inlineTokenizers: ['url'] })
     .use(remarkAllowHtmlEntities)
     .parse(markdown);
 
@@ -80,16 +79,6 @@ export const markdownToRemark = markdown => {
 
   return result;
 };
-
-/**
- * Remove named tokenizers from the parser, effectively deactivating them.
- */
-function markdownToRemarkRemoveTokenizers({ inlineTokenizers }) {
-  inlineTokenizers &&
-    inlineTokenizers.forEach(tokenizer => {
-      delete this.Parser.prototype.inlineTokenizers[tokenizer];
-    });
-}
 
 /**
  * Serialize an MDAST to a Markdown string.


### PR DESCRIPTION
Closes #1004
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines.

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first two fields are mandatory:
-->

**Summary**

To remain consistent with static site generators the editor should
convert URLs into links. This change is just reversing the decision to
disable this feature.

<!--
Explain the **motivation** for making this change.
What existing problem does the pull request solve?
-->

**Test plan**

Ran `yarn test`, all tests passed.

Ran `yarn format`, no changes.

Screenshot:
<img width="741" alt="screen shot 2019-01-16 at 8 25 00 pm" src="https://user-images.githubusercontent.com/11466782/51291462-d9d2bb80-19cc-11e9-9402-99993aca6f8c.png">

<!--
Demonstrate the code is solid.
Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.
-->

**A picture of a cute animal (not mandatory but encouraged)**
![19227122_1041948219269792_1381527688761573376_n](https://user-images.githubusercontent.com/11466782/51291603-4a79d800-19cd-11e9-90fb-7d43abf39fa1.jpg)
My dogs Leia and Samson 🐶 