### PR TITLE
feat(core): Allow customising the collection list based on multiple fields

### DIFF
--- a/dev-test/config.yml
+++ b/dev-test/config.yml
@@ -14,8 +14,8 @@ collections: # A list of collections the CMS should be able to edit
       The description is a great place for tone setting, high level information, and editing
       guidelines that are specific to a collection.
     folder: '_posts'
-    summary: '{{title}} {{year}}/{{month}}/{{day}}'
     slug: '{{year}}-{{month}}-{{day}}-{{slug}}'
+    summary: '{{title}} -- {{year}}/{{month}}/{{day}}'
     create: true # Allow users to create new documents in this collection
     fields: # The fields each document in this collection have
       - { label: 'Title', name: 'title', widget: 'string', tagname: 'h1' }
@@ -40,12 +40,10 @@ collections: # A list of collections the CMS should be able to edit
   - name: 'faq' # Used in routes, ie.: /admin/collections/:slug/edit
     label: 'FAQ' # Used in the UI
     folder: '_faqs'
-    summary: 'Version: {{version}}  -  {{title}}'
     create: true # Allow users to create new documents in this collection
     fields: # The fields each document in this collection have
       - { label: 'Question', name: 'title', widget: 'string', tagname: 'h1' }
       - { label: 'Answer', name: 'body', widget: 'markdown' }
-      - { label: 'Version', name: 'version', widget: 'string', default : '1.01' }
 
   - name: 'settings'
     label: 'Settings'

--- a/dev-test/config.yml
+++ b/dev-test/config.yml
@@ -39,8 +39,7 @@ collections: # A list of collections the CMS should be able to edit
   - name: 'faq' # Used in routes, ie.: /admin/collections/:slug/edit
     label: 'FAQ' # Used in the UI
     folder: '_faqs'
-    list_fields: ['version','title']
-    list_fields_seperator: ' - '
+    summary: 'Version: {{version}}  -  {{title}}'
     create: true # Allow users to create new documents in this collection
     fields: # The fields each document in this collection have
       - { label: 'Question', name: 'title', widget: 'string', tagname: 'h1' }

--- a/dev-test/config.yml
+++ b/dev-test/config.yml
@@ -39,10 +39,13 @@ collections: # A list of collections the CMS should be able to edit
   - name: 'faq' # Used in routes, ie.: /admin/collections/:slug/edit
     label: 'FAQ' # Used in the UI
     folder: '_faqs'
+    list_fields: ['version','title']
+    list_fields_seperator: ' - '
     create: true # Allow users to create new documents in this collection
     fields: # The fields each document in this collection have
       - { label: 'Question', name: 'title', widget: 'string', tagname: 'h1' }
       - { label: 'Answer', name: 'body', widget: 'markdown' }
+      - { label: 'Version', name: 'version', widget: 'string', default : '1.01' }
 
   - name: 'settings'
     label: 'Settings'

--- a/dev-test/config.yml
+++ b/dev-test/config.yml
@@ -14,6 +14,7 @@ collections: # A list of collections the CMS should be able to edit
       The description is a great place for tone setting, high level information, and editing
       guidelines that are specific to a collection.
     folder: '_posts'
+    summary: '{{title}}-{{year}}-{{month}}-{{day}}'
     slug: '{{year}}-{{month}}-{{day}}-{{slug}}'
     create: true # Allow users to create new documents in this collection
     fields: # The fields each document in this collection have

--- a/dev-test/config.yml
+++ b/dev-test/config.yml
@@ -14,7 +14,7 @@ collections: # A list of collections the CMS should be able to edit
       The description is a great place for tone setting, high level information, and editing
       guidelines that are specific to a collection.
     folder: '_posts'
-    summary: '{{title}}-{{year}}-{{month}}-{{day}}'
+    summary: '{{title}} {{year}}/{{month}}/{{day}}'
     slug: '{{year}}-{{month}}-{{day}}-{{slug}}'
     create: true # Allow users to create new documents in this collection
     fields: # The fields each document in this collection have

--- a/dev-test/index.html
+++ b/dev-test/index.html
@@ -22,16 +22,16 @@
     },
     _faqs: {
       "what-is-netlify-cms.md": {
-        content: "---\nversion: '1.0'\ntitle: What is netlify CMS?\ndate: 2015-11-02T00:00.000Z\n---\n\n# Netlify CMS is Content Manager for Static Site Generators\n\nStatic sites are many times faster, cheaper and safer and traditional dynamic websites.\n\nModern static site generators like Jekyll, Middleman, Roots or Hugo are powerful publishing and development systems, but when we build sites for non-technical users, we need a layer on top of them.\n\nNetlify CMS is there to let your marketing team push new content to your public site, or to let technical writers work on your documentation.\n\nNetlify CMS integrates with Git and turns normal content editors into git comitters.\n\n"
+        content: "---\ntitle: What is netlify CMS?\ndate: 2015-11-02T00:00.000Z\n---\n\n# Netlify CMS is Content Manager for Static Site Generators\n\nStatic sites are many times faster, cheaper and safer and traditional dynamic websites.\n\nModern static site generators like Jekyll, Middleman, Roots or Hugo are powerful publishing and development systems, but when we build sites for non-technical users, we need a layer on top of them.\n\nNetlify CMS is there to let your marketing team push new content to your public site, or to let technical writers work on your documentation.\n\nNetlify CMS integrates with Git and turns normal content editors into git comitters.\n\n"
       },
       "what-is-jam-stack.md": {
-        content: "---\nversion: '1.0'\ntitle: What is the “JAM Stack”?\ndate: 2015-11-02T00:00.000Z\n---\n\n# The JAM stack is a new way of building websites and apps that are fast, secure and simple to work with.\n\nJAM stands for JavaScript, APIs and Markup. It's the fastest growing new stack for building websites and apps: no more servers, host all your front-end on a CDN and use APIs for any moving parts.\n\n"
+        content: "---\ntitle: What is the “JAM Stack”?\ndate: 2015-11-02T00:00.000Z\n---\n\n# The JAM stack is a new way of building websites and apps that are fast, secure and simple to work with.\n\nJAM stands for JavaScript, APIs and Markup. It's the fastest growing new stack for building websites and apps: no more servers, host all your front-end on a CDN and use APIs for any moving parts.\n\n"
       },
       "cache-invalidation.md": {
-        content: "---\nversion: '2.0'\ntitle: What about Cache Invalidation?\ndate: 2015-11-02T00:00.000Z\n---\n\n# Netlify handles cache invalidation automatically\n\nWhen your changes go live, they go live.\n\nNo waiting for cache purges, no cumbersome varnish setup, no API calls to clean your distribution. Netlify handles cache purges within an average of 250ms from your deploy!\n\n"
+        content: "---\ntitle: What about Cache Invalidation?\ndate: 2015-11-02T00:00.000Z\n---\n\n# Netlify handles cache invalidation automatically\n\nWhen your changes go live, they go live.\n\nNo waiting for cache purges, no cumbersome varnish setup, no API calls to clean your distribution. Netlify handles cache purges within an average of 250ms from your deploy!\n\n"
       },
       "continuous-deployment.md": {
-        content: "---\nversion: '1.1'\ntitle: Does Netlify support Continuous Deployment?\ndate: 2015-11-02T00:00.000Z\n---\n\n# Yes, Netlify let you Integrate your site or web-app to GitHub, GitLab or BitBucket and run your build tool on our servers.\n\nAutomatically rebuild your site every time your content changes: trigger builds by pushing to git or via webhooks.\n\n"
+        content: "---\ntitle: Does Netlify support Continuous Deployment?\ndate: 2015-11-02T00:00.000Z\n---\n\n# Yes, Netlify let you Integrate your site or web-app to GitHub, GitLab or BitBucket and run your build tool on our servers.\n\nAutomatically rebuild your site every time your content changes: trigger builds by pushing to git or via webhooks.\n\n"
       }
     },
     _data: {
@@ -71,7 +71,7 @@
     var slug = dateString + "-faq-number-" + i + ".md";
 
     window.repoFiles._faqs[slug] = {
-      content: "---\nversion: '1." + i + "'\ntitle: \"This FAQ item # " + i + "\"\ndate: " + dateString + "T00:99:99.999Z\n---\n\n# Loren ipsum dolor sit amet"
+      content: "---\ntitle: \"This FAQ item # " + i + "\"\ndate: " + dateString + "T00:99:99.999Z\n---\n\n# Loren ipsum dolor sit amet"
     }
   }
   </script>

--- a/dev-test/index.html
+++ b/dev-test/index.html
@@ -22,16 +22,16 @@
     },
     _faqs: {
       "what-is-netlify-cms.md": {
-        content: "---\ntitle: What is netlify CMS?\ndate: 2015-11-02T00:00.000Z\n---\n\n# Netlify CMS is Content Manager for Static Site Generators\n\nStatic sites are many times faster, cheaper and safer and traditional dynamic websites.\n\nModern static site generators like Jekyll, Middleman, Roots or Hugo are powerful publishing and development systems, but when we build sites for non-technical users, we need a layer on top of them.\n\nNetlify CMS is there to let your marketing team push new content to your public site, or to let technical writers work on your documentation.\n\nNetlify CMS integrates with Git and turns normal content editors into git comitters.\n\n"
+        content: "---\nversion: '1.0'\ntitle: What is netlify CMS?\ndate: 2015-11-02T00:00.000Z\n---\n\n# Netlify CMS is Content Manager for Static Site Generators\n\nStatic sites are many times faster, cheaper and safer and traditional dynamic websites.\n\nModern static site generators like Jekyll, Middleman, Roots or Hugo are powerful publishing and development systems, but when we build sites for non-technical users, we need a layer on top of them.\n\nNetlify CMS is there to let your marketing team push new content to your public site, or to let technical writers work on your documentation.\n\nNetlify CMS integrates with Git and turns normal content editors into git comitters.\n\n"
       },
       "what-is-jam-stack.md": {
-        content: "---\ntitle: What is the “JAM Stack”?\ndate: 2015-11-02T00:00.000Z\n---\n\n# The JAM stack is a new way of building websites and apps that are fast, secure and simple to work with.\n\nJAM stands for JavaScript, APIs and Markup. It's the fastest growing new stack for building websites and apps: no more servers, host all your front-end on a CDN and use APIs for any moving parts.\n\n"
+        content: "---\nversion: '1.0'\ntitle: What is the “JAM Stack”?\ndate: 2015-11-02T00:00.000Z\n---\n\n# The JAM stack is a new way of building websites and apps that are fast, secure and simple to work with.\n\nJAM stands for JavaScript, APIs and Markup. It's the fastest growing new stack for building websites and apps: no more servers, host all your front-end on a CDN and use APIs for any moving parts.\n\n"
       },
       "cache-invalidation.md": {
-        content: "---\ntitle: What about Cache Invalidation?\ndate: 2015-11-02T00:00.000Z\n---\n\n# Netlify handles cache invalidation automatically\n\nWhen your changes go live, they go live.\n\nNo waiting for cache purges, no cumbersome varnish setup, no API calls to clean your distribution. Netlify handles cache purges within an average of 250ms from your deploy!\n\n"
+        content: "---\nversion: '1.0'\ntitle: What about Cache Invalidation?\ndate: 2015-11-02T00:00.000Z\n---\n\n# Netlify handles cache invalidation automatically\n\nWhen your changes go live, they go live.\n\nNo waiting for cache purges, no cumbersome varnish setup, no API calls to clean your distribution. Netlify handles cache purges within an average of 250ms from your deploy!\n\n"
       },
       "continuous-deployment.md": {
-        content: "---\ntitle: Does Netlify support Continuous Deployment?\ndate: 2015-11-02T00:00.000Z\n---\n\n# Yes, Netlify let you Integrate your site or web-app to GitHub, GitLab or BitBucket and run your build tool on our servers.\n\nAutomatically rebuild your site every time your content changes: trigger builds by pushing to git or via webhooks.\n\n"
+        content: "---\nversion: '1.0'\ntitle: Does Netlify support Continuous Deployment?\ndate: 2015-11-02T00:00.000Z\n---\n\n# Yes, Netlify let you Integrate your site or web-app to GitHub, GitLab or BitBucket and run your build tool on our servers.\n\nAutomatically rebuild your site every time your content changes: trigger builds by pushing to git or via webhooks.\n\n"
       }
     },
     _data: {
@@ -71,7 +71,7 @@
     var slug = dateString + "-faq-number-" + i + ".md";
 
     window.repoFiles._faqs[slug] = {
-      content: "---\ntitle: \"This FAQ item # " + i + "\"\ndate: " + dateString + "T00:99:99.999Z\n---\n\n# Loren ipsum dolor sit amet"
+      content: "---\nversion: '1.0'\ntitle: \"This FAQ item # " + i + "\"\ndate: " + dateString + "T00:99:99.999Z\n---\n\n# Loren ipsum dolor sit amet"
     }
   }
   </script>

--- a/dev-test/index.html
+++ b/dev-test/index.html
@@ -28,10 +28,10 @@
         content: "---\nversion: '1.0'\ntitle: What is the “JAM Stack”?\ndate: 2015-11-02T00:00.000Z\n---\n\n# The JAM stack is a new way of building websites and apps that are fast, secure and simple to work with.\n\nJAM stands for JavaScript, APIs and Markup. It's the fastest growing new stack for building websites and apps: no more servers, host all your front-end on a CDN and use APIs for any moving parts.\n\n"
       },
       "cache-invalidation.md": {
-        content: "---\nversion: '1.0'\ntitle: What about Cache Invalidation?\ndate: 2015-11-02T00:00.000Z\n---\n\n# Netlify handles cache invalidation automatically\n\nWhen your changes go live, they go live.\n\nNo waiting for cache purges, no cumbersome varnish setup, no API calls to clean your distribution. Netlify handles cache purges within an average of 250ms from your deploy!\n\n"
+        content: "---\nversion: '2.0'\ntitle: What about Cache Invalidation?\ndate: 2015-11-02T00:00.000Z\n---\n\n# Netlify handles cache invalidation automatically\n\nWhen your changes go live, they go live.\n\nNo waiting for cache purges, no cumbersome varnish setup, no API calls to clean your distribution. Netlify handles cache purges within an average of 250ms from your deploy!\n\n"
       },
       "continuous-deployment.md": {
-        content: "---\nversion: '1.0'\ntitle: Does Netlify support Continuous Deployment?\ndate: 2015-11-02T00:00.000Z\n---\n\n# Yes, Netlify let you Integrate your site or web-app to GitHub, GitLab or BitBucket and run your build tool on our servers.\n\nAutomatically rebuild your site every time your content changes: trigger builds by pushing to git or via webhooks.\n\n"
+        content: "---\nversion: '1.1'\ntitle: Does Netlify support Continuous Deployment?\ndate: 2015-11-02T00:00.000Z\n---\n\n# Yes, Netlify let you Integrate your site or web-app to GitHub, GitLab or BitBucket and run your build tool on our servers.\n\nAutomatically rebuild your site every time your content changes: trigger builds by pushing to git or via webhooks.\n\n"
       }
     },
     _data: {
@@ -71,7 +71,7 @@
     var slug = dateString + "-faq-number-" + i + ".md";
 
     window.repoFiles._faqs[slug] = {
-      content: "---\nversion: '1.0'\ntitle: \"This FAQ item # " + i + "\"\ndate: " + dateString + "T00:99:99.999Z\n---\n\n# Loren ipsum dolor sit amet"
+      content: "---\nversion: '1." + i + "'\ntitle: \"This FAQ item # " + i + "\"\ndate: " + dateString + "T00:99:99.999Z\n---\n\n# Loren ipsum dolor sit amet"
     }
   }
   </script>

--- a/packages/netlify-cms-core/src/backend.js
+++ b/packages/netlify-cms-core/src/backend.js
@@ -389,11 +389,15 @@ class Backend {
     const errors = [];
     const collectionEntriesRequests = collections
       .map(async collection => {
+        let summaryString = collection.get('summary') || "";
+        let results = summaryString ? summaryString.match(/(?<=\{\{)[^}]+(?=\}\})/g) : [];
+
         // TODO: pass search fields in as an argument
         const searchFields = [
           selectInferedField(collection, 'title'),
           selectInferedField(collection, 'shortTitle'),
           selectInferedField(collection, 'author'),
+          ...results
         ];
         const collectionEntries = await this.listAllEntries(collection);
         return fuzzy.filter(searchTerm, collectionEntries, {

--- a/packages/netlify-cms-core/src/backend.js
+++ b/packages/netlify-cms-core/src/backend.js
@@ -1,4 +1,4 @@
-import { attempt, flatten, isError, trimStart, trimEnd, flow, partialRight } from 'lodash';
+import { attempt, flatten, isError, trimStart, trimEnd, flow, partialRight, uniq } from 'lodash';
 import { Map } from 'immutable';
 import { stripIndent } from 'common-tags';
 import moment from 'moment';
@@ -20,6 +20,11 @@ import { sanitizeSlug } from 'Lib/urlHelper';
 import { getBackend } from 'Lib/registry';
 import { localForage, Cursor, CURSOR_COMPATIBILITY_SYMBOL } from 'netlify-cms-lib-util';
 import { EDITORIAL_WORKFLOW, status } from 'Constants/publishModes';
+import {
+  SLUG_MISSING_REQUIRED_DATE,
+  compileStringTemplate,
+  extractTemplateVars,
+} from 'Lib/stringTemplate';
 
 class LocalStorageAuthStore {
   storageKey = 'netlify-cms-user';
@@ -53,28 +58,6 @@ function prepareSlug(slug) {
   );
 }
 
-const dateParsers = {
-  year: date => date.getFullYear(),
-  month: date => `0${date.getMonth() + 1}`.slice(-2),
-  day: date => `0${date.getDate()}`.slice(-2),
-  hour: date => `0${date.getHours()}`.slice(-2),
-  minute: date => `0${date.getMinutes()}`.slice(-2),
-  second: date => `0${date.getSeconds()}`.slice(-2),
-};
-
-const SLUG_MISSING_REQUIRED_DATE = 'SLUG_MISSING_REQUIRED_DATE';
-const USE_FIELD_PREFIX = 'fields.';
-
-// Allow `fields.` prefix in placeholder to override built in replacements
-// like "slug" and "year" with values from fields of the same name.
-function getExplicitFieldReplacement(key, data) {
-  if (!key.startsWith(USE_FIELD_PREFIX)) {
-    return;
-  }
-  const fieldName = key.substring(USE_FIELD_PREFIX.length);
-  return data.get(fieldName, '');
-}
-
 function getEntryBackupKey(collectionName, slug) {
   const baseKey = 'backup';
   if (!collectionName) {
@@ -87,42 +70,6 @@ function getEntryBackupKey(collectionName, slug) {
 function getLabelForFileCollectionEntry(collection, path) {
   const files = collection.get('files');
   return files && files.find(f => f.get('file') === path).get('label');
-}
-
-export function compileSlug(template, date, identifier = '', data = Map(), processor) {
-  let missingRequiredDate;
-
-  const slug = template.replace(/\{\{([^}]+)\}\}/g, (_, key) => {
-    let replacement;
-    const explicitFieldReplacement = getExplicitFieldReplacement(key, data);
-
-    if (explicitFieldReplacement) {
-      replacement = explicitFieldReplacement;
-    } else if (dateParsers[key] && !date) {
-      missingRequiredDate = true;
-      return '';
-    } else if (dateParsers[key]) {
-      replacement = dateParsers[key](date);
-    } else if (key === 'slug') {
-      replacement = identifier;
-    } else {
-      replacement = data.get(key, '');
-    }
-
-    if (processor) {
-      return processor(replacement);
-    }
-
-    return replacement;
-  });
-
-  if (missingRequiredDate) {
-    const err = new Error();
-    err.name = SLUG_MISSING_REQUIRED_DATE;
-    throw err;
-  } else {
-    return slug;
-  }
 }
 
 function slugFormatter(collection, entryData, slugConfig) {
@@ -138,7 +85,11 @@ function slugFormatter(collection, entryData, slugConfig) {
   // Pass entire slug through `prepareSlug` and `sanitizeSlug`.
   // TODO: only pass slug replacements through sanitizers, static portions of
   // the slug template should not be sanitized. (breaking change)
-  const processSlug = flow([compileSlug, prepareSlug, partialRight(sanitizeSlug, slugConfig)]);
+  const processSlug = flow([
+    compileStringTemplate,
+    prepareSlug,
+    partialRight(sanitizeSlug, slugConfig),
+  ]);
 
   return processSlug(template, new Date(), identifier, entryData);
 }
@@ -233,7 +184,7 @@ function createPreviewUrl(baseUrl, collection, slug, slugConfig, entry) {
   let compiledPath;
 
   try {
-    compiledPath = compileSlug(pathTemplate, date, slug, fields, processSegment);
+    compiledPath = compileStringTemplate(pathTemplate, date, slug, fields, processSegment);
   } catch (err) {
     // Print an error and ignore `preview_path` if both:
     //   1. Date is invalid (according to Moment), and
@@ -384,21 +335,19 @@ class Backend {
     const errors = [];
     const collectionEntriesRequests = collections
       .map(async collection => {
-        let summaryString = collection.get('summary') || '';
-        let results = summaryString ? summaryString.match(/(?<=\{\{)[^}]+(?=\}\})/g) : [];
+        const summary = collection.get('summary', '');
+        const summaryFields = extractTemplateVars(summary);
 
         // TODO: pass search fields in as an argument
         const searchFields = [
-          ...new Set([
-            selectInferedField(collection, 'title'),
-            selectInferedField(collection, 'shortTitle'),
-            selectInferedField(collection, 'author'),
-            ...results,
-          ]),
+          selectInferedField(collection, 'title'),
+          selectInferedField(collection, 'shortTitle'),
+          selectInferedField(collection, 'author'),
+          ...summaryFields,
         ];
         const collectionEntries = await this.listAllEntries(collection);
         return fuzzy.filter(searchTerm, collectionEntries, {
-          extract: extractSearchFields(searchFields),
+          extract: extractSearchFields(uniq(searchFields)),
         });
       })
       .map(p => p.catch(err => errors.push(err) && []));

--- a/packages/netlify-cms-core/src/backend.js
+++ b/packages/netlify-cms-core/src/backend.js
@@ -125,20 +125,15 @@ export function compileSlug(template, date, identifier = '', data = Map(), proce
   }
 }
 
-export function getIdentifier(entryData, collection) {
+function slugFormatter(collection, entryData, slugConfig) {
+  const template = collection.get('slug') || '{{slug}}';
+
   const identifier = entryData.get(selectIdentifier(collection));
   if (!identifier) {
     throw new Error(
       'Collection must have a field name that is a valid entry identifier, or must have `identifier_field` set',
     );
   }
-  return identifier;
-}
-
-function slugFormatter(collection, entryData, slugConfig) {
-  const template = collection.get('slug') || '{{slug}}';
-
-  const identifier = getIdentifier(entryData, collection);
 
   // Pass entire slug through `prepareSlug` and `sanitizeSlug`.
   // TODO: only pass slug replacements through sanitizers, static portions of

--- a/packages/netlify-cms-core/src/backend.js
+++ b/packages/netlify-cms-core/src/backend.js
@@ -64,7 +64,7 @@ function getEntryBackupKey(collectionName, slug) {
     return baseKey;
   }
   const suffix = slug ? `.${slug}` : '';
-  return `backup.${collectionName}${suffix}`;
+  return `${baseKey}.${collectionName}${suffix}`;
 }
 
 function getLabelForFileCollectionEntry(collection, path) {
@@ -134,7 +134,7 @@ const sortByScore = (a, b) => {
   return 0;
 };
 
-function parsePreviewPathDate(collection, entry) {
+export function parsePreviewPathDate(collection, entry) {
   const dateField =
     collection.get('preview_path_date_field') || selectInferedField(collection, 'date');
   if (!dateField) {

--- a/packages/netlify-cms-core/src/backend.js
+++ b/packages/netlify-cms-core/src/backend.js
@@ -394,10 +394,12 @@ class Backend {
 
         // TODO: pass search fields in as an argument
         const searchFields = [
-          selectInferedField(collection, 'title'),
-          selectInferedField(collection, 'shortTitle'),
-          selectInferedField(collection, 'author'),
-          ...results,
+          ...new Set([
+            selectInferedField(collection, 'title'),
+            selectInferedField(collection, 'shortTitle'),
+            selectInferedField(collection, 'author'),
+            ...results,
+          ]),
         ];
         const collectionEntries = await this.listAllEntries(collection);
         return fuzzy.filter(searchTerm, collectionEntries, {

--- a/packages/netlify-cms-core/src/backend.js
+++ b/packages/netlify-cms-core/src/backend.js
@@ -389,7 +389,7 @@ class Backend {
     const errors = [];
     const collectionEntriesRequests = collections
       .map(async collection => {
-        let summaryString = collection.get('summary') || "";
+        let summaryString = collection.get('summary') || '';
         let results = summaryString ? summaryString.match(/(?<=\{\{)[^}]+(?=\}\})/g) : [];
 
         // TODO: pass search fields in as an argument
@@ -397,7 +397,7 @@ class Backend {
           selectInferedField(collection, 'title'),
           selectInferedField(collection, 'shortTitle'),
           selectInferedField(collection, 'author'),
-          ...results
+          ...results,
         ];
         const collectionEntries = await this.listAllEntries(collection);
         return fuzzy.filter(searchTerm, collectionEntries, {

--- a/packages/netlify-cms-core/src/backend.js
+++ b/packages/netlify-cms-core/src/backend.js
@@ -24,6 +24,7 @@ import {
   compileStringTemplate,
   extractTemplateVars,
   parseDateFromEntry,
+  dateParsers,
 } from 'Lib/stringTemplate';
 
 class LocalStorageAuthStore {
@@ -329,7 +330,12 @@ class Backend {
           selectInferedField(collection, 'title'),
           selectInferedField(collection, 'shortTitle'),
           selectInferedField(collection, 'author'),
-          ...summaryFields,
+          ...summaryFields.map(elem => {
+            if (dateParsers[elem]) {
+              return selectInferedField(collection, 'date');
+            }
+            return elem;
+          }),
         ];
         const collectionEntries = await this.listAllEntries(collection);
         return fuzzy.filter(searchTerm, collectionEntries, {

--- a/packages/netlify-cms-core/src/backend.js
+++ b/packages/netlify-cms-core/src/backend.js
@@ -89,7 +89,7 @@ function getLabelForFileCollectionEntry(collection, path) {
   return files && files.find(f => f.get('file') === path).get('label');
 }
 
-function compileSlug(template, date, identifier = '', data = Map(), processor) {
+export function compileSlug(template, date, identifier = '', data = Map(), processor) {
   let missingRequiredDate;
 
   const slug = template.replace(/\{\{([^}]+)\}\}/g, (_, key) => {
@@ -125,15 +125,20 @@ function compileSlug(template, date, identifier = '', data = Map(), processor) {
   }
 }
 
-function slugFormatter(collection, entryData, slugConfig) {
-  const template = collection.get('slug') || '{{slug}}';
-
+export function getIdentifier(entryData, collection) {
   const identifier = entryData.get(selectIdentifier(collection));
   if (!identifier) {
     throw new Error(
       'Collection must have a field name that is a valid entry identifier, or must have `identifier_field` set',
     );
   }
+  return identifier;
+}
+
+function slugFormatter(collection, entryData, slugConfig) {
+  const template = collection.get('slug') || '{{slug}}';
+
+  const identifier = getIdentifier(entryData, collection);
 
   // Pass entire slug through `prepareSlug` and `sanitizeSlug`.
   // TODO: only pass slug replacements through sanitizers, static portions of

--- a/packages/netlify-cms-core/src/components/Collection/Entries/EntryCard.js
+++ b/packages/netlify-cms-core/src/components/Collection/Entries/EntryCard.js
@@ -6,7 +6,7 @@ import { colors, colorsRaw, components, lengths } from 'netlify-cms-ui-default';
 import { VIEW_STYLE_LIST, VIEW_STYLE_GRID } from 'Constants/collectionViews';
 import { compileStringTemplate } from 'Lib/stringTemplate';
 import { selectIdentifier } from 'Reducers/collections';
-import { parsePreviewPathDate } from 'backend';
+import { parsePreviewPathDate } from 'coreSrc/backend';
 
 const ListCard = styled.li`
   ${components.card};

--- a/packages/netlify-cms-core/src/components/Collection/Entries/EntryCard.js
+++ b/packages/netlify-cms-core/src/components/Collection/Entries/EntryCard.js
@@ -89,8 +89,17 @@ const EntryCard = ({
   viewStyle = VIEW_STYLE_LIST,
 }) => {
   const label = entry.get('label');
-  const title = label || entry.getIn(['data', inferedFields.titleField]);
+  let title = label || entry.getIn(['data', inferedFields.titleField]);
   const path = `/collections/${collection.get('name')}/entries/${entry.get('slug')}`;
+  const list_fields = collection.get('list_fields');
+  const list_fields_seperator = collection.get('list_fields_seperator') || ' - ';
+  if (list_fields){
+    title = '';
+    list_fields.forEach(function (value) {
+      title = ((title.length > 0) ? title + list_fields_seperator : '' ) +  entry.getIn(['data', value]);
+    });
+  }
+
   let image = entry.getIn(['data', inferedFields.imageField]);
   image = resolvePath(image, publicFolder);
   if (image) {

--- a/packages/netlify-cms-core/src/components/Collection/Entries/EntryCard.js
+++ b/packages/netlify-cms-core/src/components/Collection/Entries/EntryCard.js
@@ -4,6 +4,7 @@ import { Link } from 'react-router-dom';
 import { resolvePath } from 'netlify-cms-lib-util';
 import { colors, colorsRaw, components, lengths } from 'netlify-cms-ui-default';
 import { VIEW_STYLE_LIST, VIEW_STYLE_GRID } from 'Constants/collectionViews';
+import { compileSlug, getIdentifier } from 'src/backend';
 
 const ListCard = styled.li`
   ${components.card};
@@ -89,19 +90,16 @@ const EntryCard = ({
   viewStyle = VIEW_STYLE_LIST,
 }) => {
   const label = entry.get('label');
-  let title = label || entry.getIn(['data', inferedFields.titleField]);
+  const entryData = entry.get('data');
+  let title = label || entryData.get(inferedFields.titleField);
   const path = `/collections/${collection.get('name')}/entries/${entry.get('slug')}`;
-  const list_fields = collection.get('list_fields');
-  const list_fields_seperator = collection.get('list_fields_seperator') || ' - ';
-  if (list_fields) {
-    title = '';
-    list_fields.forEach(function(value) {
-      title =
-        (title.length > 0 ? title + list_fields_seperator : '') + entry.getIn(['data', value]);
-    });
+
+  const summary = collection.get('summary');
+  if(summary) {
+    title = compileSlug(summary, new Date(), getIdentifier(entryData, collection), entryData);
   }
 
-  let image = entry.getIn(['data', inferedFields.imageField]);
+  let image = entryData.get(inferedFields.imageField);
   image = resolvePath(image, publicFolder);
   if (image) {
     image = encodeURI(image);

--- a/packages/netlify-cms-core/src/components/Collection/Entries/EntryCard.js
+++ b/packages/netlify-cms-core/src/components/Collection/Entries/EntryCard.js
@@ -4,7 +4,8 @@ import { Link } from 'react-router-dom';
 import { resolvePath } from 'netlify-cms-lib-util';
 import { colors, colorsRaw, components, lengths } from 'netlify-cms-ui-default';
 import { VIEW_STYLE_LIST, VIEW_STYLE_GRID } from 'Constants/collectionViews';
-import { compileSlug, getIdentifier } from 'src/backend';
+import { compileSlug } from 'src/backend';
+import { selectIdentifier } from 'Reducers/collections';
 
 const ListCard = styled.li`
   ${components.card};
@@ -96,7 +97,12 @@ const EntryCard = ({
 
   const summary = collection.get('summary');
   if (summary) {
-    title = compileSlug(summary, new Date(), getIdentifier(entryData, collection), entryData);
+    title = compileSlug(
+      summary,
+      new Date(),
+      entryData.get(selectIdentifier(collection)),
+      entryData,
+    );
   }
 
   let image = entryData.get(inferedFields.imageField);

--- a/packages/netlify-cms-core/src/components/Collection/Entries/EntryCard.js
+++ b/packages/netlify-cms-core/src/components/Collection/Entries/EntryCard.js
@@ -4,7 +4,7 @@ import { Link } from 'react-router-dom';
 import { resolvePath } from 'netlify-cms-lib-util';
 import { colors, colorsRaw, components, lengths } from 'netlify-cms-ui-default';
 import { VIEW_STYLE_LIST, VIEW_STYLE_GRID } from 'Constants/collectionViews';
-import { compileSlug } from 'src/backend';
+import { compileStringTemplate } from 'Lib/stringTemplate';
 import { selectIdentifier } from 'Reducers/collections';
 
 const ListCard = styled.li`
@@ -92,18 +92,13 @@ const EntryCard = ({
 }) => {
   const label = entry.get('label');
   const entryData = entry.get('data');
-  let title = label || entryData.get(inferedFields.titleField);
+  const defaultTitle = label || entryData.get(inferedFields.titleField);
   const path = `/collections/${collection.get('name')}/entries/${entry.get('slug')}`;
-
   const summary = collection.get('summary');
-  if (summary) {
-    title = compileSlug(
-      summary,
-      new Date(),
-      entryData.get(selectIdentifier(collection)),
-      entryData,
-    );
-  }
+  const identifier = entryData.get(selectIdentifier(collection));
+  const title = summary
+    ? compileStringTemplate(summary, null, identifier, entryData)
+    : defaultTitle;
 
   let image = entryData.get(inferedFields.imageField);
   image = resolvePath(image, publicFolder);

--- a/packages/netlify-cms-core/src/components/Collection/Entries/EntryCard.js
+++ b/packages/netlify-cms-core/src/components/Collection/Entries/EntryCard.js
@@ -6,6 +6,7 @@ import { colors, colorsRaw, components, lengths } from 'netlify-cms-ui-default';
 import { VIEW_STYLE_LIST, VIEW_STYLE_GRID } from 'Constants/collectionViews';
 import { compileStringTemplate } from 'Lib/stringTemplate';
 import { selectIdentifier } from 'Reducers/collections';
+import { parsePreviewPathDate } from 'backend';
 
 const ListCard = styled.li`
   ${components.card};
@@ -95,9 +96,10 @@ const EntryCard = ({
   const defaultTitle = label || entryData.get(inferedFields.titleField);
   const path = `/collections/${collection.get('name')}/entries/${entry.get('slug')}`;
   const summary = collection.get('summary');
+  const date = parsePreviewPathDate(collection, entry) || null;
   const identifier = entryData.get(selectIdentifier(collection));
   const title = summary
-    ? compileStringTemplate(summary, null, identifier, entryData)
+    ? compileStringTemplate(summary, date, identifier, entryData)
     : defaultTitle;
 
   let image = entryData.get(inferedFields.imageField);

--- a/packages/netlify-cms-core/src/components/Collection/Entries/EntryCard.js
+++ b/packages/netlify-cms-core/src/components/Collection/Entries/EntryCard.js
@@ -4,9 +4,8 @@ import { Link } from 'react-router-dom';
 import { resolvePath } from 'netlify-cms-lib-util';
 import { colors, colorsRaw, components, lengths } from 'netlify-cms-ui-default';
 import { VIEW_STYLE_LIST, VIEW_STYLE_GRID } from 'Constants/collectionViews';
-import { compileStringTemplate } from 'Lib/stringTemplate';
+import { compileStringTemplate, parseDateFromEntry } from 'Lib/stringTemplate';
 import { selectIdentifier } from 'Reducers/collections';
-import { parsePreviewPathDate } from 'coreSrc/backend';
 
 const ListCard = styled.li`
   ${components.card};
@@ -96,7 +95,7 @@ const EntryCard = ({
   const defaultTitle = label || entryData.get(inferedFields.titleField);
   const path = `/collections/${collection.get('name')}/entries/${entry.get('slug')}`;
   const summary = collection.get('summary');
-  const date = parsePreviewPathDate(collection, entry) || null;
+  const date = parseDateFromEntry(entry, collection) || null;
   const identifier = entryData.get(selectIdentifier(collection));
   const title = summary
     ? compileStringTemplate(summary, date, identifier, entryData)

--- a/packages/netlify-cms-core/src/components/Collection/Entries/EntryCard.js
+++ b/packages/netlify-cms-core/src/components/Collection/Entries/EntryCard.js
@@ -93,10 +93,11 @@ const EntryCard = ({
   const path = `/collections/${collection.get('name')}/entries/${entry.get('slug')}`;
   const list_fields = collection.get('list_fields');
   const list_fields_seperator = collection.get('list_fields_seperator') || ' - ';
-  if (list_fields){
+  if (list_fields) {
     title = '';
-    list_fields.forEach(function (value) {
-      title = ((title.length > 0) ? title + list_fields_seperator : '' ) +  entry.getIn(['data', value]);
+    list_fields.forEach(function(value) {
+      title =
+        (title.length > 0 ? title + list_fields_seperator : '') + entry.getIn(['data', value]);
     });
   }
 

--- a/packages/netlify-cms-core/src/components/Collection/Entries/EntryCard.js
+++ b/packages/netlify-cms-core/src/components/Collection/Entries/EntryCard.js
@@ -95,7 +95,7 @@ const EntryCard = ({
   const path = `/collections/${collection.get('name')}/entries/${entry.get('slug')}`;
 
   const summary = collection.get('summary');
-  if(summary) {
+  if (summary) {
     title = compileSlug(summary, new Date(), getIdentifier(entryData, collection), entryData);
   }
 

--- a/packages/netlify-cms-core/src/constants/configSchema.js
+++ b/packages/netlify-cms-core/src/constants/configSchema.js
@@ -89,6 +89,7 @@ const getConfigSchema = () => ({
             },
           },
           identifier_field: { type: 'string' },
+          summary: { type: 'string' },
           slug: { type: 'string' },
           preview_path: { type: 'string' },
           preview_path_date_field: { type: 'string' },

--- a/packages/netlify-cms-core/src/lib/stringTemplate.js
+++ b/packages/netlify-cms-core/src/lib/stringTemplate.js
@@ -6,7 +6,7 @@ function formatDate(date) {
   return `0${date}`.slice(-2);
 }
 
-const dateParsers = {
+export const dateParsers = {
   year: date => date.getFullYear(),
   month: date => formatDate(date.getMonth() + 1),
   day: date => formatDate(date.getDate()),

--- a/packages/netlify-cms-core/src/lib/stringTemplate.js
+++ b/packages/netlify-cms-core/src/lib/stringTemplate.js
@@ -1,0 +1,72 @@
+const dateParsers = {
+  year: date => date.getFullYear(),
+  month: date => `0${date.getMonth() + 1}`.slice(-2),
+  day: date => `0${date.getDate()}`.slice(-2),
+  hour: date => `0${date.getHours()}`.slice(-2),
+  minute: date => `0${date.getMinutes()}`.slice(-2),
+  second: date => `0${date.getSeconds()}`.slice(-2),
+};
+
+export const SLUG_MISSING_REQUIRED_DATE = 'SLUG_MISSING_REQUIRED_DATE';
+const USE_FIELD_PREFIX = 'fields.';
+const templateVariablePattern = '{{([^}]+)}}';
+
+// Allow `fields.` prefix in placeholder to override built in replacements
+// like "slug" and "year" with values from fields of the same name.
+function getExplicitFieldReplacement(key, data) {
+  if (!key.startsWith(USE_FIELD_PREFIX)) {
+    return;
+  }
+  const fieldName = key.substring(USE_FIELD_PREFIX.length);
+  return data.get(fieldName, '');
+}
+
+export function compileStringTemplate(template, date, identifier = '', data = Map(), processor) {
+  let missingRequiredDate;
+
+  // Allow date processing (support for replacements like `{{year}}`), pass
+  // `null` as the date arg.
+  const useDate = date === null;
+
+  const slug = template.replace(RegExp(templateVariablePattern, 'g'), template, (_, key) => {
+    let replacement;
+    const explicitFieldReplacement = getExplicitFieldReplacement(key, data);
+
+    if (explicitFieldReplacement) {
+      replacement = explicitFieldReplacement;
+    } else if (dateParsers[key] && !date) {
+      missingRequiredDate = true;
+      return '';
+    } else if (dateParsers[key]) {
+      replacement = dateParsers[key](date);
+    } else if (key === 'slug') {
+      replacement = identifier;
+    } else {
+      replacement = data.get(key, '');
+    }
+
+    if (processor) {
+      return processor(replacement);
+    }
+
+    return replacement;
+  });
+
+  if (useDate && missingRequiredDate) {
+    const err = new Error();
+    err.name = SLUG_MISSING_REQUIRED_DATE;
+    throw err;
+  } else {
+    return slug;
+  }
+}
+
+function extractVars(template, regexp) {
+  const result = regexp.exec(template);
+  return result && [result[1]].concat(extractVars(template, regexp)).filter(v => v);
+}
+
+export function extractTemplateVars(template) {
+  const regexp = RegExp(templateVariablePattern, 'g');
+  return extractVars(template, regexp);
+}

--- a/packages/netlify-cms-core/src/lib/stringTemplate.js
+++ b/packages/netlify-cms-core/src/lib/stringTemplate.js
@@ -70,5 +70,6 @@ export function compileStringTemplate(template, date, identifier = '', data = Ma
 export function extractTemplateVars(template) {
   const regexp = RegExp(templateVariablePattern, 'g');
   const contentRegexp = RegExp(templateContentPattern, 'g');
-  return template.match(regexp).map(elem => elem.match(contentRegexp)[0]);
+  const matches = template.match(regexp) || [];
+  return matches.map(elem => elem.match(contentRegexp)[0]);
 }

--- a/packages/netlify-cms-core/src/lib/stringTemplate.js
+++ b/packages/netlify-cms-core/src/lib/stringTemplate.js
@@ -1,3 +1,6 @@
+import moment from 'moment';
+import { selectInferedField } from 'Reducers/collections';
+
 // prepends a Zero if the date has only 1 digit
 function formatDate(date) {
   return `0${date}`.slice(-2);
@@ -13,6 +16,7 @@ const dateParsers = {
 };
 
 export const SLUG_MISSING_REQUIRED_DATE = 'SLUG_MISSING_REQUIRED_DATE';
+
 const FIELD_PREFIX = 'fields.';
 const templateContentPattern = '[^}{]+';
 const templateVariablePattern = `{{(${templateContentPattern})}}`;
@@ -25,6 +29,19 @@ function getExplicitFieldReplacement(key, data) {
   }
   const fieldName = key.substring(FIELD_PREFIX.length);
   return data.get(fieldName, '');
+}
+
+export function parseDateFromEntry(entry, collection, fieldName) {
+  const dateFieldName = fieldName || selectInferedField(collection, 'date');
+  if (!dateFieldName) {
+    return;
+  }
+
+  const dateValue = entry.getIn(['data', dateFieldName]);
+  const dateMoment = dateValue && moment(dateValue);
+  if (dateMoment && dateMoment.isValid()) {
+    return dateMoment.toDate();
+  }
 }
 
 export function compileStringTemplate(template, date, identifier = '', data = Map(), processor) {

--- a/packages/netlify-cms-core/src/lib/stringTemplate.js
+++ b/packages/netlify-cms-core/src/lib/stringTemplate.js
@@ -1,34 +1,40 @@
+// prepends a Zero if the date has only 1 digit
+function formatDate(date) {
+  return `0${date}`.slice(-2);
+}
+
 const dateParsers = {
   year: date => date.getFullYear(),
-  month: date => `0${date.getMonth() + 1}`.slice(-2),
-  day: date => `0${date.getDate()}`.slice(-2),
-  hour: date => `0${date.getHours()}`.slice(-2),
-  minute: date => `0${date.getMinutes()}`.slice(-2),
-  second: date => `0${date.getSeconds()}`.slice(-2),
+  month: date => formatDate(date.getMonth() + 1),
+  day: date => formatDate(date.getDate()),
+  hour: date => formatDate(date.getHours()),
+  minute: date => formatDate(date.getMinutes()),
+  second: date => formatDate(date.getSeconds()),
 };
 
 export const SLUG_MISSING_REQUIRED_DATE = 'SLUG_MISSING_REQUIRED_DATE';
-const USE_FIELD_PREFIX = 'fields.';
-const templateVariablePattern = '{{([^}]+)}}';
+const FIELD_PREFIX = 'fields.';
+const templateContentPattern = '[^}{]+';
+const templateVariablePattern = `{{(${templateContentPattern})}}`;
 
 // Allow `fields.` prefix in placeholder to override built in replacements
 // like "slug" and "year" with values from fields of the same name.
 function getExplicitFieldReplacement(key, data) {
-  if (!key.startsWith(USE_FIELD_PREFIX)) {
+  if (!key.startsWith(FIELD_PREFIX)) {
     return;
   }
-  const fieldName = key.substring(USE_FIELD_PREFIX.length);
+  const fieldName = key.substring(FIELD_PREFIX.length);
   return data.get(fieldName, '');
 }
 
 export function compileStringTemplate(template, date, identifier = '', data = Map(), processor) {
   let missingRequiredDate;
 
-  // Allow date processing (support for replacements like `{{year}}`), pass
+  // Turn off date processing (support for replacements like `{{year}}`), by passing in
   // `null` as the date arg.
-  const useDate = date === null;
+  const useDate = date !== null;
 
-  const slug = template.replace(RegExp(templateVariablePattern, 'g'), template, (_, key) => {
+  const slug = template.replace(RegExp(templateVariablePattern, 'g'), (_, key) => {
     let replacement;
     const explicitFieldReplacement = getExplicitFieldReplacement(key, data);
 
@@ -61,12 +67,8 @@ export function compileStringTemplate(template, date, identifier = '', data = Ma
   }
 }
 
-function extractVars(template, regexp) {
-  const result = regexp.exec(template);
-  return result && [result[1]].concat(extractVars(template, regexp)).filter(v => v);
-}
-
 export function extractTemplateVars(template) {
   const regexp = RegExp(templateVariablePattern, 'g');
-  return extractVars(template, regexp);
+  const contentRegexp = RegExp(templateContentPattern, 'g');
+  return template.match(regexp).map(elem => elem.match(contentRegexp)[0]);
 }

--- a/packages/netlify-cms-core/src/reducers/collections.js
+++ b/packages/netlify-cms-core/src/reducers/collections.js
@@ -115,7 +115,7 @@ export const selectTemplateName = (collection, slug) =>
 export const selectIdentifier = collection => {
   const identifier = collection.get('identifier_field');
   const identifierFields = identifier ? [identifier, ...IDENTIFIER_FIELDS] : IDENTIFIER_FIELDS;
-  const fieldNames = collection.get('fields').map(field => field.get('name'));
+  const fieldNames = collection.get('fields', []).map(field => field.get('name'));
   return identifierFields.find(id =>
     fieldNames.find(name => name.toLowerCase().trim() === id.toLowerCase().trim()),
   );

--- a/packages/netlify-cms-core/src/reducers/collections.js
+++ b/packages/netlify-cms-core/src/reducers/collections.js
@@ -128,7 +128,7 @@ export const selectInferedField = (collection, fieldName) => {
   const fields = collection.get('fields');
   let field;
 
-  // If colllection has no fields or fieldName is not defined within inferables list, return null
+  // If collection has no fields or fieldName is not defined within inferables list, return null
   if (!fields || !inferableField) return null;
   // Try to return a field of the specified type with one of the synonyms
   const mainTypeFields = fields

--- a/website/content/docs/configuration-options.md
+++ b/website/content/docs/configuration-options.md
@@ -171,8 +171,7 @@ The `collections` setting is the heart of your Netlify CMS configuration, as it 
 * `preview_path`: see detailed description below
 * `fields` (required): see detailed description below
 * `editor`: see detailed description below
-* `list_fields`: see detailed description below
-* `list_fields_seperator`: see detailed description below
+* `summary`: see detailed description below
 
 The last few options require more detailed information.
 
@@ -324,22 +323,12 @@ This setting changes options for the editor view of the collection. It has one o
 ```
 
 
-### `list_fields`
+### `summary`
 
-This setting allows the customisation of the collection list view. Multiple fields can be combined into the list field.
-This over-rides the default of `title` field and `identifier_field`
-
-**Example**
-```yaml
-    list_fields: ['version','title']
-```
-
-### `list_fields_seperator`
-This setting allows specifying a separator used between fields defined in `list_fields` attribute.
-If not defined the default separator is ` - `
-
+This setting allows the customisation of the collection list view. Similar to the `slug` field, a string with templates can be used to include values of different fields, e.g. `{{title}}`.
+This option over-rides the default of `title` field and `identifier_field`.
 
 **Example**
 ```yaml
-    list_fields_seperator: ' - '
+    summary: "Version: {{version}} - {{title}}"
 ```

--- a/website/content/docs/configuration-options.md
+++ b/website/content/docs/configuration-options.md
@@ -171,6 +171,8 @@ The `collections` setting is the heart of your Netlify CMS configuration, as it 
 * `preview_path`: see detailed description below
 * `fields` (required): see detailed description below
 * `editor`: see detailed description below
+* `list_fields`: see detailed description below
+* `list_fields_seperator`: see detailed description below
 
 The last few options require more detailed information.
 
@@ -319,4 +321,25 @@ This setting changes options for the editor view of the collection. It has one o
 ```yaml
   editor:
      preview: false
+```
+
+
+### `list_fields`
+
+This setting allows the customisation of the collection list view. Multiple fields can be combined into the list field.
+This over-rides the default of `title` field and `identifier_field`
+
+**Example**
+```yaml
+    list_fields: ['version','title']
+```
+
+### `list_fields_seperator`
+This setting allows specifying a separator used between fields defined in `list_fields` attribute.
+If not defined the default separator is ` - `
+
+
+**Example**
+```yaml
+    list_fields_seperator: ' - '
 ```


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines.

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first two fields are mandatory:
-->

**Summary**

<!--
Explain the **motivation** for making this change.
What existing problem does the pull request solve?
-->

This allows customising the collection list display based on multiple fields rather than the `title` or `identifier_field`. 
Adding the following to the collection definition in the config.yml controls the feature. 
```yaml
    list_fields: ['version','title']
    list_fields_seperator: ' - '
```
full collection
```yaml
  - name: 'faq' # Used in routes, ie.: /admin/collections/:slug/edit
    label: 'FAQ' # Used in the UI
    folder: '_faqs'
    list_fields: ['version','title']
    list_fields_seperator: ' - '
    create: true # Allow users to create new documents in this collection
    fields: # The fields each document in this collection have
      - { label: 'Question', name: 'title', widget: 'string', tagname: 'h1' }
      - { label: 'Answer', name: 'body', widget: 'markdown' }
      - { label: 'Version', name: 'version', widget: 'string', default : '1.01' }
```

**Test plan**

<!--
Demonstrate the code is solid.
Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.
-->
Here is a screenshot of the result. 
<img width="1165" alt="screenshot 2019-03-05 at 01 01 46" src="https://user-images.githubusercontent.com/10102054/53773502-a4cdea00-3ee2-11e9-94b0-50e01ea4d801.png">

