### PR TITLE
Passing default_transformation options while showing media library

### DIFF
--- a/packages/netlify-cms-media-library-cloudinary/src/__tests__/index.spec.js
+++ b/packages/netlify-cms-media-library-cloudinary/src/__tests__/index.spec.js
@@ -197,7 +197,7 @@ Object {
     it('calls cloudinary instance show method with default options', async () => {
       const integration = await cloudinary.init();
       integration.show();
-      expect(mediaLibrary.show).toHaveBeenCalledWith(defaultOptions);
+      expect(mediaLibrary.show).toHaveBeenCalledWith(defaultOptions.config);
     });
 
     it('accepts unknown configuration keys', async () => {
@@ -209,7 +209,7 @@ Object {
       };
       const integration = await cloudinary.init();
       integration.show(showOptions);
-      expect(mediaLibrary.show).toHaveBeenCalledWith(showOptions);
+      expect(mediaLibrary.show).toHaveBeenCalledWith(showOptions.config);
     });
 
     it('receives global configuration for behavior only', async () => {
@@ -232,7 +232,7 @@ Object {
       };
       const integration = await cloudinary.init({ options });
       integration.show();
-      expect(mediaLibrary.show).toHaveBeenCalledWith(expectedOptions);
+      expect(mediaLibrary.show).toHaveBeenCalledWith(expectedOptions.config);
     });
 
     it('allows global/default configuration to be overridden', async () => {
@@ -243,7 +243,7 @@ Object {
       };
       const integration = await cloudinary.init();
       integration.show(showOptions);
-      expect(mediaLibrary.show).toHaveBeenCalledWith(showOptions);
+      expect(mediaLibrary.show).toHaveBeenCalledWith(showOptions.config);
     });
 
     it('enforces multiple: false if allowMultiple is false', async () => {
@@ -265,7 +265,7 @@ Object {
       };
       const integration = await cloudinary.init(options);
       integration.show(showOptions);
-      expect(mediaLibrary.show).toHaveBeenCalledWith(expectedOptions);
+      expect(mediaLibrary.show).toHaveBeenCalledWith(expectedOptions.config);
     });
   });
 

--- a/packages/netlify-cms-media-library-cloudinary/src/index.js
+++ b/packages/netlify-cms-media-library-cloudinary/src/index.js
@@ -74,7 +74,7 @@ async function init({ options = {}, handleInsert } = {}) {
       if (allowMultiple === false) {
         instanceConfig.multiple = false;
       }
-      return mediaLibrary.show({ ...cloudinaryBehaviorConfig, ...instanceConfig } );
+      return mediaLibrary.show({ ...cloudinaryBehaviorConfig, ...instanceConfig });
     },
     hide: () => mediaLibrary.hide(),
     enableStandalone: () => true,

--- a/packages/netlify-cms-media-library-cloudinary/src/index.js
+++ b/packages/netlify-cms-media-library-cloudinary/src/index.js
@@ -54,7 +54,7 @@ async function init({ options = {}, handleInsert } = {}) {
   const resolvedOptions = { ...defaultOptions, ...integrationOptions };
   const cloudinaryConfig = { ...defaultConfig, ...providedConfig, ...enforcedConfig };
   const cloudinaryBehaviorConfigKeys = ['default_transformations', 'max_files', 'multiple'];
-  const cloudinaryBehaviorConfig = pick(cloudinaryConfig, cloudinaryBehaviorConfigKeys);
+  const cloudinaryBehaviorConfig = pick(resolvedOptions, cloudinaryBehaviorConfigKeys);
 
   await loadScript('https://media-library.cloudinary.com/global/all.js');
 
@@ -74,7 +74,7 @@ async function init({ options = {}, handleInsert } = {}) {
       if (allowMultiple === false) {
         instanceConfig.multiple = false;
       }
-      return mediaLibrary.show({ config: { ...cloudinaryBehaviorConfig, ...instanceConfig } });
+      return mediaLibrary.show({ ...cloudinaryBehaviorConfig, ...instanceConfig } );
     },
     hide: () => mediaLibrary.hide(),
     enableStandalone: () => true,

--- a/packages/netlify-cms-media-library-cloudinary/src/index.js
+++ b/packages/netlify-cms-media-library-cloudinary/src/index.js
@@ -54,7 +54,7 @@ async function init({ options = {}, handleInsert } = {}) {
   const resolvedOptions = { ...defaultOptions, ...integrationOptions };
   const cloudinaryConfig = { ...defaultConfig, ...providedConfig, ...enforcedConfig };
   const cloudinaryBehaviorConfigKeys = ['default_transformations', 'max_files', 'multiple'];
-  const cloudinaryBehaviorConfig = pick(resolvedOptions, cloudinaryBehaviorConfigKeys);
+  const cloudinaryBehaviorConfig = pick(cloudinaryConfig, cloudinaryBehaviorConfigKeys);
 
   await loadScript('https://media-library.cloudinary.com/global/all.js');
 


### PR DESCRIPTION
**Summary**
This initializes the Cloudinary Media Library with default_transformations during the show() function invocation.

**Motivation**
default_transformation option wasn't passed when rendering the media library. As a result, transformations didn't work properly.
