### PR TITLE
Allow multiple asset selection per field w/ Cloudinary

### DIFF
--- a/packages/netlify-cms-media-library-cloudinary/src/index.js
+++ b/packages/netlify-cms-media-library-cloudinary/src/index.js
@@ -60,7 +60,7 @@ async function init({ options = {}, handleInsert } = {}) {
 
   const insertHandler = data => {
     const assets = data.assets.map(asset => getAssetUrl(asset, resolvedOptions));
-    handleInsert(cloudinaryConfig.multiple ? assets : assets[0]);
+    handleInsert(assets.length > 1 ? assets : assets[0]);
   };
 
   const mediaLibrary = window.cloudinary.createMediaLibrary(cloudinaryConfig, { insertHandler });


### PR DESCRIPTION
Allow multiple assets to be returned from the Cloudinary widget when `multiple: true` is set at the field level.