### PR TITLE
Strip leading slashes from collection location config

### DIFF
--- a/packages/netlify-cms-core/src/actions/__tests__/config.spec.js
+++ b/packages/netlify-cms-core/src/actions/__tests__/config.spec.js
@@ -8,6 +8,7 @@ describe('config', () => {
         foo: 'bar',
         media_folder: 'path/to/media',
         public_folder: '/path/to/media',
+        collections: [],
       });
       expect(applyDefaults(config)).toEqual(config.set('publish_mode', 'simple'));
     });
@@ -18,6 +19,7 @@ describe('config', () => {
         publish_mode: 'complex',
         media_folder: 'path/to/media',
         public_folder: '/path/to/media',
+        collections: [],
       });
       expect(applyDefaults(config)).toEqual(config);
     });
@@ -28,6 +30,7 @@ describe('config', () => {
           fromJS({
             foo: 'bar',
             media_folder: 'path/to/media',
+            collections: [],
           }),
         ),
       ).toEqual(
@@ -36,6 +39,7 @@ describe('config', () => {
           publish_mode: 'simple',
           media_folder: 'path/to/media',
           public_folder: '/path/to/media',
+          collections: [],
         }),
       );
     });
@@ -47,6 +51,7 @@ describe('config', () => {
             foo: 'bar',
             media_folder: 'path/to/media',
             public_folder: '/publib/path',
+            collections: [],
           }),
         ),
       ).toEqual(
@@ -55,6 +60,39 @@ describe('config', () => {
           publish_mode: 'simple',
           media_folder: 'path/to/media',
           public_folder: '/publib/path',
+          collections: [],
+        }),
+      );
+    });
+
+    it('should strip leading slashes from collection folder', () => {
+      expect(
+        applyDefaults(
+          fromJS({
+            collections: [{ folder: '/foo' }],
+          }),
+        )
+      ).toEqual(
+        fromJS({
+          publish_mode: 'simple',
+          public_folder: '/',
+          collections: [{ folder: 'foo' }],
+        }),
+      );
+    });
+
+    it('should strip leading slashes from collection files', () => {
+      expect(
+        applyDefaults(
+          fromJS({
+            collections: [{ files: [{ file: '/foo' }] }],
+          }),
+        )
+      ).toEqual(
+        fromJS({
+          publish_mode: 'simple',
+          public_folder: '/',
+          collections: [{ files: [{ file: 'foo' }] }],
         }),
       );
     });

--- a/packages/netlify-cms-core/src/actions/__tests__/config.spec.js
+++ b/packages/netlify-cms-core/src/actions/__tests__/config.spec.js
@@ -71,7 +71,7 @@ describe('config', () => {
           fromJS({
             collections: [{ folder: '/foo' }],
           }),
-        )
+        ),
       ).toEqual(
         fromJS({
           publish_mode: 'simple',
@@ -87,7 +87,7 @@ describe('config', () => {
           fromJS({
             collections: [{ files: [{ file: '/foo' }] }],
           }),
-        )
+        ),
       ).toEqual(
         fromJS({
           publish_mode: 'simple',

--- a/packages/netlify-cms-core/src/actions/config.js
+++ b/packages/netlify-cms-core/src/actions/config.js
@@ -30,19 +30,32 @@ export function applyDefaults(config) {
   return Map(defaults)
     .mergeDeep(config)
     .withMutations(map => {
-      /**
-       * Use `site_url` as default `display_url`.
-       */
+
+      // Use `site_url` as default `display_url`.
       if (!map.get('display_url') && map.get('site_url')) {
         map.set('display_url', map.get('site_url'));
       }
-      /**
-       * Use media_folder as default public_folder.
-       */
+
+      // Use media_folder as default public_folder.
       const defaultPublicFolder = `/${trimStart(map.get('media_folder'), '/')}`;
       if (!map.get('public_folder')) {
         map.set('public_folder', defaultPublicFolder);
       }
+
+      // Strip leading slash from collection folders and files
+      map.set('collections', map.get('collections').map(collection => {
+        const folder = collection.get('folder');
+        if (folder) {
+          return collection.set('folder', trimStart(folder, '/'));
+        }
+
+        const files = collection.get('files');
+        if (files) {
+          return collection.set('files', files.map(file => {
+            return file.set('file', trimStart(file.get('file'), '/'));
+          }));
+        }
+      }));
     });
 }
 
@@ -128,7 +141,9 @@ export function loadConfig() {
       const mergedConfig = mergePreloadedConfig(preloadedConfig, loadedConfig);
       validateConfig(mergedConfig.toJS());
 
+      console.log(mergedConfig);
       const config = applyDefaults(mergedConfig);
+      console.log(config);
 
       dispatch(configDidLoad(config));
       dispatch(authenticateUser());

--- a/packages/netlify-cms-core/src/actions/config.js
+++ b/packages/netlify-cms-core/src/actions/config.js
@@ -141,9 +141,7 @@ export function loadConfig() {
       const mergedConfig = mergePreloadedConfig(preloadedConfig, loadedConfig);
       validateConfig(mergedConfig.toJS());
 
-      console.log(mergedConfig);
       const config = applyDefaults(mergedConfig);
-      console.log(config);
 
       dispatch(configDidLoad(config));
       dispatch(authenticateUser());

--- a/packages/netlify-cms-core/src/actions/config.js
+++ b/packages/netlify-cms-core/src/actions/config.js
@@ -30,7 +30,6 @@ export function applyDefaults(config) {
   return Map(defaults)
     .mergeDeep(config)
     .withMutations(map => {
-
       // Use `site_url` as default `display_url`.
       if (!map.get('display_url') && map.get('site_url')) {
         map.set('display_url', map.get('site_url'));
@@ -43,19 +42,25 @@ export function applyDefaults(config) {
       }
 
       // Strip leading slash from collection folders and files
-      map.set('collections', map.get('collections').map(collection => {
-        const folder = collection.get('folder');
-        if (folder) {
-          return collection.set('folder', trimStart(folder, '/'));
-        }
+      map.set(
+        'collections',
+        map.get('collections').map(collection => {
+          const folder = collection.get('folder');
+          if (folder) {
+            return collection.set('folder', trimStart(folder, '/'));
+          }
 
-        const files = collection.get('files');
-        if (files) {
-          return collection.set('files', files.map(file => {
-            return file.set('file', trimStart(file.get('file'), '/'));
-          }));
-        }
-      }));
+          const files = collection.get('files');
+          if (files) {
+            return collection.set(
+              'files',
+              files.map(file => {
+                return file.set('file', trimStart(file.get('file'), '/'));
+              }),
+            );
+          }
+        }),
+      );
     });
 }
 


### PR DESCRIPTION
Strip leading slashes from a collections `folder` or `file` properties.

Closes #821.