### PR TITLE
Fix editorial workflow changing LM pointers to binary files

### DIFF
--- a/packages/netlify-cms-backend-git-gateway/src/implementation.js
+++ b/packages/netlify-cms-backend-git-gateway/src/implementation.js
@@ -279,34 +279,33 @@ export default class GitGateway {
       },
     );
   }
-  getLargeMediaDisplayURLs(mediaFiles) {
-    return this.getLargeMediaClient().then(client => {
-      const largeMediaItems = mediaFiles
-        .filter(({ path }) => client.matchPath(path))
-        .map(({ id, path }) => ({ path, sha: id }));
-      return this.backend
-        .fetchFiles(largeMediaItems)
-        .then(items =>
-          items.map(({ file: { sha }, data }) => {
-            const parsedPointerFile = parsePointerFile(data);
-            return [
-              {
-                pointerId: sha,
-                resourceId: parsedPointerFile.sha,
-              },
-              parsedPointerFile,
-            ];
-          }),
-        )
-        .then(unzip)
-        .then(([idMaps, files]) =>
-          Promise.all([idMaps, client.getResourceDownloadURLArgs(files).then(fromPairs)]),
-        )
-        .then(([idMaps, resourceMap]) =>
-          idMaps.map(({ pointerId, resourceId }) => [pointerId, resourceMap[resourceId]]),
-        )
-        .then(fromPairs);
-    });
+  async getLargeMediaDisplayURLs(mediaFiles) {
+    const client = await this.getLargeMediaClient();
+    const largeMediaItems = mediaFiles
+      .filter(({ path }) => client.matchPath(path))
+      .map(({ id, path }) => ({ path, sha: id }));
+    return this.backend
+      .fetchFiles(largeMediaItems)
+      .then(items =>
+        items.map(({ file: { sha }, data }) => {
+          const parsedPointerFile = parsePointerFile(data);
+          return [
+            {
+              pointerId: sha,
+              resourceId: parsedPointerFile.sha,
+            },
+            parsedPointerFile,
+          ];
+        }),
+      )
+      .then(unzip)
+      .then(([idMaps, files]) =>
+        Promise.all([idMaps, client.getResourceDownloadURLArgs(files).then(fromPairs)]),
+      )
+      .then(([idMaps, resourceMap]) =>
+        idMaps.map(({ pointerId, resourceId }) => [pointerId, resourceMap[resourceId]]),
+      )
+      .then(fromPairs);
   }
 
   getMediaDisplayURL(displayURL) {

--- a/packages/netlify-cms-core/src/actions/mediaLibrary.js
+++ b/packages/netlify-cms-core/src/actions/mediaLibrary.js
@@ -159,14 +159,19 @@ export function persistMedia(file, opts = {}) {
 
     try {
       const id = await getBlobSHA(file);
-      const displayURL = URL.createObjectURL(file);
       const assetProxy = await createAssetProxy(fileName, file, false, privateUpload);
       dispatch(addAsset(assetProxy));
       if (!integration) {
         const asset = await backend.persistMedia(state.config, assetProxy);
+        const displayURL = asset.displayURL || URL.createObjectURL(file);
         return dispatch(mediaPersisted({ id, displayURL, ...asset }));
       }
-      return dispatch(mediaPersisted({ id, displayURL, ...assetProxy.asset }, { privateUpload }));
+      return dispatch(
+        mediaPersisted(
+          { id, displayURL: URL.createObjectURL(file), ...assetProxy.asset },
+          { privateUpload },
+        ),
+      );
     } catch (error) {
       console.error(error);
       dispatch(


### PR DESCRIPTION
**Summary**

Prevents editorial workflow draft branches from being created with a binary version of a file that should be a Large Media pointer. Closes #2220. Also prevents images from having a broken display URL on first upload.

**Test plan**

Tested manually.