### PR TITLE
Add VuePress in generators / folder array

### DIFF
--- a/website/content/docs/add-to-your-site.md
+++ b/website/content/docs/add-to-your-site.md
@@ -20,6 +20,7 @@ A static `admin` folder contains all Netlify CMS files, stored at the root of yo
 | Spike                        | `/views`              |
 | Wyam                         | `/input`              |
 | Pelican                      | `/content`            |
+| VuePress                     | `/.vuepress/public`   |
 
 If your generator isn't listed here, you can check its documentation, or as a shortcut, look in your project for a `css` or `images` folder. The contents of folders like that are usually processed as static files, so it's likely you can store your `admin` folder next to those. (When you've found the location, feel free to add it to these docs by [filing a pull request](https://github.com/netlify/netlify-cms/blob/master/CONTRIBUTING.md)!)
 


### PR DESCRIPTION
For VuePress, assets are located in `.vuepress/public` folder

<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines.

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first two fields are mandatory:
-->

**Summary**

<!--
Explain the **motivation** for making this change.
What existing problem does the pull request solve?
-->

Just adding information for [VuePress](https://vuepress.vuejs.org/).

**Test plan**

<!--
Demonstrate the code is solid.
Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.
-->

No test... but you can find some information on this [blog post](https://www.vuejsradar.com/vuepress-netlify-cms-integration/), in the Installation part.

**A picture of a cute animal (not mandatory but encouraged)**
![Cute animal](https://proxy.duckduckgo.com/iu/?u=https%3A%2F%2Fbaby-animals.net%2Fwp-content%2Fgallery%2Fbaby-fox-wallpapers%2FBaby-animal-wallpapers.jpg&f=1)