### PR TITLE
Feature/#2048 number range validation

### DIFF
--- a/packages/netlify-cms-core/src/components/Editor/EditorControlPane/Widget.js
+++ b/packages/netlify-cms-core/src/components/Editor/EditorControlPane/Widget.js
@@ -90,9 +90,10 @@ export default class Widget extends Component {
   validate = (skipWrapped = false) => {
     const { field, value } = this.props;
     const errors = [];
-    const validations = field.get('widget') === 'number' ?
-      [this.validatePresence, this.validateRange] :
-      [this.validatePresence, this.validatePattern];
+    const validations =
+      field.get('widget') === 'number'
+        ? [this.validatePresence, this.validateRange]
+        : [this.validatePresence, this.validatePattern];
 
     validations.forEach(func => {
       const response = func(field, value);
@@ -120,7 +121,7 @@ export default class Widget extends Component {
     }
 
     switch (true) {
-      case (min !== false && max !== false && (value < min || value > max)):
+      case min !== false && max !== false && (value < min || value > max):
         error = {
           type: ValidationErrorTypes.RANGE,
           message: t('editor.editorControlPane.widget.range', {
@@ -130,7 +131,7 @@ export default class Widget extends Component {
           }),
         };
         break;
-      case (min !== false && value < min):
+      case min !== false && value < min:
         error = {
           type: ValidationErrorTypes.RANGE,
           message: t('editor.editorControlPane.widget.min', {
@@ -139,7 +140,7 @@ export default class Widget extends Component {
           }),
         };
         break;
-      case (max !== false && value > max):
+      case max !== false && value > max:
         error = {
           type: ValidationErrorTypes.RANGE,
           message: t('editor.editorControlPane.widget.max', {

--- a/packages/netlify-cms-core/src/components/Editor/EditorControlPane/Widget.js
+++ b/packages/netlify-cms-core/src/components/Editor/EditorControlPane/Widget.js
@@ -90,11 +90,7 @@ export default class Widget extends Component {
   validate = (skipWrapped = false) => {
     const { field, value } = this.props;
     const errors = [];
-    const validations =
-      field.get('widget') === 'number'
-        ? [this.validatePresence, this.validateRange]
-        : [this.validatePresence, this.validatePattern];
-
+    const validations = [this.validatePresence, this.validatePattern];
     validations.forEach(func => {
       const response = func(field, value);
       if (response.error) errors.push(response.error);
@@ -106,54 +102,6 @@ export default class Widget extends Component {
       if (wrappedError.error) errors.push(wrappedError.error);
     }
     this.props.onValidate(errors);
-  };
-
-  validateRange = (field, value) => {
-    const t = this.props.t;
-    const hasPattern = !!field.get('pattern', false);
-    const min = field.get('min', false);
-    const max = field.get('max', false);
-    let error;
-
-    // Pattern overrides min/max logic always:
-    if (hasPattern) {
-      return this.validatePattern(field, value);
-    }
-
-    switch (true) {
-      case min !== false && max !== false && (value < min || value > max):
-        error = {
-          type: ValidationErrorTypes.RANGE,
-          message: t('editor.editorControlPane.widget.range', {
-            fieldLabel: field.get('label', field.get('name')),
-            minValue: min,
-            maxValue: max,
-          }),
-        };
-        break;
-      case min !== false && value < min:
-        error = {
-          type: ValidationErrorTypes.RANGE,
-          message: t('editor.editorControlPane.widget.min', {
-            fieldLabel: field.get('label', field.get('name')),
-            minValue: min,
-          }),
-        };
-        break;
-      case max !== false && value > max:
-        error = {
-          type: ValidationErrorTypes.RANGE,
-          message: t('editor.editorControlPane.widget.max', {
-            fieldLabel: field.get('label', field.get('name')),
-            maxValue: max,
-          }),
-        };
-        break;
-      default:
-        error = false;
-    }
-
-    return { error };
   };
 
   validatePresence = (field, value) => {

--- a/packages/netlify-cms-core/src/components/Editor/EditorControlPane/Widget.js
+++ b/packages/netlify-cms-core/src/components/Editor/EditorControlPane/Widget.js
@@ -90,7 +90,10 @@ export default class Widget extends Component {
   validate = (skipWrapped = false) => {
     const { field, value } = this.props;
     const errors = [];
-    const validations = [this.validatePresence, this.validatePattern];
+    const validations = field.get('widget') === 'number' ?
+      [this.validatePresence, this.validateRange] :
+      [this.validatePresence, this.validatePattern];
+
     validations.forEach(func => {
       const response = func(field, value);
       if (response.error) errors.push(response.error);
@@ -102,6 +105,54 @@ export default class Widget extends Component {
       if (wrappedError.error) errors.push(wrappedError.error);
     }
     this.props.onValidate(errors);
+  };
+
+  validateRange = (field, value) => {
+    const t = this.props.t;
+    const hasPattern = !!field.get('pattern', false);
+    const min = field.get('min', false);
+    const max = field.get('max', false);
+    let error;
+
+    // Pattern overrides min/max logic always:
+    if (hasPattern) {
+      return this.validatePattern(field, value);
+    }
+
+    switch (true) {
+      case (min !== false && max !== false && (value < min || value > max)):
+        error = {
+          type: ValidationErrorTypes.RANGE,
+          message: t('editor.editorControlPane.widget.range', {
+            fieldLabel: field.get('label', field.get('name')),
+            minValue: min,
+            maxValue: max,
+          }),
+        };
+        break;
+      case (min !== false && value < min):
+        error = {
+          type: ValidationErrorTypes.RANGE,
+          message: t('editor.editorControlPane.widget.min', {
+            fieldLabel: field.get('label', field.get('name')),
+            minValue: min,
+          }),
+        };
+        break;
+      case (max !== false && value > max):
+        error = {
+          type: ValidationErrorTypes.RANGE,
+          message: t('editor.editorControlPane.widget.max', {
+            fieldLabel: field.get('label', field.get('name')),
+            maxValue: max,
+          }),
+        };
+        break;
+      default:
+        error = false;
+    }
+
+    return { error };
   };
 
   validatePresence = (field, value) => {

--- a/packages/netlify-cms-core/src/constants/defaultPhrases.js
+++ b/packages/netlify-cms-core/src/constants/defaultPhrases.js
@@ -39,6 +39,9 @@ export function getPhrases() {
           required: '%{fieldLabel} is required.',
           regexPattern: "%{fieldLabel} didn't match the pattern: %{pattern}.",
           processing: '%{fieldLabel} is processing.',
+          range: '%{fieldLabel} must be between %{minValue} and %{maxValue}.',
+          min: '%{fieldLabel} must be at least %{minValue}.',
+          max: '%{fieldLabel} must be %{maxValue} or less.',
         },
       },
       editor: {

--- a/packages/netlify-cms-core/src/constants/validationErrorTypes.js
+++ b/packages/netlify-cms-core/src/constants/validationErrorTypes.js
@@ -1,5 +1,6 @@
 export default {
   PRESENCE: 'PRESENCE',
   PATTERN: 'PATTERN',
+  RANGE: 'RANGE',
   CUSTOM: 'CUSTOM',
 };

--- a/packages/netlify-cms-widget-number/src/NumberControl.js
+++ b/packages/netlify-cms-widget-number/src/NumberControl.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import ImmutablePropTypes from 'react-immutable-proptypes';
-import ValidationErrorTypes from 'Constants/validationErrorTypes';
+import ValidationErrorTypes from 'netlify-cms-core/src/constants/validationErrorTypes';
 
 export default class NumberControl extends React.Component {
   static propTypes = {

--- a/packages/netlify-cms-widget-number/src/NumberControl.js
+++ b/packages/netlify-cms-widget-number/src/NumberControl.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import ImmutablePropTypes from 'react-immutable-proptypes';
+import ValidationErrorTypes from 'Constants/validationErrorTypes';
 
 export default class NumberControl extends React.Component {
   static propTypes = {
@@ -15,6 +16,7 @@ export default class NumberControl extends React.Component {
     step: PropTypes.number,
     min: PropTypes.number,
     max: PropTypes.number,
+    t: PropTypes.func.isRequired,
   };
 
   static defaultProps = {
@@ -31,6 +33,54 @@ export default class NumberControl extends React.Component {
     } else {
       onChange(e.target.value);
     }
+  };
+
+  isValid = () => {
+    const { field, value, t } = this.props;
+    const hasPattern = !!field.get('pattern', false);
+    const min = field.get('min', false);
+    const max = field.get('max', false);
+    let error;
+
+    // Pattern overrides min/max logic always:
+    if (hasPattern) {
+      return true;
+    }
+
+    switch (true) {
+      case min !== false && max !== false && (value < min || value > max):
+        error = {
+          type: ValidationErrorTypes.RANGE,
+          message: t('editor.editorControlPane.widget.range', {
+            fieldLabel: field.get('label', field.get('name')),
+            minValue: min,
+            maxValue: max,
+          }),
+        };
+        break;
+      case min !== false && value < min:
+        error = {
+          type: ValidationErrorTypes.RANGE,
+          message: t('editor.editorControlPane.widget.min', {
+            fieldLabel: field.get('label', field.get('name')),
+            minValue: min,
+          }),
+        };
+        break;
+      case max !== false && value > max:
+        error = {
+          type: ValidationErrorTypes.RANGE,
+          message: t('editor.editorControlPane.widget.max', {
+            fieldLabel: field.get('label', field.get('name')),
+            maxValue: max,
+          }),
+        };
+        break;
+      default:
+        return true;
+    }
+
+    return { error };
   };
 
   render() {

--- a/website/content/docs/widgets/number.md
+++ b/website/content/docs/widgets/number.md
@@ -13,6 +13,7 @@ The number widget uses an HTML number input, saving the value as a string, integ
   - `valueType`: accepts `int` or `float`; any other value results in saving as a string
   - `min`: accepts a number for minimum value accepted; unset by default
   - `max`: accepts a number for maximum value accepted; unset by default
+  - `step`: accepts a number for stepping up/down values in the input; 1 by default
 - **Example:**
     ```yaml
     - label: "Puppy Count"
@@ -22,4 +23,5 @@ The number widget uses an HTML number input, saving the value as a string, integ
       valueType: "int"
       min: 1
       max: 101
+      step: 2
     ```


### PR DESCRIPTION
**Summary**
This PR closes #2048 implementing the requested changes.

**Test plan**
1. Min and max values set (type int):
![number_range_test1](https://user-images.githubusercontent.com/8883545/52098715-09d2af00-25c8-11e9-8ad4-0514e6b60675.png) ![numbers_range_test1](https://user-images.githubusercontent.com/8883545/52098760-3dadd480-25c8-11e9-8e50-142554b0baa0.gif)

2. Only min value set (type float):
![numbers_range_test2](https://user-images.githubusercontent.com/8883545/52098771-51593b00-25c8-11e9-9fdf-73b2925ed9b2.png)
![numbers_range_test2](https://user-images.githubusercontent.com/8883545/52098773-54542b80-25c8-11e9-911f-3a9906d690c6.gif)

3. Only max value set (type float):
![numbers_range_test3](https://user-images.githubusercontent.com/8883545/52098801-6fbf3680-25c8-11e9-8a92-e11c36a00994.png)
![numbers_range_test3](https://user-images.githubusercontent.com/8883545/52098806-72ba2700-25c8-11e9-896d-af5871ea7811.gif)

4. Pattern override:
![numbers_range_test4](https://user-images.githubusercontent.com/8883545/52098826-82397000-25c8-11e9-81b0-baf0cb29fa7c.png)
![numbers_range_test4](https://user-images.githubusercontent.com/8883545/52098829-8796ba80-25c8-11e9-9aa0-e9213ec3ae46.gif)

**A picture of a cute animal (not mandatory but encouraged)**
![img_20181130_111332](https://user-images.githubusercontent.com/8883545/52098990-228f9480-25c9-11e9-90eb-baea94fda2ba.jpg)

As a final note, I considered simply implementing an `isValid()` method inside `NumberControl` as it would be already in the loop for validation out of the box (not requiring the changes in `EditorControlPane/Widget.js`) but for the error strings to be translatable we'd have to always provide the base in the `defaultPhrases` constants as the Number widget is part of the core. The error type would also be `CUSTOM` instead of the new `RANGE` type, which shouldn't matter as much but still... Let me know what you think.