### PR TITLE
fix(netlify-cms-widget-select) Show label instead of value when multiple is true

### DIFF
--- a/packages/netlify-cms-widget-select/src/SelectControl.js
+++ b/packages/netlify-cms-widget-select/src/SelectControl.js
@@ -50,7 +50,7 @@ const styles = {
 };
 
 function optionToString(option) {
-  return option && option.value ? option.value : '';
+  return option && option.value ? option.value : null;
 }
 
 function convertToOption(raw) {
@@ -82,10 +82,15 @@ export default class SelectControl extends React.Component {
   };
 
   handleChange = selectedOption => {
-    const { onChange } = this.props;
+    const { onChange, field } = this.props;
+    const isMultiple = field.get('multiple', false);
 
     if (Array.isArray(selectedOption)) {
-      onChange(fromJS(selectedOption.map(optionToString)));
+      if (!isMultiple && selectedOption.length === 0) {
+        onChange(null);
+      } else {
+        onChange(fromJS(selectedOption.map(optionToString)));
+      }
     } else {
       onChange(optionToString(selectedOption));
     }
@@ -100,7 +105,8 @@ export default class SelectControl extends React.Component {
       }
 
       return selectedOptions
-        .filter(i => options.find(o => o.value === (i.value || i)))
+        .map(i => options.find(o => o.value === (i.value || i)))
+        .filter(Boolean)
         .map(convertToOption);
     } else {
       return find(options, ['value', value]) || null;


### PR DESCRIPTION
**Summary**

Fixes value being displayed in input instead of label for `multiple: true` in select widget.

This also fixes some inconsistencies I discovered when adding some more tests to the component:
- Fixes onChange being called with empty array instead of null when input contents are deleted and `multiple: false`
- Fixes onChange being called with empty string instead of null when input is cleared and `multiple: false`
- Add more tests

I am not sure how a missing value is actually represented for the select widget. I guess any falsy value will do (and also empty arrays). This is confusing to me (especially the case from above where an empty array is used for a select with `multiple: false`), so I opted for null for all of the cases where the select value is not currently set.

**Test plan**

- Create select field with `multiple: true` and `value|label` options
- Select an option for this field
- Expected: Input shows label of selected option
- Got: Input shows value of selected option