### PR TITLE
Failing tests for more invalid markdown cases

### DIFF
--- a/packages/netlify-cms-widget-markdown/src/serializers/__tests__/slate.spec.js
+++ b/packages/netlify-cms-widget-markdown/src/serializers/__tests__/slate.spec.js
@@ -87,4 +87,291 @@ describe('slate', () => {
     };
     expect(slateToMarkdown(slateAst)).toEqual('foo **bar**');
   });
+
+  describe('with nested styles within a single word', () => {
+    it('should not produce invalid markdown when a bold word has italics applied to a smaller part', () => {
+      const slateAst = {
+        object: 'block',
+        type: 'root',
+        nodes: [
+          {
+            object: 'block',
+            type: 'paragraph',
+            nodes: [
+              {
+                object: 'text',
+                data: undefined,
+                leaves: [
+                  { text: 'h', marks: [{ type: 'bold' }] },
+                  { text: 'e', marks: [{ type: 'bold' }, { type: 'italic' }] },
+                  { text: 'y', marks: [{ type: 'bold' }] },
+                ],
+              },
+            ],
+          },
+        ],
+      };
+      expect(slateToMarkdown(slateAst)).toEqual('**h**_**e**_**y**');
+    });
+
+    it('should not produce invalid markdown when an italic word has bold applied to a smaller part', () => {
+      const slateAst = {
+        object: 'block',
+        type: 'root',
+        nodes: [
+          {
+            object: 'block',
+            type: 'paragraph',
+            nodes: [
+              {
+                object: 'text',
+                data: undefined,
+                leaves: [
+                  { text: 'h', marks: [{ type: 'italic' }] },
+                  { text: 'e', marks: [{ type: 'italic' }, { type: 'bold' }] },
+                  { text: 'y', marks: [{ type: 'italic' }] },
+                ],
+              },
+            ],
+          },
+        ],
+      };
+      expect(slateToMarkdown(slateAst)).toEqual('_h**_e_**y_');
+    });
+
+    it('should not produce invalid markdown when an italic word has bold applied to a smaller part', () => {
+      const slateAst = {
+        object: 'block',
+        type: 'root',
+        nodes: [
+          {
+            object: 'block',
+            type: 'paragraph',
+            nodes: [
+              {
+                object: 'text',
+                data: undefined,
+                leaves: [
+                  { text: 'h', marks: [{ type: 'italic' }] },
+                  { text: 'e', marks: [{ type: 'italic' }, { type: 'bold' }] },
+                  { text: 'y', marks: [{ type: 'italic' }] },
+                ],
+              },
+            ],
+          },
+        ],
+      };
+      expect(slateToMarkdown(slateAst)).toEqual('_h**_e_**y_');
+    });
+
+    it('should handle italics inside bold inside strikethrough', () => {
+      const slateAst = {
+        object: 'block',
+        type: 'root',
+        nodes: [
+          {
+            object: 'block',
+            type: 'paragraph',
+            nodes: [
+              {
+                object: 'text',
+                data: undefined,
+                leaves: [
+                  { text: 'h', marks: [{ type: 'strikethrough' }] },
+                  {
+                    text: 'e',
+                    marks: [{ type: 'strikethrough' }, { type: 'bold' }],
+                  },
+                  {
+                    text: 'l',
+                    marks: [{ type: 'strikethrough' }, { type: 'bold' }, { type: 'italic' }],
+                  },
+                  {
+                    text: 'l',
+                    marks: [{ type: 'strikethrough' }, { type: 'bold' }],
+                  },
+                  { text: 'o', marks: [{ type: 'strikethrough' }] },
+                ],
+              },
+            ],
+          },
+        ],
+      };
+
+      expect(slateToMarkdown(slateAst)).toEqual('~~h~~**~~e~~**_~~**l**~~_**~~l~~**~~o~~');
+    });
+
+    it('should handle bold inside italics inside strikethrough', () => {
+      const slateAst = {
+        object: 'block',
+        type: 'root',
+        nodes: [
+          {
+            object: 'block',
+            type: 'paragraph',
+            nodes: [
+              {
+                object: 'text',
+                data: undefined,
+                leaves: [
+                  { text: 'h', marks: [{ type: 'strikethrough' }] },
+                  {
+                    text: 'e',
+                    marks: [{ type: 'strikethrough' }, { type: 'italic' }],
+                  },
+                  {
+                    text: 'l',
+                    marks: [{ type: 'strikethrough' }, { type: 'italic' }, { type: 'bold' }],
+                  },
+                  {
+                    text: 'l',
+                    marks: [{ type: 'strikethrough' }, { type: 'italic' }],
+                  },
+                  { text: 'o', marks: [{ type: 'strikethrough' }] },
+                ],
+              },
+            ],
+          },
+        ],
+      };
+
+      expect(slateToMarkdown(slateAst)).toEqual('~~h~~_~~e~~_**_~~l~~_**_~~l~~_~~o~~');
+    });
+
+    it('should handle strikethrough inside italics inside bold', () => {
+      const slateAst = {
+        object: 'block',
+        type: 'root',
+        nodes: [
+          {
+            object: 'block',
+            type: 'paragraph',
+            nodes: [
+              {
+                object: 'text',
+                data: undefined,
+                leaves: [
+                  { text: 'h', marks: [{ type: 'bold' }] },
+                  { text: 'e', marks: [{ type: 'bold' }, { type: 'italic' }] },
+                  {
+                    text: 'l',
+                    marks: [{ type: 'bold' }, { type: 'italic' }, { type: 'strikethrough' }],
+                  },
+                  { text: 'l', marks: [{ type: 'bold' }, { type: 'italic' }] },
+                  { text: 'o', marks: [{ type: 'bold' }] },
+                ],
+              },
+            ],
+          },
+        ],
+      };
+
+      expect(slateToMarkdown(slateAst)).toEqual('**h**_**e**_~~**_l_**~~_**l**_**o**');
+    });
+
+    it('should handle italics inside strikethrough inside bold', () => {
+      const slateAst = {
+        object: 'block',
+        type: 'root',
+        nodes: [
+          {
+            object: 'block',
+            type: 'paragraph',
+            nodes: [
+              {
+                object: 'text',
+                data: undefined,
+                leaves: [
+                  { text: 'h', marks: [{ type: 'bold' }] },
+                  {
+                    text: 'e',
+                    marks: [{ type: 'bold' }, { type: 'strikethrough' }],
+                  },
+                  {
+                    text: 'l',
+                    marks: [{ type: 'bold' }, { type: 'strikethrough' }, { type: 'italic' }],
+                  },
+                  {
+                    text: 'l',
+                    marks: [{ type: 'bold' }, { type: 'strikethrough' }],
+                  },
+                  { text: 'o', marks: [{ type: 'bold' }] },
+                ],
+              },
+            ],
+          },
+        ],
+      };
+
+      expect(slateToMarkdown(slateAst)).toEqual('**h**~~**e**~~_~~**l**~~_~~**l**~~**o**');
+    });
+
+    it('should handle strikethrough inside bold inside italics', () => {
+      const slateAst = {
+        object: 'block',
+        type: 'root',
+        nodes: [
+          {
+            object: 'block',
+            type: 'paragraph',
+            nodes: [
+              {
+                object: 'text',
+                data: undefined,
+                leaves: [
+                  { text: 'h', marks: [{ type: 'italic' }] },
+                  { text: 'e', marks: [{ type: 'italic' }, { type: 'bold' }] },
+                  {
+                    text: 'l',
+                    marks: [{ type: 'italic' }, { type: 'bold' }, { type: 'strikethrough' }],
+                  },
+                  { text: 'l', marks: [{ type: 'italic' }, { type: 'bold' }] },
+                  { text: 'o', marks: [{ type: 'italic' }] },
+                ],
+              },
+            ],
+          },
+        ],
+      };
+
+      expect(slateToMarkdown(slateAst)).toEqual('_h_**_e_**~~**_l_**~~**_l_**_o_');
+    });
+
+    it('should handle bold inside strikethrough inside italics', () => {
+      const slateAst = {
+        object: 'block',
+        type: 'root',
+        nodes: [
+          {
+            object: 'block',
+            type: 'paragraph',
+            nodes: [
+              {
+                object: 'text',
+                data: undefined,
+                leaves: [
+                  { text: 'h', marks: [{ type: 'italic' }] },
+                  {
+                    text: 'e',
+                    marks: [{ type: 'italic' }, { type: 'strikethrough' }],
+                  },
+                  {
+                    text: 'l',
+                    marks: [{ type: 'italic' }, { type: 'strikethrough' }, { type: 'bold' }],
+                  },
+                  {
+                    text: 'l',
+                    marks: [{ type: 'italic' }, { type: 'strikethrough' }],
+                  },
+                  { text: 'o', marks: [{ type: 'italic' }] },
+                ],
+              },
+            ],
+          },
+        ],
+      };
+
+      expect(slateToMarkdown(slateAst)).toEqual('_h_~~_e_~~**_~~l~~_**~~_l_~~_o_');
+    });
+  });
 });

--- a/packages/netlify-cms-widget-markdown/src/serializers/__tests__/slate.spec.js
+++ b/packages/netlify-cms-widget-markdown/src/serializers/__tests__/slate.spec.js
@@ -88,7 +88,7 @@ describe('slate', () => {
     expect(slateToMarkdown(slateAst)).toEqual('foo **bar**');
   });
 
-  describe('with nested styles within a single word', () => {
+  describe.skip('with nested styles within a single word', () => {
     it('should not produce invalid markdown when a bold word has italics applied to a smaller part', () => {
       const slateAst = {
         object: 'block',


### PR DESCRIPTION
**Summary**

Lifted from https://github.com/netlify/netlify-cms/pull/1517#issuecomment-433533196

This shows some more cases where the slate => markdown conversion results in invalid markdown.

There's no fix is enclosed for now, but I wanted to keep the bug visible now that the other PR got merged.

**Test plan**

We should get the enclosed tests to pass :)
