### PR TITLE
fix(netlify-cms-core) respect subsequent dashes in slugs (#2006)

### DIFF
--- a/packages/netlify-cms-core/src/lib/__tests__/urlHelper.spec.js
+++ b/packages/netlify-cms-core/src/lib/__tests__/urlHelper.spec.js
@@ -96,8 +96,13 @@ describe('sanitizeSlug', () => {
     ).toEqual('escrzy');
   });
 
+  it('does not remove doubles in original string even if they match `sanitize_replacement`', () => {
+    expect(sanitizeSlug('test--test  test', Map({ sanitize_replacement: '-' }))).toEqual(
+      'test--test-test',
+    );
+  });
+
   it('removes double replacements', () => {
-    expect(sanitizeSlug('test--test')).toEqual('test-test');
     expect(sanitizeSlug('test   test')).toEqual('test-test');
   });
 


### PR DESCRIPTION
Fixes #2006 Slug option containing multiple consequent dashes not working as expected

This is my first attempt at contributing to an open source project 🙌. 

**Summary**

Specifically, a user wanted to define a slug template with subsequent hyphens (eg: {{year}}-{{month}}-{{day}}---{{slug}}). The existing implementation removed the subsequent hyphens in generated urls and filenames.

More generally, the issue was that subsequent characters were removed when they matched the `sanitize_replacement` character, which defaults to `-`.

Now subsequent url safe characters will be respected if they are included in the slug template or if they are included in the page title. 

**Test plan**
I added a test to the urlHelper spec to cover the case of intentional subsequent hyphens when the replacement string is a hyphen. I modified a test case that was asserting the undesired removal of hyphens.
