### PR TITLE
Recover entry after unexpected quit, show in error boundary

### DIFF
--- a/packages/netlify-cms-core/package.json
+++ b/packages/netlify-cms-core/package.json
@@ -21,6 +21,7 @@
   "dependencies": {
     "ajv": "^6.4.0",
     "ajv-errors": "^1.0.0",
+    "copy-text-to-clipboard": "^1.0.4",
     "diacritics": "^1.3.0",
     "emotion": "^9.2.6",
     "fuzzy": "^0.1.1",

--- a/packages/netlify-cms-core/src/actions/entries.js
+++ b/packages/netlify-cms-core/src/actions/entries.js
@@ -226,13 +226,13 @@ export function localBackupRetrieved(entry) {
   return {
     type: DRAFT_LOCAL_BACKUP_RETRIEVED,
     payload: { entry },
-  }
+  };
 }
 
 export function loadLocalBackup() {
   return {
     type: DRAFT_CREATE_FROM_LOCAL_BACKUP,
-  }
+  };
 }
 
 export function persistLocalBackup(entry, collection) {
@@ -240,7 +240,7 @@ export function persistLocalBackup(entry, collection) {
     const state = getState();
     const backend = currentBackend(state.config);
     return backend.persistLocalDraftBackup(entry, collection);
-  }
+  };
 }
 
 export function retrieveLocalBackup(collection, slug) {
@@ -251,7 +251,7 @@ export function retrieveLocalBackup(collection, slug) {
     if (entry) {
       return dispatch(localBackupRetrieved(entry));
     }
-  }
+  };
 }
 
 export function deleteLocalBackup(collection, slug) {
@@ -259,7 +259,7 @@ export function deleteLocalBackup(collection, slug) {
     const state = getState();
     const backend = currentBackend(state.config);
     return backend.deleteLocalDraftBackup(collection, slug);
-  }
+  };
 }
 
 /*

--- a/packages/netlify-cms-core/src/actions/entries.js
+++ b/packages/netlify-cms-core/src/actions/entries.js
@@ -30,6 +30,8 @@ export const DRAFT_CHANGE = 'DRAFT_CHANGE';
 export const DRAFT_CHANGE_FIELD = 'DRAFT_CHANGE_FIELD';
 export const DRAFT_VALIDATION_ERRORS = 'DRAFT_VALIDATION_ERRORS';
 export const DRAFT_CLEAR_ERRORS = 'DRAFT_CLEAR_ERRORS';
+export const DRAFT_LOCAL_BACKUP_RETRIEVED = 'DRAFT_LOCAL_BACKUP_RETRIEVED';
+export const DRAFT_CREATE_FROM_LOCAL_BACKUP = 'DRAFT_CREATE_FROM_LOCAL_BACKUP';
 
 export const ENTRY_PERSIST_REQUEST = 'ENTRY_PERSIST_REQUEST';
 export const ENTRY_PERSIST_SUCCESS = 'ENTRY_PERSIST_SUCCESS';
@@ -218,6 +220,46 @@ export function changeDraftFieldValidation(uniquefieldId, errors) {
 
 export function clearFieldErrors() {
   return { type: DRAFT_CLEAR_ERRORS };
+}
+
+export function localBackupRetrieved(entry) {
+  return {
+    type: DRAFT_LOCAL_BACKUP_RETRIEVED,
+    payload: { entry },
+  }
+}
+
+export function loadLocalBackup() {
+  return {
+    type: DRAFT_CREATE_FROM_LOCAL_BACKUP,
+  }
+}
+
+export function persistLocalBackup(entry, collection) {
+  return (dispatch, getState) => {
+    const state = getState();
+    const backend = currentBackend(state.config);
+    return backend.persistLocalDraftBackup(entry, collection);
+  }
+}
+
+export function retrieveLocalBackup(collection, slug) {
+  return async (dispatch, getState) => {
+    const state = getState();
+    const backend = currentBackend(state.config);
+    const entry = await backend.getLocalDraftBackup(collection, slug);
+    if (entry) {
+      return dispatch(localBackupRetrieved(entry));
+    }
+  }
+}
+
+export function deleteLocalBackup(collection, slug) {
+  return (dispatch, getState) => {
+    const state = getState();
+    const backend = currentBackend(state.config);
+    return backend.deleteLocalDraftBackup(collection, slug);
+  }
 }
 
 /*

--- a/packages/netlify-cms-core/src/backend.js
+++ b/packages/netlify-cms-core/src/backend.js
@@ -3,6 +3,7 @@ import { Map } from 'immutable';
 import { stripIndent } from 'common-tags';
 import moment from 'moment';
 import fuzzy from 'fuzzy';
+import { localForage } from 'netlify-cms-lib-util';
 import { resolveFormat } from 'Formats/formats';
 import { selectIntegration } from 'Reducers/integrations';
 import {
@@ -73,6 +74,16 @@ function getExplicitFieldReplacement(key, data) {
   const fieldName = key.substring(USE_FIELD_PREFIX.length);
   return data.get(fieldName, '').trim();
 }
+
+function getEntryBackupKey(collectionName, slug) {
+  const suffix = slug ? `.${slug}` : '';
+  return `backup.${collectionName}${suffix}`;
+};
+
+function getLabelForFileCollectionEntry(collection, path) {
+  const files = collection.get('files');
+  const label = files && files.find(f => f.get('file') === path).get('label');
+};
 
 function compileSlug(template, date, identifier = '', data = Map(), processor) {
   let missingRequiredDate;
@@ -416,10 +427,36 @@ class Backend {
       }));
   }
 
+  async getLocalDraftBackup(collection, slug) {
+    const key = getEntryBackupKey(collection.get('name'), slug);
+    const backup = await localForage.getItem(key);
+    if (!backup || !backup.raw.trim()) {
+      return;
+    }
+    const { raw, path } = backup;
+    const label = getLabelForFileCollectionEntry(collection, path);
+    return this.entryWithFormat(collection, slug)(
+      createEntry(collection.get('name'), slug, path, { raw, label }),
+    );
+  }
+
+  persistLocalDraftBackup(entry, collection) {
+    const key = getEntryBackupKey(collection.get('name'), entry.get('slug'));
+    const raw = this.entryToRaw(collection, entry);
+    if (!raw.trim()) {
+      return;
+    }
+    return localForage.setItem(key, { raw, path: entry.get('path') });
+  }
+
+  deleteLocalDraftBackup(collection, slug) {
+    const key = getEntryBackupKey(collection.get('name'), slug);
+    return localForage.removeItem(key);
+  }
+
   getEntry(collection, slug) {
     const path = selectEntryPath(collection, slug);
-    const files = collection.get('files');
-    const label = files && files.find(f => f.get('file') === path).get('label');
+    const label = getLabelForFileCollectionEntry(collection, path);
     return this.implementation.getEntry(collection, slug, path).then(loadedEntry =>
       this.entryWithFormat(collection, slug)(
         createEntry(collection.get('name'), slug, loadedEntry.file.path, {

--- a/packages/netlify-cms-core/src/backend.js
+++ b/packages/netlify-cms-core/src/backend.js
@@ -78,12 +78,12 @@ function getExplicitFieldReplacement(key, data) {
 function getEntryBackupKey(collectionName, slug) {
   const suffix = slug ? `.${slug}` : '';
   return `backup.${collectionName}${suffix}`;
-};
+}
 
 function getLabelForFileCollectionEntry(collection, path) {
   const files = collection.get('files');
-  const label = files && files.find(f => f.get('file') === path).get('label');
-};
+  return files && files.find(f => f.get('file') === path).get('label');
+}
 
 function compileSlug(template, date, identifier = '', data = Map(), processor) {
   let missingRequiredDate;

--- a/packages/netlify-cms-core/src/backend.js
+++ b/packages/netlify-cms-core/src/backend.js
@@ -250,6 +250,8 @@ function createPreviewUrl(baseUrl, collection, slug, slugConfig, entry) {
 
 class Backend {
   constructor(implementation, { backendName, authStore = null, config } = {}) {
+    // We can't reliably run this on exit, so we do cleanup on load.
+    this.deleteAnonymousBackup();
     this.config = config;
     this.implementation = implementation.init(config, {
       useWorkflow: config.getIn(['publish_mode']) === EDITORIAL_WORKFLOW,
@@ -453,6 +455,12 @@ class Backend {
   async deleteLocalDraftBackup(collection, slug) {
     const key = getEntryBackupKey(collection.get('name'), slug);
     await localForage.removeItem(key);
+    return this.deleteAnonymousBackup();
+  }
+
+  // Unnamed backup for use in the global error boundary, should always be
+  // deleted on cms load.
+  deleteAnonymousBackup() {
     return localForage.removeItem('backup');
   }
 

--- a/packages/netlify-cms-core/src/backend.js
+++ b/packages/netlify-cms-core/src/backend.js
@@ -440,18 +440,20 @@ class Backend {
     );
   }
 
-  persistLocalDraftBackup(entry, collection) {
+  async persistLocalDraftBackup(entry, collection) {
     const key = getEntryBackupKey(collection.get('name'), entry.get('slug'));
     const raw = this.entryToRaw(collection, entry);
     if (!raw.trim()) {
       return;
     }
-    return localForage.setItem(key, { raw, path: entry.get('path') });
+    await localForage.setItem(key, { raw, path: entry.get('path') });
+    return localForage.setItem('backup', raw);
   }
 
-  deleteLocalDraftBackup(collection, slug) {
+  async deleteLocalDraftBackup(collection, slug) {
     const key = getEntryBackupKey(collection.get('name'), slug);
-    return localForage.removeItem(key);
+    await localForage.removeItem(key);
+    return localForage.removeItem('backup');
   }
 
   getEntry(collection, slug) {

--- a/packages/netlify-cms-core/src/backend.js
+++ b/packages/netlify-cms-core/src/backend.js
@@ -76,6 +76,10 @@ function getExplicitFieldReplacement(key, data) {
 }
 
 function getEntryBackupKey(collectionName, slug) {
+  const baseKey = 'backup';
+  if (!collectionName) {
+    return baseKey;
+  }
   const suffix = slug ? `.${slug}` : '';
   return `backup.${collectionName}${suffix}`;
 }
@@ -449,7 +453,7 @@ class Backend {
       return;
     }
     await localForage.setItem(key, { raw, path: entry.get('path') });
-    return localForage.setItem('backup', raw);
+    return localForage.setItem(getEntryBackupKey(), raw);
   }
 
   async deleteLocalDraftBackup(collection, slug) {
@@ -461,7 +465,7 @@ class Backend {
   // Unnamed backup for use in the global error boundary, should always be
   // deleted on cms load.
   deleteAnonymousBackup() {
-    return localForage.removeItem('backup');
+    return localForage.removeItem(getEntryBackupKey());
   }
 
   getEntry(collection, slug) {

--- a/packages/netlify-cms-core/src/components/Editor/Editor.js
+++ b/packages/netlify-cms-core/src/components/Editor/Editor.js
@@ -134,6 +134,7 @@ class Editor extends React.Component {
         return leaveMessage;
       }
     };
+
     const unblock = history.block(navigationBlocker);
 
     /**

--- a/packages/netlify-cms-core/src/components/Editor/Editor.js
+++ b/packages/netlify-cms-core/src/components/Editor/Editor.js
@@ -193,7 +193,7 @@ class Editor extends React.Component {
 
     if (prevProps.entry === this.props.entry) return;
 
-    const { entry, entryDraft, newEntry, fields, collection } = this.props;
+    const { entry, newEntry, fields, collection } = this.props;
 
     if (entry && !entry.get('isFetching') && !entry.get('error')) {
       /**
@@ -215,7 +215,7 @@ class Editor extends React.Component {
     window.removeEventListener('beforeunload', this.exitBlocker);
   }
 
-  createBackup = debounce(function (entry, collection) {
+  createBackup = debounce(function(entry, collection) {
     this.props.persistLocalBackup(entry, collection);
   }, 2000);
 
@@ -254,7 +254,6 @@ class Editor extends React.Component {
       currentStatus,
       hasWorkflow,
       loadEntry,
-      newEntry,
       slug,
       createEmptyDraft,
     } = this.props;
@@ -269,18 +268,11 @@ class Editor extends React.Component {
     } else if (slug && hasWorkflow && !currentStatus) {
       loadEntry(collection, slug);
     }
-  }
+  };
 
   handlePublishEntry = async (opts = {}) => {
     const { createNew = false } = opts;
-    const {
-      publishUnpublishedEntry,
-      entryDraft,
-      collection,
-      slug,
-      currentStatus,
-      t,
-    } = this.props;
+    const { publishUnpublishedEntry, entryDraft, collection, slug, currentStatus, t } = this.props;
     if (currentStatus !== status.last()) {
       window.alert(t('editor.editor.onPublishingNotReady'));
       return;
@@ -301,14 +293,7 @@ class Editor extends React.Component {
   };
 
   handleDeleteEntry = () => {
-    const {
-      entryDraft,
-      newEntry,
-      collection,
-      deleteEntry,
-      slug,
-      t,
-    } = this.props;
+    const { entryDraft, newEntry, collection, deleteEntry, slug, t } = this.props;
     if (entryDraft.get('hasChanged')) {
       if (!window.confirm(t('editor.editor.onDeleteWithUnsavedChanges'))) {
         return;

--- a/packages/netlify-cms-core/src/components/Editor/Editor.js
+++ b/packages/netlify-cms-core/src/components/Editor/Editor.js
@@ -175,15 +175,11 @@ class Editor extends React.Component {
     }
 
     if (!prevProps.localBackup && this.props.localBackup) {
-      if (this.props.newEntry) {
+      const confirmLoadBackup = window.confirm(this.props.t('editor.editor.confirmLoadBackup'));
+      if (confirmLoadBackup) {
         this.props.loadLocalBackup();
       } else {
-        const confirmLoadBackup = window.confirm(this.props.t('editor.editor.confirmLoadBackup'));
-        if (confirmLoadBackup) {
-          this.props.loadLocalBackup();
-        } else {
-          this.deleteBackup();
-        }
+        this.deleteBackup();
       }
     }
 

--- a/packages/netlify-cms-core/src/components/UI/ErrorBoundary.js
+++ b/packages/netlify-cms-core/src/components/UI/ErrorBoundary.js
@@ -44,7 +44,7 @@ const CopyButton = styled.button`
   ${buttons.gray};
   display: block;
   margin: 12px 0;
-`
+`;
 
 class ErrorBoundary extends React.Component {
   static propTypes = {
@@ -64,12 +64,13 @@ class ErrorBoundary extends React.Component {
   }
 
   shouldComponentUpdate(nextProps, nextState) {
-    return this.state.errorMessage !== nextState.errorMessage ||
-      this.state.backup !== nextState.backup;
+    return (
+      this.state.errorMessage !== nextState.errorMessage || this.state.backup !== nextState.backup
+    );
   }
 
   async componentDidUpdate() {
-    const backup = await localForage.getItem('backup')
+    const backup = await localForage.getItem('backup');
     console.log(backup);
     this.setState({ backup });
   }
@@ -94,18 +95,20 @@ class ErrorBoundary extends React.Component {
             {t('ui.errorBoundary.reportIt')}
           </a>
         </p>
-        <hr/>
+        <hr />
         <h2>Details</h2>
         <p>{errorMessage}</p>
-        {backup &&
+        {backup && (
           <>
-            <hr/>
+            <hr />
             <h2>Recovered document</h2>
             <strong>Please copy/paste this somewhere before navigating away!</strong>
             <CopyButton onClick={() => copyToClipboard(backup)}>Copy to clipboard</CopyButton>
-            <pre><code>{backup}</code></pre>
+            <pre>
+              <code>{backup}</code>
+            </pre>
           </>
-        }
+        )}
       </div>
     );
   }

--- a/packages/netlify-cms-core/src/components/UI/ErrorBoundary.js
+++ b/packages/netlify-cms-core/src/components/UI/ErrorBoundary.js
@@ -1,19 +1,50 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { translate } from 'react-polyglot';
-import { css } from 'react-emotion';
-import { colors } from 'netlify-cms-ui-default';
+import styled, { css } from 'react-emotion';
+import copyToClipboard from 'copy-text-to-clipboard';
+import { localForage } from 'netlify-cms-lib-util';
+import { buttons, colors } from 'netlify-cms-ui-default';
 
 const ISSUE_URL = 'https://github.com/netlify/netlify-cms/issues/new?template=bug_report.md';
 
 const styles = {
   errorBoundary: css`
-    padding: 0 20px;
+    padding: 40px;
+
+    h1 {
+      font-size: 28px;
+    }
+
+    h2 {
+      font-size: 20px;
+    }
+
+    strong {
+      color: ${colors.textLead};
+      font-weight: 500;
+    }
+
+    hr {
+      width: 200px;
+      margin: 30px 0;
+      border: 0;
+      height: 1px;
+      background-color: ${colors.text};
+    }
   `,
   errorText: css`
     color: ${colors.errorText};
   `,
 };
+
+const CopyButton = styled.button`
+  ${buttons.button};
+  ${buttons.default};
+  ${buttons.gray};
+  display: block;
+  margin: 12px 0;
+`
 
 class ErrorBoundary extends React.Component {
   static propTypes = {
@@ -24,15 +55,27 @@ class ErrorBoundary extends React.Component {
   state = {
     hasError: false,
     errorMessage: '',
+    backup: '',
   };
 
-  componentDidCatch(error) {
+  static getDerivedStateFromError(error) {
     console.error(error);
-    this.setState({ hasError: true, errorMessage: error.toString() });
+    return { hasError: true, errorMessage: error.toString() };
+  }
+
+  shouldComponentUpdate(nextProps, nextState) {
+    return this.state.errorMessage !== nextState.errorMessage ||
+      this.state.backup !== nextState.backup;
+  }
+
+  async componentDidUpdate() {
+    const backup = await localForage.getItem('backup')
+    console.log(backup);
+    this.setState({ backup });
   }
 
   render() {
-    const { hasError, errorMessage } = this.state;
+    const { hasError, errorMessage, backup } = this.state;
     if (!hasError) {
       return this.props.children;
     }
@@ -51,7 +94,18 @@ class ErrorBoundary extends React.Component {
             {t('ui.errorBoundary.reportIt')}
           </a>
         </p>
+        <hr/>
+        <h2>Details</h2>
         <p>{errorMessage}</p>
+        {backup &&
+          <>
+            <hr/>
+            <h2>Recovered document</h2>
+            <strong>Please copy/paste this somewhere before navigating away!</strong>
+            <CopyButton onClick={() => copyToClipboard(backup)}>Copy to clipboard</CopyButton>
+            <pre><code>{backup}</code></pre>
+          </>
+        }
       </div>
     );
   }

--- a/packages/netlify-cms-core/src/constants/defaultPhrases.js
+++ b/packages/netlify-cms-core/src/constants/defaultPhrases.js
@@ -117,9 +117,9 @@ export function getPhrases() {
     },
     ui: {
       errorBoundary: {
-        title: 'Sorry!',
+        title: 'Error',
         details: "There's been an error - please ",
-        reportIt: 'report it!',
+        reportIt: 'report it.',
       },
       settingsDropdown: {
         logOut: 'Log Out',

--- a/packages/netlify-cms-core/src/constants/defaultPhrases.js
+++ b/packages/netlify-cms-core/src/constants/defaultPhrases.js
@@ -59,6 +59,7 @@ export function getPhrases() {
         onDeleteUnpublishedChanges:
           'All unpublished changes to this entry will be deleted. Do you still want to delete?',
         loadingEntry: 'Loading entry...',
+        confirmLoadBackup: 'A local backup was recovered for this entry, would you like to use it?',
       },
       editorToolbar: {
         publishing: 'Publishing...',

--- a/packages/netlify-cms-core/src/formats/frontmatter.js
+++ b/packages/netlify-cms-core/src/formats/frontmatter.js
@@ -49,7 +49,7 @@ function inferFrontmatterFormat(str) {
     case '{':
       return getFormatOpts('json');
     default:
-      throw 'Unrecognized front-matter format.';
+      console.warn('Unrecognized front-matter format.');
   }
 }
 

--- a/packages/netlify-cms-core/src/reducers/entryDraft.js
+++ b/packages/netlify-cms-core/src/reducers/entryDraft.js
@@ -6,6 +6,8 @@ import {
   DRAFT_CHANGE_FIELD,
   DRAFT_VALIDATION_ERRORS,
   DRAFT_CLEAR_ERRORS,
+  DRAFT_LOCAL_BACKUP_RETRIEVED,
+  DRAFT_CREATE_FROM_LOCAL_BACKUP,
   ENTRY_PERSIST_REQUEST,
   ENTRY_PERSIST_SUCCESS,
   ENTRY_PERSIST_FAILURE,
@@ -51,8 +53,22 @@ const entryDraftReducer = (state = Map(), action) => {
         state.set('fieldsErrors', Map());
         state.set('hasChanged', false);
       });
+    case DRAFT_CREATE_FROM_LOCAL_BACKUP:
+      // Local Backup
+      return state.withMutations(state => {
+        const backupEntry = state.get('localBackup');
+        state.delete('localBackup');
+        state.set('entry', backupEntry);
+        state.setIn(['entry', 'newRecord'], !backupEntry.get('path'));
+        state.set('mediaFiles', List());
+        state.set('fieldsMetaData', Map());
+        state.set('fieldsErrors', Map());
+        state.set('hasChanged', true);
+      });
     case DRAFT_DISCARD:
       return initialState;
+    case DRAFT_LOCAL_BACKUP_RETRIEVED:
+      return state.set('localBackup', fromJS(action.payload.entry));
     case DRAFT_CHANGE_FIELD:
       return state.withMutations(state => {
         state.setIn(['entry', 'data', action.payload.field], action.payload.value);

--- a/packages/netlify-cms-widget-markdown/src/MarkdownControl/VisualEditor.js
+++ b/packages/netlify-cms-widget-markdown/src/MarkdownControl/VisualEditor.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import ImmutablePropTypes from 'react-immutable-proptypes';
 import styled, { cx } from 'react-emotion';
-import { get, isEmpty, debounce } from 'lodash';
+import { get, isEmpty, debounce, uniq } from 'lodash';
 import { List } from 'immutable';
 import { Value, Document, Block, Text } from 'slate';
 import { Editor as Slate } from 'slate-react';
@@ -48,11 +48,39 @@ export default class Editor extends React.Component {
     super(props);
     this.state = {
       value: createSlateValue(props.value),
+      lastRawValue: props.value,
     };
   }
 
   shouldComponentUpdate(nextProps, nextState) {
-    return !this.state.value.equals(nextState.value);
+    const forcePropsValue = this.shouldForcePropsValue(
+      this.props.value,
+      this.state.lastRawValue,
+      nextProps.value,
+      nextState.lastRawValue,
+    );
+    return !this.state.value.equals(nextState.value) || forcePropsValue;
+  }
+
+  componentDidUpdate(prevProps, prevState) {
+    const forcePropsValue = this.shouldForcePropsValue(
+      prevProps.value,
+      prevState.lastRawValue,
+      this.props.value,
+      this.state.lastRawValue,
+    );
+
+    if (forcePropsValue) {
+      this.setState({ value: createSlateValue(this.props.value) });
+    }
+  }
+
+  // If the old props/state values and new state value are all the same, and
+  // the new props value does not match the others, the new props value
+  // originated from outside of this widget and should be used.
+  shouldForcePropsValue(oldPropsValue, oldStateValue, newPropsValue, newStateValue) {
+    return uniq([oldPropsValue, oldStateValue, newStateValue]).length === 1
+      && oldPropsValue !== newPropsValue;
   }
 
   handlePaste = (e, data, change) => {
@@ -194,7 +222,7 @@ export default class Editor extends React.Component {
     const { onChange } = this.props;
     const raw = change.value.document.toJSON();
     const markdown = slateToMarkdown(raw);
-    onChange(markdown);
+    this.setState({ lastRawValue: markdown }, () => onChange(markdown));
   }, 150);
 
   handleChange = change => {

--- a/packages/netlify-cms-widget-markdown/src/MarkdownControl/VisualEditor.js
+++ b/packages/netlify-cms-widget-markdown/src/MarkdownControl/VisualEditor.js
@@ -79,8 +79,10 @@ export default class Editor extends React.Component {
   // the new props value does not match the others, the new props value
   // originated from outside of this widget and should be used.
   shouldForcePropsValue(oldPropsValue, oldStateValue, newPropsValue, newStateValue) {
-    return uniq([oldPropsValue, oldStateValue, newStateValue]).length === 1
-      && oldPropsValue !== newPropsValue;
+    return (
+      uniq([oldPropsValue, oldStateValue, newStateValue]).length === 1 &&
+      oldPropsValue !== newPropsValue
+    );
   }
 
   handlePaste = (e, data, change) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3477,6 +3477,11 @@ copy-descriptor@^0.1.0:
   resolved "https://registry.yarnpkg.com/copy-descriptor/-/copy-descriptor-0.1.1.tgz#676f6eb3c39997c2ee1ac3a924fd6124748f578d"
   integrity sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=
 
+copy-text-to-clipboard@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/copy-text-to-clipboard/-/copy-text-to-clipboard-1.0.4.tgz#2286ff6c53495962c5318d34746d256939069c49"
+  integrity sha512-4hDE+0bgqm4G/nXnt91CP3rc0vOptaePPU5WfVZuhv2AYNJogdLHR4pF1XPgXDAGY4QCzj9pD7zKATa+50sQPg==
+
 copy-webpack-plugin@^4.5.2:
   version "4.5.2"
   resolved "https://registry.yarnpkg.com/copy-webpack-plugin/-/copy-webpack-plugin-4.5.2.tgz#d53444a8fea2912d806e78937390ddd7e632ee5c"


### PR DESCRIPTION
- Regularly persists changes to browser storage, prompts to load local changes after unexpected exit.
- Displays raw entry (if available) on error screen w/ copy to clipboard button.

The next iteration for this functionality, though not a current priority, is to stop trying to do things when the browser is unloading, and instead create highly visible auto-saving functionality that persists to the backend, allowing the user to manage any auto-saved versions in the UI.

Closes #388 
Closes #1752 