### PR TITLE
Fix Deploy Preview Links href in latest blog post

### DIFF
--- a/website/content/blog/netlify-cms-2-4-0.md
+++ b/website/content/blog/netlify-cms-2-4-0.md
@@ -7,7 +7,7 @@ description: >-
 twitter_image: /img/preview-link-published.png
 date: 2019-02-08T23:00:58.501Z
 ---
-Netlify CMS 2.4.0 is out with significant bugfixes, like working validation for nested fields, and some nice new features, including [Deploy Preview Links](https://www.netlifycms.org/blog/2019/02/netlify-cms-2-4-0) and a new [Map widget](https://www.netlifycms.org/docs/widgets/#map)!
+Netlify CMS 2.4.0 is out with significant bugfixes, like working validation for nested fields, and some nice new features, including [Deploy Preview Links](https://www.netlifycms.org/blog/2019/02/deploy-preview-links) and a new [Map widget](https://www.netlifycms.org/docs/widgets/#map)!
 
 ## Release Notes
 


### PR DESCRIPTION
**Summary**
Seems like `Deploy Preview Links` is linking to the current blog post instead of the one specifically about the subject.
