### PR TITLE
Add autolabel to production

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -32,7 +32,16 @@ const plugins = () => {
   ];
 
   if (isProduction) {
-    return [...defaultPlugins, ['emotion', { hoist: true }]];
+    return [
+      ...defaultPlugins,
+      [
+        'emotion',
+        {
+          hoist: true,
+          autoLabel: true,
+        },
+      ],
+    ];
   }
 
   if (isTest) {


### PR DESCRIPTION
**Summary**

I would like to modify the netlify CMS UI look and feel on a client by client basis by dropping a CSS file in my `admin/index.html` file.

React emotion computes hashed class names.

```
const brownStyles = css({ color: 'brown' }) // css-1q8eu9e
```

Adding `autoLabel: true` to the config automatically includes the label property to styles so that class names generated by css or styled include the name of the variable the result is assigned to.

```
const brownStyles = css({ color: 'brown' }) // css-1q8eu9e-brownStyles
```

With the label included in the class name I can tweak the Admin theme at my own discretion.

**Test plan**

Labeling the CSS class names shouldn't have any overhead or cause any issues to my knowledge?