### PR TITLE
Fix previews for GitHub images not in Large Media when using Large Media integration

### DIFF
--- a/packages/netlify-cms-backend-git-gateway/src/implementation.js
+++ b/packages/netlify-cms-backend-git-gateway/src/implementation.js
@@ -215,12 +215,14 @@ export default class GitGateway {
           return mediaFiles;
         }
         const largeMediaURLThunks = await this.getLargeMedia(mediaFiles);
-        return mediaFiles.map(({ id, url, getDisplayURL, ...rest }) => ({
+        return mediaFiles.map(({ id, url, urlIsPublicPath, getDisplayURL, ...rest }) => ({
           ...rest,
           id,
           url,
-          urlIsPublicPath: false,
-          getDisplayURL: largeMediaURLThunks[id] ? largeMediaURLThunks[id] : getDisplayURL,
+          urlIsPublicPath: largeMediaURLThunks[id] ? false : urlIsPublicPath,
+          getDisplayURL: largeMediaURLThunks[id]
+            ? largeMediaURLThunks[id]
+            : getDisplayURL || (url && (() => Promise.resolve(url))),
         }));
       },
     );

--- a/website/content/docs/netlify-large-media.md
+++ b/website/content/docs/netlify-large-media.md
@@ -6,13 +6,13 @@ weight: 10
 
 [Netlify Large Media](https://www.netlify.com/features/large-media/) is a [Git LFS](https://git-lfs.github.com/) implementation for repositories connected to Netlify sites. This means that you can use Git to work with large asset files like images, audio, and video, without bloating your repository. It does this by replacing the asset files in your repository with text pointer files, then uploading the assets to the Neltify Large Media storage service.
 
-If you have a Netlify site with Large Media enabled, Netlify CMS (version 2.5.0 and above) will handle Large Media asset files seamlessly, in the same way as files stored directly in the repository.
+If you have a Netlify site with Large Media enabled, Netlify CMS (version 2.5.1 and above) will handle Large Media asset files seamlessly, in the same way as files stored directly in the repository.
 
 ## Requirements
 
 To use Netlify Large Media with Netlify CMS, you will need to do the following:
 
-- [Upgrade Netlify CMS](/docs/update-the-cms-version/) to version 2.5.0 or above
+- [Upgrade Netlify CMS](/docs/update-the-cms-version/) to version 2.5.1 or above.
 - Configure Netlify CMS to use the [Git Gateway backend with Netlify Identity](/docs/authentication-backends/#git-gateway-with-netlify-identity).
 - Configure the Netlify site and connected repository to use Large Media, following the [Large Media docs on Netlify](https://www.netlify.com/docs/large-media/).
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines.

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first two fields are mandatory:
-->

**Summary**

Fixes previews for images that do not match the specified Large Media patterns when using Large Media with GitHub.