### PR TITLE
feat(netlify-cms-core) added unregisterEditorComponent function

### DIFF
--- a/packages/netlify-cms-core/src/lib/registry.js
+++ b/packages/netlify-cms-core/src/lib/registry.js
@@ -23,6 +23,7 @@ export default {
   getWidget,
   resolveWidget,
   registerEditorComponent,
+  unregisterEditorComponent,
   getEditorComponents,
   registerWidgetValueSerializer,
   getWidgetValueSerializer,
@@ -77,6 +78,9 @@ export function resolveWidget(name) {
 export function registerEditorComponent(component) {
   const plugin = EditorComponent(component);
   registry.editorComponents = registry.editorComponents.set(plugin.get('id'), plugin);
+}
+export function unregisterEditorComponent(id) {
+  registry.editorComponents = registry.editorComponents.delete(id);
 }
 export function getEditorComponents() {
   return registry.editorComponents;

--- a/website/content/docs/custom-widgets.md
+++ b/website/content/docs/custom-widgets.md
@@ -123,6 +123,27 @@ CMS.registerEditorComponent({
 
 ![youtube-widget](/img/screen shot 2018-01-05 at 4.25.07 pm.png)
 
+## `unregisterEditorComponent`
+
+Unregister a block level component for the Markdown editor (for example, `image` which is included by default):
+
+```js
+CMS.unregisterEditorComponent(key)
+```
+
+**Params**
+
+* **id:** The id with which is identified the component in the registry.
+
+**Example:**
+
+```html
+<script src="https://unpkg.com/netlify-cms@^2.0.0/dist/netlify-cms.js"></script>
+<script>
+CMS.unregisterEditorComponent('image');
+</script>
+```
+
 ## Advanced field validation
 
 All widget fields, including those for built-in widgets, [include basic validation](../widgets/#common-widget-options) capability using the `required` and `pattern` options.


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines.

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first two fields are mandatory:
-->

**Summary**

<!--
Explain the **motivation** for making this change.
What existing problem does the pull request solve?
-->

Added the function `unregisterEditorComponent` to disable custom editor components (for example the `image` component added by default in the distributed netlify-cms).
The function is exposed in the `CMS` object as the ones used for register new widgets or editor components.

**Example**

A basic implementation:

```html
<script src="https://unpkg.com/netlify-cms@^2.0.0/dist/netlify-cms.js"></script>
<script>
CMS.unregisterEditorComponent('image');
</script>
```

<!--
Demonstrate the code is solid.
Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.
-->

**Documentation**

Documentation has been added below the description of `registerEditorComponent` in "Creating custom widgets" docs page.

**A picture of a cute animal (not mandatory but encouraged)**

In loving memory of Askra :black_heart: :heart: 

![Askra](https://mastodon.bida.im/system/media_attachments/files/000/742/863/small/7e4704717e4f2cb4.jpg?1552386978)