### PR TITLE
Add config item to set base URL for UI when using media library

### DIFF
--- a/packages/netlify-cms-core/src/reducers/index.js
+++ b/packages/netlify-cms-core/src/reducers/index.js
@@ -61,6 +61,11 @@ export const getAsset = (state, path) => {
    * If an external media library is in use, just return the path.
    */
   if (state.mediaLibrary.get('externalLibrary')) {
+    const mediaLibraryConfig = state.config.get("media_library");
+    if(mediaLibraryConfig.get("output_filename_only") && mediaLibraryConfig.get("display_base_url"))
+    {
+      return mediaLibraryConfig.get("display_base_url") + path;
+    }
     return path;
   }
   return fromMedias.getAsset(state.config.get('public_folder'), state.medias, path);

--- a/packages/netlify-cms-core/src/reducers/index.js
+++ b/packages/netlify-cms-core/src/reducers/index.js
@@ -61,10 +61,12 @@ export const getAsset = (state, path) => {
    * If an external media library is in use, just return the path.
    */
   if (state.mediaLibrary.get('externalLibrary')) {
-    const mediaLibraryConfig = state.config.get("media_library");
-    if(mediaLibraryConfig.get("output_filename_only") && mediaLibraryConfig.get("display_base_url"))
-    {
-      return mediaLibraryConfig.get("display_base_url") + path;
+    const mediaLibraryConfig = state.config.get('media_library');
+    if (
+      mediaLibraryConfig.get('output_filename_only') &&
+      mediaLibraryConfig.get('display_base_url')
+    ) {
+      return mediaLibraryConfig.get('display_base_url') + path;
     }
     return path;
   }

--- a/packages/netlify-cms-core/src/reducers/index.js
+++ b/packages/netlify-cms-core/src/reducers/index.js
@@ -64,7 +64,8 @@ export const getAsset = (state, path) => {
     const mediaLibraryConfig = state.config.get('media_library');
     if (
       mediaLibraryConfig.get('output_filename_only') &&
-      mediaLibraryConfig.get('display_base_url')
+      mediaLibraryConfig.get('display_base_url') &&
+      !path.startsWith('http')
     ) {
       return mediaLibraryConfig.get('display_base_url') + path;
     }


### PR DESCRIPTION
Fixes #1934 

I am not 100% sure this is the right way to add this functionality, but it allows setting display_base_url to be used when output_filename_only=true, so that the UI can render images from external media libraries. 