### PR TITLE
[WIP] Fix searchFields with single value

### DIFF
--- a/packages/netlify-cms-widget-relation/src/RelationControl.js
+++ b/packages/netlify-cms-widget-relation/src/RelationControl.js
@@ -130,9 +130,10 @@ export default class RelationControl extends React.Component {
   loadOptions = debounce((term, callback) => {
     const { field, query, forID } = this.props;
     const collection = field.get('collection');
-    const searchFields = field.get('searchFields').toJS();
+    const searchFields = field.get('searchFields');
+    const searchFieldsArray = List.isList(searchFields) ? searchFields.toJS() : [searchFields];
 
-    query(forID, collection, searchFields, term).then(({ payload }) => {
+    query(forID, collection, searchFieldsArray, term).then(({ payload }) => {
       let options = this.parseHitOptions(payload.response.hits);
 
       if (!this.allOptions && !term) {


### PR DESCRIPTION
Fixes #2114.

**Summary**
This fixes an uncaught error with relation widgets where searchFields is set to a string and not a list of values.

**Test plan**
Truth be told, I have not manually tested this code because I don't know how to. `searchFields` and `displayFields` could probably use regression tests for this bug, but I don't know how to add those. 

**Cute Animal**
[Here's a sleeping Koala.](https://unsplash.com/photos/EerxztHCjM8)
