### PR TITLE
Allow publish bundle to have React as external peer dependencies

### DIFF
--- a/packages/netlify-cms-backend-bitbucket/package.json
+++ b/packages/netlify-cms-backend-bitbucket/package.json
@@ -35,7 +35,7 @@
     "netlify-cms-lib-util": "^2.1.0",
     "netlify-cms-ui-default": "^2.0.6",
     "prop-types": "^15.6.2",
-    "react": "^16.4.1",
+    "react": "^16.8.1",
     "react-emotion": "^9.2.6"
   }
 }

--- a/packages/netlify-cms-backend-git-gateway/package.json
+++ b/packages/netlify-cms-backend-git-gateway/package.json
@@ -39,7 +39,7 @@
     "netlify-cms-lib-util": "^2.0.0",
     "netlify-cms-ui-default": "^2.0.0",
     "prop-types": "^15.6.2",
-    "react": "^16.4.1",
+    "react": "^16.8.1",
     "react-emotion": "^9.2.6"
   }
 }

--- a/packages/netlify-cms-backend-github/package.json
+++ b/packages/netlify-cms-backend-github/package.json
@@ -35,7 +35,7 @@
     "netlify-cms-lib-util": "^2.0.0",
     "netlify-cms-ui-default": "^2.0.0",
     "prop-types": "^15.6.2",
-    "react": "^16.4.1",
+    "react": "^16.8.1",
     "react-emotion": "^9.2.6"
   }
 }

--- a/packages/netlify-cms-backend-gitlab/package.json
+++ b/packages/netlify-cms-backend-gitlab/package.json
@@ -35,7 +35,7 @@
     "netlify-cms-lib-util": "^2.0.0",
     "netlify-cms-ui-default": "^2.0.0",
     "prop-types": "^15.6.2",
-    "react": "^16.4.1",
+    "react": "^16.8.1",
     "react-emotion": "^9.2.6"
   }
 }

--- a/packages/netlify-cms-backend-test/package.json
+++ b/packages/netlify-cms-backend-test/package.json
@@ -32,7 +32,7 @@
     "netlify-cms-lib-util": "^2.0.0",
     "netlify-cms-ui-default": "^2.0.0",
     "prop-types": "^15.6.2",
-    "react": "^16.4.1",
+    "react": "^16.8.1",
     "react-emotion": "^9.2.6",
     "react-immutable-proptypes": "^2.1.0"
   }

--- a/packages/netlify-cms-core/package.json
+++ b/packages/netlify-cms-core/package.json
@@ -39,10 +39,8 @@
     "netlify-cms-ui-default": "^2.3.0",
     "node-polyglot": "^2.3.0",
     "prop-types": "^15.5.10",
-    "react": "^16.8.1",
     "react-dnd": "^7.0.0",
     "react-dnd-html5-backend": "^7.0.0",
-    "react-dom": "^16.8.1",
     "react-emotion": "^9.2.5",
     "react-frame-component": "^4.0.2",
     "react-hot-loader": "^4.0.0",
@@ -75,5 +73,9 @@
     "to-string-loader": "^1.1.5",
     "webpack": "^4.16.1",
     "webpack-cli": "^3.1.0"
+  },
+  "peerDependencies": {
+    "react": "^16.8.1",
+    "react-dom": "^16.8.1"
   }
 }

--- a/packages/netlify-cms-editor-component-image/package.json
+++ b/packages/netlify-cms-editor-component-image/package.json
@@ -24,6 +24,6 @@
     "webpack-cli": "^3.1.0"
   },
   "peerDependencies": {
-    "react": "^16.4.1"
+    "react": "^16.8.1"
   }
 }

--- a/packages/netlify-cms-ui-default/package.json
+++ b/packages/netlify-cms-ui-default/package.json
@@ -29,7 +29,8 @@
     "emotion": "^9.2.6",
     "lodash": "^4.13.1",
     "prop-types": "^15.5.10",
-    "react": "^16.4.1",
+    "react": "^16.8.1",
+    "react-dom": "^16.8.1",
     "react-emotion": "^9.2.6"
   }
 }

--- a/packages/netlify-cms-widget-boolean/package.json
+++ b/packages/netlify-cms-widget-boolean/package.json
@@ -29,7 +29,7 @@
     "lodash": "^4.17.10",
     "netlify-cms-ui-default": "^2.0.0",
     "prop-types": "^15.5.10",
-    "react": "^16.4.1",
+    "react": "^16.8.1",
     "react-immutable-proptypes": "^2.1.0"
   }
 }

--- a/packages/netlify-cms-widget-date/package.json
+++ b/packages/netlify-cms-widget-date/package.json
@@ -35,7 +35,8 @@
     "moment": "^2.11.2",
     "netlify-cms-ui-default": "^2.0.0",
     "prop-types": "^15.5.10",
-    "react": "^16.4.1",
+    "react": "^16.8.1",
+    "react-dom": "^16.8.1",
     "react-emotion": "^9.2.6"
   }
 }

--- a/packages/netlify-cms-widget-datetime/package.json
+++ b/packages/netlify-cms-widget-datetime/package.json
@@ -31,7 +31,8 @@
   },
   "peerDependencies": {
     "emotion": "^9.2.6",
-    "react": "^16.4.1"
+    "react": "^16.8.1",
+    "react-dom": "^16.8.1"
   },
   "localExternals": [
     "netlify-cms-widget-date"

--- a/packages/netlify-cms-widget-file/package.json
+++ b/packages/netlify-cms-widget-file/package.json
@@ -35,7 +35,7 @@
     "immutable": "^3.7.6",
     "netlify-cms-ui-default": "^2.0.0",
     "prop-types": "^15.5.10",
-    "react": "^16.4.1",
+    "react": "^16.8.1",
     "react-emotion": "^9.2.6",
     "react-immutable-proptypes": "^2.1.0"
   }

--- a/packages/netlify-cms-widget-image/package.json
+++ b/packages/netlify-cms-widget-image/package.json
@@ -33,7 +33,7 @@
     "immutable": "^3.7.6",
     "netlify-cms-ui-default": "^2.0.0",
     "prop-types": "^15.5.10",
-    "react": "^16.4.1",
+    "react": "^16.8.1",
     "react-emotion": "^9.2.6"
   },
   "localExternals": [

--- a/packages/netlify-cms-widget-list/package.json
+++ b/packages/netlify-cms-widget-list/package.json
@@ -35,7 +35,8 @@
     "lodash": "^4.17.10",
     "netlify-cms-ui-default": "^2.0.0",
     "prop-types": "^15.5.10",
-    "react": "^16.4.1",
+    "react": "^16.8.1",
+    "react-dom": "^16.8.1",
     "react-emotion": "^9.2.6",
     "react-immutable-proptypes": "^2.1.0"
   },

--- a/packages/netlify-cms-widget-map/package.json
+++ b/packages/netlify-cms-widget-map/package.json
@@ -32,7 +32,7 @@
     "lodash": "^4.17.10",
     "netlify-cms-ui-default": "^2.0.0",
     "prop-types": "^15.5.10",
-    "react": "^16.4.1",
+    "react": "^16.8.1",
     "react-immutable-proptypes": "^2.1.0"
   },
   "dependencies": {

--- a/packages/netlify-cms-widget-markdown/package.json
+++ b/packages/netlify-cms-widget-markdown/package.json
@@ -51,8 +51,8 @@
     "lodash": "^4.17.10",
     "netlify-cms-ui-default": "^2.0.0",
     "prop-types": "^15.5.10",
-    "react": "^16.4.1",
-    "react-dom": "^16.0.0",
+    "react": "^16.8.1",
+    "react-dom": "^16.8.1",
     "react-emotion": "^9.2.5",
     "react-immutable-proptypes": "^2.1.0"
   }

--- a/packages/netlify-cms-widget-number/package.json
+++ b/packages/netlify-cms-widget-number/package.json
@@ -28,6 +28,6 @@
     "emotion": "^9.2.6",
     "netlify-cms-ui-default": "^2.0.0",
     "prop-types": "^15.5.10",
-    "react": "^16.4.1"
+    "react": "^16.8.1"
   }
 }

--- a/packages/netlify-cms-widget-object/package.json
+++ b/packages/netlify-cms-widget-object/package.json
@@ -32,7 +32,7 @@
     "lodash": "^4.17.10",
     "netlify-cms-ui-default": "^2.0.0",
     "prop-types": "^15.5.10",
-    "react": "^16.4.1",
+    "react": "^16.8.1",
     "react-emotion": "^9.2.6",
     "react-immutable-proptypes": "^2.1.0"
   }

--- a/packages/netlify-cms-widget-relation/package.json
+++ b/packages/netlify-cms-widget-relation/package.json
@@ -34,7 +34,7 @@
     "lodash": "^4.17.10",
     "netlify-cms-ui-default": "^2.0.0",
     "prop-types": "^15.5.10",
-    "react": "^16.4.1",
+    "react": "^16.8.1",
     "react-emotion": "^9.2.5",
     "uuid": "^3.1.0"
   }

--- a/packages/netlify-cms-widget-select/package.json
+++ b/packages/netlify-cms-widget-select/package.json
@@ -32,7 +32,8 @@
     "immutable": "^3.7.6",
     "netlify-cms-ui-default": "^2.0.0",
     "prop-types": "^15.5.10",
-    "react": "^16.4.1",
+    "react": "^16.8.1",
+    "react-dom": "^16.8.1",
     "react-immutable-proptypes": "^2.1.0"
   },
   "dependencies": {

--- a/packages/netlify-cms-widget-string/package.json
+++ b/packages/netlify-cms-widget-string/package.json
@@ -27,6 +27,6 @@
   "peerDependencies": {
     "netlify-cms-ui-default": "^2.0.0",
     "prop-types": "^15.5.10",
-    "react": "^16.4.1"
+    "react": "^16.8.1"
   }
 }

--- a/packages/netlify-cms-widget-text/package.json
+++ b/packages/netlify-cms-widget-text/package.json
@@ -33,6 +33,6 @@
   "peerDependencies": {
     "netlify-cms-ui-default": "^2.0.0",
     "prop-types": "^15.5.10",
-    "react": "^16.4.1"
+    "react": "^16.8.1"
   }
 }

--- a/packages/netlify-cms/package.json
+++ b/packages/netlify-cms/package.json
@@ -44,7 +44,9 @@
     "netlify-cms-widget-relation": "^2.0.6",
     "netlify-cms-widget-select": "^2.1.1",
     "netlify-cms-widget-string": "^2.0.4",
-    "netlify-cms-widget-text": "^2.0.6"
+    "netlify-cms-widget-text": "^2.0.6",
+    "react": "^16.8.1",
+    "react-dom": "^16.8.1"
   },
   "devDependencies": {
     "copy-webpack-plugin": "^4.5.2",

--- a/packages/netlify-cms/src/index-manual.js
+++ b/packages/netlify-cms/src/index-manual.js
@@ -4,6 +4,9 @@ import './widgets';
 import './editor-components';
 import './media-libraries';
 
-console.log(`Using netlify-cms manual initialization required.\nDependencies['react', 'react-dom']`);
+console.log(
+  `Using netlify-cms manual initialization required.
+Dependencies['react', 'react-dom']`,
+);
 
 export { CMS as default, init };

--- a/packages/netlify-cms/src/index-manual.js
+++ b/packages/netlify-cms/src/index-manual.js
@@ -1,0 +1,9 @@
+import CMS, { init } from 'netlify-cms-core/src';
+import './backends';
+import './widgets';
+import './editor-components';
+import './media-libraries';
+
+console.log(`Using netlify-cms manual initialization required.\nDependencies['react', 'react-dom']`);
+
+export { CMS as default, init };

--- a/packages/netlify-cms/webpack.config.js
+++ b/packages/netlify-cms/webpack.config.js
@@ -71,11 +71,6 @@ if (isProduction) {
         return externals.some(isPeerDep) ? cb(null, request) : cb();
       },
     },
-
-      /**
-   * Exclude peer dependencies from package bundles.
-   */
-
   ];
 } else {
   module.exports = baseConfig;

--- a/packages/netlify-cms/webpack.config.js
+++ b/packages/netlify-cms/webpack.config.js
@@ -52,6 +52,30 @@ if (isProduction) {
         filename: 'dist/cms.js',
       },
     },
+
+    /**
+     * Output the same script with react, react-dom as external peers.
+     */
+    {
+      ...baseConfig,
+      entry: [path.join(__dirname, 'src/index-manual.js'), baseConfig.entry],
+      output: {
+        ...baseConfig.output,
+        filename: 'dist/netlify-cms-manual-init.js',
+      },
+      externals: (context, request, cb) => {
+        const localExternals = pkg.localExternals || [];
+        const peerDeps = ['react', 'react-dom'];
+        const externals = isProduction ? peerDeps : [...localExternals, ...peerDeps];
+        const isPeerDep = dep => new RegExp(`^${dep}($|/)`).test(request);
+        return externals.some(isPeerDep) ? cb(null, request) : cb();
+      },
+    },
+
+      /**
+   * Exclude peer dependencies from package bundles.
+   */
+
   ];
 } else {
   module.exports = baseConfig;

--- a/yarn.lock
+++ b/yarn.lock
@@ -9754,14 +9754,14 @@ react-dnd@^7.0.0:
     shallowequal "^1.1.0"
 
 react-dom@^16.8.1:
-  version "16.8.1"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.8.1.tgz#ec860f98853d09d39bafd3a6f1e12389d283dbb4"
-  integrity sha512-N74IZUrPt6UiDjXaO7UbDDFXeUXnVhZzeRLy/6iqqN1ipfjrhR60Bp5NuBK+rv3GMdqdIuwIl22u1SYwf330bg==
+  version "16.8.2"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.8.2.tgz#7c8a69545dd554d45d66442230ba04a6a0a3c3d3"
+  integrity sha512-cPGfgFfwi+VCZjk73buu14pYkYBR1b/SRMSYqkLDdhSEHnSwcuYTPu6/Bh6ZphJFIk80XLvbSe2azfcRzNF+Xg==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
     prop-types "^15.6.2"
-    scheduler "^0.13.1"
+    scheduler "^0.13.2"
 
 react-emotion@^9.2.5:
   version "9.2.6"
@@ -10027,14 +10027,14 @@ react-waypoint@^8.1.0:
     react-is "^16.6.3"
 
 react@^16.8.1:
-  version "16.8.1"
-  resolved "https://registry.yarnpkg.com/react/-/react-16.8.1.tgz#ae11831f6cb2a05d58603a976afc8a558e852c4a"
-  integrity sha512-wLw5CFGPdo7p/AgteFz7GblI2JPOos0+biSoxf1FPsGxWQZdN/pj6oToJs1crn61DL3Ln7mN86uZ4j74p31ELQ==
+  version "16.8.2"
+  resolved "https://registry.yarnpkg.com/react/-/react-16.8.2.tgz#83064596feaa98d9c2857c4deae1848b542c9c0c"
+  integrity sha512-aB2ctx9uQ9vo09HVknqv3DGRpI7OIGJhCx3Bt0QqoRluEjHSaObJl+nG12GDdYH6sTgE7YiPJ6ZUyMx9kICdXw==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
     prop-types "^15.6.2"
-    scheduler "^0.13.1"
+    scheduler "^0.13.2"
 
 read-cmd-shim@^1.0.1:
   version "1.0.1"
@@ -10754,10 +10754,10 @@ sax@^1.2.4, sax@~1.2.4:
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
   integrity sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==
 
-scheduler@^0.13.1:
-  version "0.13.1"
-  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.13.1.tgz#1a217df1bfaabaf4f1b92a9127d5d732d85a9591"
-  integrity sha512-VJKOkiKIN2/6NOoexuypwSrybx13MY7NSy9RNt8wPvZDMRT1CW6qlpF5jXRToXNHz3uWzbm2elNpZfXfGPqP9A==
+scheduler@^0.13.2:
+  version "0.13.2"
+  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.13.2.tgz#969eaee2764a51d2e97b20a60963b2546beff8fa"
+  integrity sha512-qK5P8tHS7vdEMCW5IPyt8v9MJOHqTrOUgPXib7tqm9vh834ibBX5BNhwkplX/0iOzHW5sXyluehYfS9yrkz9+w==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"


### PR DESCRIPTION
### **Summary**

Closes #2026 

**Changes:**

Create new bundle in `netlify-cms` to use react and react-dom as externals

- Move react and react-dom as peer deps in netlify-cms-core
- Make react and react-dom dependencies in netlify-cms
- Webpack config in netlify-cms to build new bundle


### **Test plan**

Make sure netlify-cms works as espected.
Use new bundle in projects importing cms (like Gatsby starter)

**A picture of a cute animal (not mandatory but encouraged)**
🐶