### PR TITLE
Update select.md

### DIFF
--- a/website/content/docs/widgets/select.md
+++ b/website/content/docs/widgets/select.md
@@ -9,7 +9,7 @@ The select widget allows you to pick a string value from a dropdown menu.
 - **UI:** select input
 - **Data type:** string or array
 - **Options:**
-  - `default`: accepts a string; defaults to an empty string
+  - `default`: accepts a string; defaults to an empty string. Accepts an array of strings with `multiple: true` enabled.
   - `options`: (**required**) a list of options for the dropdown menu; can be listed in two ways:
       - string values: the label displayed in the dropdown is the value saved in the file
       - object with `label` and `value` fields: the label displays in the dropdown; the value is saved in the file

--- a/website/content/docs/widgets/select.md
+++ b/website/content/docs/widgets/select.md
@@ -9,7 +9,7 @@ The select widget allows you to pick a string value from a dropdown menu.
 - **UI:** select input
 - **Data type:** string or array
 - **Options:**
-  - `default`: accepts a string; defaults to an empty string. Accepts an array of strings with `multiple: true` enabled.
+  - `default`: accepts a string; defaults to an empty string. Accepts an array of strings and defaults to an empty array with `multiple: true` enabled.
   - `options`: (**required**) a list of options for the dropdown menu; can be listed in two ways:
       - string values: the label displayed in the dropdown is the value saved in the file
       - object with `label` and `value` fields: the label displays in the dropdown; the value is saved in the file

--- a/website/content/docs/widgets/select.md
+++ b/website/content/docs/widgets/select.md
@@ -38,5 +38,6 @@ The select widget allows you to pick a string value from a dropdown menu.
       widget: "select"
       multiple: true
       options: ["Design", "UX", "Dev"]
+      default: ["Design"]
     ```
 


### PR DESCRIPTION

**Summary**

Add a default example for the `select` widget with `multiple: true` enabled. It needs an array of strings instead of a string. 

**Test plan**
Added the changed configuration to `config.yml` on dev-test and it works.
<img width="789" alt="workslikeacharm" src="https://user-images.githubusercontent.com/6247534/54697373-b98abe80-4b2d-11e9-8f71-2c196be0d83b.png">
