### PR TITLE
docs: put star button first, add search to home

### DIFF
--- a/website/src/components/header.js
+++ b/website/src/components/header.js
@@ -57,9 +57,12 @@ class Header extends Component {
                   <Link to="/" className="logo">
                     <img src={logo} />
                   </Link>
-                  {isDocs && <DocSearch />}
+                  <DocSearch />
                 </div>
                 <div className="nav-container">
+                  <span className="gh-button">
+                    <GitHubButton />
+                  </span>
                   <Link className="nav-link docs-link" to="/docs/intro/">
                     Docs
                   </Link>
@@ -72,9 +75,6 @@ class Header extends Component {
                   <Link className="nav-link" to="/blog/">
                     Blog
                   </Link>
-                  <span className="gh-button">
-                    <GitHubButton />
-                  </span>
                 </div>
               </div>
             </header>


### PR DESCRIPTION
1. Our star button makes the whole nav jump when it loads - some other projects put it first in the nav and I sort of like that idea, gives it a little more attention.
2. Search should be everywhere like every other docs site.