### PR TITLE
Redirect to first collection when a collection doesn't exist

### DIFF
--- a/packages/netlify-cms-core/src/components/App/App.js
+++ b/packages/netlify-cms-core/src/components/App/App.js
@@ -177,7 +177,11 @@ class App extends React.Component {
             <Redirect exact from="/" to={defaultPath} />
             <Redirect exact from="/search/" to={defaultPath} />
             {hasWorkflow ? <Route path="/workflow" component={Workflow} /> : null}
-            <Route exact path="/collections/:name" component={Collection} />
+            <Route
+              exact
+              path="/collections/:name"
+              render={props => !!collections.get(props.match.params.name) ? <Collection {...props}/> : <Redirect to={defaultPath} />}
+            />
             <Route
               path="/collections/:name/new"
               render={props => <Editor {...props} newRecord />}

--- a/packages/netlify-cms-core/src/components/App/App.js
+++ b/packages/netlify-cms-core/src/components/App/App.js
@@ -180,13 +180,10 @@ class App extends React.Component {
             <Route
               exact
               path="/collections/:name"
-              render={props =>
-                collections.get(props.match.params.name) ? (
-                  <Collection {...props} />
-                ) : (
-                  <Redirect to={defaultPath} />
-                )
-              }
+              render={props => {
+                const collectionExists = collections.get(props.match.params.name);
+                return collectionExists ? <Collection {...props} /> : <Redirect to={defaultPath} />;
+              }}
             />
             <Route
               path="/collections/:name/new"

--- a/packages/netlify-cms-core/src/components/App/App.js
+++ b/packages/netlify-cms-core/src/components/App/App.js
@@ -180,7 +180,7 @@ class App extends React.Component {
             <Route
               exact
               path="/collections/:name"
-              render={props => !!collections.get(props.match.params.name) ? <Collection {...props}/> : <Redirect to={defaultPath} />}
+              render={props => collections.get(props.match.params.name) ? <Collection {...props}/> : <Redirect to={defaultPath} />}
             />
             <Route
               path="/collections/:name/new"

--- a/packages/netlify-cms-core/src/components/App/App.js
+++ b/packages/netlify-cms-core/src/components/App/App.js
@@ -180,7 +180,13 @@ class App extends React.Component {
             <Route
               exact
               path="/collections/:name"
-              render={props => collections.get(props.match.params.name) ? <Collection {...props}/> : <Redirect to={defaultPath} />}
+              render={props =>
+                collections.get(props.match.params.name) ? (
+                  <Collection {...props} />
+                ) : (
+                  <Redirect to={defaultPath} />
+                )
+              }
             />
             <Route
               path="/collections/:name/new"

--- a/packages/netlify-cms-core/src/components/Collection/Collection.js
+++ b/packages/netlify-cms-core/src/components/Collection/Collection.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import ImmutablePropTypes from 'react-immutable-proptypes';
-import { Redirect } from 'react-router-dom';
 import styled from '@emotion/styled';
 import { connect } from 'react-redux';
 import { lengths } from 'netlify-cms-ui-default';
@@ -52,7 +51,6 @@ class Collection extends React.Component {
   render() {
     const { collection, collections, collectionName, isSearchResults, searchTerm } = this.props;
     const newEntryUrl = collection.get('create') ? getNewEntryUrl(collectionName) : '';
-
     return (
       <CollectionContainer>
         <Sidebar collections={collections} searchTerm={searchTerm} />

--- a/packages/netlify-cms-core/src/components/Collection/Collection.js
+++ b/packages/netlify-cms-core/src/components/Collection/Collection.js
@@ -52,7 +52,7 @@ class Collection extends React.Component {
   redirectToFirstCollection = () => {
     const { collections } = this.props;
     const firstCollection = collections.first();
-    const redirectPath = `/collections/${!!firstCollection ? firstCollection.get('name') : ''}`;
+    const redirectPath = `/collections/${firstCollection ? firstCollection.get('name') : ''}`;
 
     return <Redirect to={redirectPath}/>;
   }
@@ -60,7 +60,7 @@ class Collection extends React.Component {
   render() {
     const { collection, collections, collectionName, isSearchResults, searchTerm } = this.props;
 
-    if (collection === undefined ) {
+    if (!collection) {
       return this.redirectToFirstCollection();
     }
 

--- a/packages/netlify-cms-core/src/components/Collection/Collection.js
+++ b/packages/netlify-cms-core/src/components/Collection/Collection.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import ImmutablePropTypes from 'react-immutable-proptypes';
+import { Redirect } from 'react-router-dom';
 import styled from '@emotion/styled';
 import { connect } from 'react-redux';
 import { lengths } from 'netlify-cms-ui-default';
@@ -48,9 +49,23 @@ class Collection extends React.Component {
     }
   };
 
+  redirectToFirstCollection = () => {
+    const { collections } = this.props;
+    const firstCollection = collections.first();
+    const redirectPath = `/collections/${!!firstCollection ? firstCollection.get('name') : ''}`;
+
+    return <Redirect to={redirectPath}/>;
+  }
+
   render() {
     const { collection, collections, collectionName, isSearchResults, searchTerm } = this.props;
+
+    if (collection === undefined ) {
+      return this.redirectToFirstCollection();
+    }
+
     const newEntryUrl = collection.get('create') ? getNewEntryUrl(collectionName) : '';
+
     return (
       <CollectionContainer>
         <Sidebar collections={collections} searchTerm={searchTerm} />

--- a/packages/netlify-cms-core/src/components/Collection/Collection.js
+++ b/packages/netlify-cms-core/src/components/Collection/Collection.js
@@ -49,21 +49,8 @@ class Collection extends React.Component {
     }
   };
 
-  redirectToFirstCollection = () => {
-    const { collections } = this.props;
-    const firstCollection = collections.first();
-    const redirectPath = `/collections/${firstCollection ? firstCollection.get('name') : ''}`;
-
-    return <Redirect to={redirectPath}/>;
-  }
-
   render() {
     const { collection, collections, collectionName, isSearchResults, searchTerm } = this.props;
-
-    if (!collection) {
-      return this.redirectToFirstCollection();
-    }
-
     const newEntryUrl = collection.get('create') ? getNewEntryUrl(collectionName) : '';
 
     return (


### PR DESCRIPTION
**Summary**

Fixes #2155

Redirect to first collection when a collection doesn't exist.

**Test plan**

- Go to: http://localhost:8080/#/collections/non-existent-collection
- You should be redirected to: http://localhost:8080/#/collections/posts
