### PR TITLE
Fix non-Large Media previews with Git Gateway+Github

### DIFF
--- a/packages/netlify-cms-backend-git-gateway/src/implementation.js
+++ b/packages/netlify-cms-backend-git-gateway/src/implementation.js
@@ -315,6 +315,9 @@ export default class GitGateway {
       if (client.enabled && client.matchPath(path)) {
         return client.getDownloadURL(largeMediaDisplayURL);
       }
+      if (typeof original === 'string') {
+        return original;
+      }
       if (this.backend.getMediaDisplayURL) {
         return this.backend.getMediaDisplayURL(original);
       }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines.

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first two fields are mandatory:
-->

**Summary**

Images not in Large Media fail to show previews when using Git Gateway with GitHub in Netlify CMS 2.6.0. This PR fixes that bug.
