### PR TITLE
Skip the `config.yml` file on init()

### DIFF
--- a/packages/netlify-cms-core/src/actions/config.js
+++ b/packages/netlify-cms-core/src/actions/config.js
@@ -111,7 +111,10 @@ export function loadConfig() {
     try {
       const preloadedConfig = getState().config;
       const configUrl = getConfigUrl();
-      const loadedConfig = await getConfig(configUrl, preloadedConfig && preloadedConfig.size > 1);
+      const loadedConfig =
+        preloadedConfig && preloadedConfig.get('load_config_file') === false
+        ? {}
+        : await getConfig(configUrl, preloadedConfig && preloadedConfig.size > 1);
 
       /**
        * Merge any existing configuration so the result can be validated.

--- a/packages/netlify-cms-core/src/actions/config.js
+++ b/packages/netlify-cms-core/src/actions/config.js
@@ -113,8 +113,8 @@ export function loadConfig() {
       const configUrl = getConfigUrl();
       const loadedConfig =
         preloadedConfig && preloadedConfig.get('load_config_file') === false
-        ? {}
-        : await getConfig(configUrl, preloadedConfig && preloadedConfig.size > 1);
+          ? {}
+          : await getConfig(configUrl, preloadedConfig && preloadedConfig.size > 1);
 
       /**
        * Merge any existing configuration so the result can be validated.

--- a/website/content/docs/beta-features.md
+++ b/website/content/docs/beta-features.md
@@ -134,6 +134,57 @@ init({
   },
 })
 
+/**
+ * Optionally pass in a complete config object and set a flag
+ *  (`load_config_file: false`) to ignore the `config.yml`.
+ *
+ * For example, the code below contains a complete config. The
+ * `config.yml` will be ignored when setting `load_config_file` to false.
+ * It is not required if the `config.yml` file is missing to set
+ * `load_config_file`, but will improve performance and avoid a load error.
+ */
+
+init({
+  config: {
+    backend: {
+      name: 'git-gateway',
+    },
+    load_config_file: false,
+    media_folder: "static/images/uploads",
+    public_folder: "/images/uploads",
+    collections: [
+      {
+        label: "Blog",
+        name: "blog",
+        folder: "_posts/blog",
+        create: true,
+        fields: [
+          {
+            label: "Title",
+            name: "title",
+            widget: "string"
+          },
+          {
+            label: "Publish Date",
+            name: "date",
+            widget: "datetime"
+          },
+          {
+            label: "Featured Image",
+            name: "thumbnail",
+            widget: "image"
+          },
+          {
+            label: "Body",
+            name: "body",
+            widget: "markdown"
+          }
+        ]
+      },
+    ]
+  },
+})
+
 // The registry works as expected, and can be used before or after init.
 CMS.registerPreviewTemplate(...);
 ```

--- a/website/content/docs/beta-features.md
+++ b/website/content/docs/beta-features.md
@@ -153,35 +153,13 @@ init({
     media_folder: "static/images/uploads",
     public_folder: "/images/uploads",
     collections: [
-      {
-        label: "Blog",
-        name: "blog",
-        folder: "_posts/blog",
-        create: true,
-        fields: [
-          {
-            label: "Title",
-            name: "title",
-            widget: "string"
-          },
-          {
-            label: "Publish Date",
-            name: "date",
-            widget: "datetime"
-          },
-          {
-            label: "Featured Image",
-            name: "thumbnail",
-            widget: "image"
-          },
-          {
-            label: "Body",
-            name: "body",
-            widget: "markdown"
-          }
-        ]
-      },
-    ]
+      { label: "Blog", name: "blog", folder: "_posts/blog", create: true, fields: [
+        { label: "Title", name: "title", widget: "string" },
+        { label: "Publish Date", name: "date", widget: "datetime" },
+        { label: "Featured Image", name: "thumbnail", widget: "image" },
+        { label: "Body", name: "body", widget: "markdown" },
+      ]},
+    ],
   },
 })
 


### PR DESCRIPTION
replaces #1866

**Summary**

Checks the pre-loaded config for `load_config_file: false`

**Test plan**

Tested against multiple configurations with and without the `config.yml` existing and using a full config with `init()`.

**A picture of a cute animal (not mandatory but encouraged)**
🕊