### PR TITLE
[Docs] Re-order navigation to accommodate guides

### DIFF
--- a/website/content/docs/custom-widgets.md
+++ b/website/content/docs/custom-widgets.md
@@ -1,7 +1,7 @@
 ---
 title: Creating Custom Widgets
 weight: 35
-group: guides
+group: customization
 ---
 
 The NetlifyCMS exposes a `window.CMS` global object that you can use to register custom widgets, previews, and editor plugins. The same object is also the default export if you import Netify CMS as an npm module. The available widget extension methods are:

--- a/website/content/docs/customization.md
+++ b/website/content/docs/customization.md
@@ -1,7 +1,7 @@
 ---
 title: Creating Custom Previews
-position: 50
-group: guides
+weight: 50
+group: customization
 ---
 
 The NetlifyCMS exposes a `window.CMS` global object that you can use to register custom widgets, previews and editor plugins. The available customization methods are:

--- a/website/content/docs/gatsby.md
+++ b/website/content/docs/gatsby.md
@@ -1,5 +1,5 @@
 ---
-title: Using Netlify CMS with Gatsby
+title: Gatsby
 group: guides
 weight: 20
 ---

--- a/website/gatsby-config.js
+++ b/website/gatsby-config.js
@@ -28,6 +28,10 @@ module.exports = {
           title: 'Guides',
         },
         {
+          name: 'customization',
+          title: 'Customization',
+        },
+        {
           name: 'contributing',
           title: 'Contributing',
         },


### PR DESCRIPTION
Menu placement as proposed on https://github.com/netlify/netlify-cms/pull/2117#issuecomment-470144816

I also went ahead and renamed the Gatsby guide to be more consistent with the Docs.

Fixes #2149 