### PR TITLE
chore: fix develop watch

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -23,6 +23,13 @@ const plugins = () => {
     '@babel/plugin-proposal-object-rest-spread',
     '@babel/plugin-proposal-export-default-from',
     [
+      'emotion',
+      {
+        sourceMap: true,
+        autoLabel: true,
+      },
+    ],
+    [
       'module-resolver',
       isESM
         ? {
@@ -69,19 +76,6 @@ const plugins = () => {
     ],
   ];
 
-  if (isProduction) {
-    return [
-      ...defaultPlugins,
-      [
-        'emotion',
-        {
-          hoist: true,
-          autoLabel: true,
-        },
-      ],
-    ];
-  }
-
   if (isESM) {
     return [
       ...defaultPlugins,
@@ -90,14 +84,6 @@ const plugins = () => {
         {
           NETLIFY_CMS_VERSION: `${version}`,
           NETLIFY_CMS_CORE_VERSION: `${coreVersion}`,
-        },
-      ],
-      [
-        'emotion',
-        {
-          sourceMap: false,
-          hoist: true,
-          autoLabel: true,
         },
       ],
       [
@@ -122,27 +108,14 @@ const plugins = () => {
           },
         },
       ],
-      [
-        'emotion',
-        {
-          sourceMap: true,
-          autoLabel: true,
-        },
-      ],
     ];
   }
 
-  defaultPlugins.push('react-hot-loader/babel');
-  return [
-    ...defaultPlugins,
-    [
-      'emotion',
-      {
-        sourceMap: true,
-        autoLabel: true,
-      },
-    ],
-  ];
+  if (!isProduction) {
+    defaultPlugins.push('react-hot-loader/babel');
+  }
+
+  return defaultPlugins;
 };
 
 module.exports = {

--- a/babel.config.js
+++ b/babel.config.js
@@ -95,6 +95,7 @@ const plugins = () => {
       [
         'emotion',
         {
+          sourceMap: false,
           hoist: true,
           autoLabel: true,
         },

--- a/babel.config.js
+++ b/babel.config.js
@@ -6,18 +6,7 @@ const isTest = process.env.NODE_ENV === 'test';
 const isESM = process.env.NODE_ENV === 'esm';
 
 const presets = () => {
-  if (isTest) {
-    return ['@babel/preset-react', '@babel/preset-env'];
-  }
-  return [
-    '@babel/preset-react',
-    [
-      '@babel/preset-env',
-      {
-        modules: false,
-      },
-    ],
-  ];
+  return ['@babel/preset-react', '@babel/preset-env'];
 };
 
 const plugins = () => {

--- a/package.json
+++ b/package.json
@@ -2,8 +2,7 @@
   "scripts": {
     "bootstrap": "lerna bootstrap",
     "start": "run-s clean bootstrap build:esm develop",
-    "watch": "lerna run watch --parallel",
-    "develop": "lerna run --parallel develop",
+    "develop": "lerna run develop --parallel",
     "build": "run-s clean build:esm build:lerna",
     "build:lerna": "lerna run build",
     "build:esm": "lerna run build:esm",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "scripts": {
     "bootstrap": "lerna bootstrap",
-    "start": "run-s clean bootstrap develop",
+    "start": "run-s clean bootstrap build:esm develop",
     "watch": "lerna run watch --parallel",
     "develop": "lerna run --parallel develop",
     "build": "run-s clean build:esm build:lerna",

--- a/packages/netlify-cms-backend-bitbucket/package.json
+++ b/packages/netlify-cms-backend-bitbucket/package.json
@@ -15,8 +15,7 @@
   ],
   "sideEffects": false,
   "scripts": {
-    "watch": "webpack -w",
-    "develop": "npm run watch",
+    "develop": "yarn build:esm --watch",
     "build": "cross-env NODE_ENV=production webpack",
     "build:esm": "cross-env NODE_ENV=esm babel src --out-dir dist/esm --ignore src/**/__tests__/* --root-mode upward"
   },

--- a/packages/netlify-cms-backend-git-gateway/package.json
+++ b/packages/netlify-cms-backend-git-gateway/package.json
@@ -16,8 +16,7 @@
   ],
   "sideEffects": false,
   "scripts": {
-    "watch": "webpack -w",
-    "develop": "npm run watch",
+    "develop": "yarn build:esm --watch",
     "build": "cross-env NODE_ENV=production webpack",
     "build:esm": "cross-env NODE_ENV=esm babel src --out-dir dist/esm --ignore src/**/__tests__/* --root-mode upward"
   },

--- a/packages/netlify-cms-backend-github/package.json
+++ b/packages/netlify-cms-backend-github/package.json
@@ -15,8 +15,7 @@
   ],
   "sideEffects": false,
   "scripts": {
-    "watch": "webpack -w",
-    "develop": "npm run watch",
+    "develop": "yarn build:esm --watch",
     "build": "cross-env NODE_ENV=production webpack",
     "build:esm": "cross-env NODE_ENV=esm babel src --out-dir dist/esm --ignore src/**/__tests__/* --root-mode upward"
   },

--- a/packages/netlify-cms-backend-gitlab/package.json
+++ b/packages/netlify-cms-backend-gitlab/package.json
@@ -15,8 +15,7 @@
   ],
   "sideEffects": false,
   "scripts": {
-    "watch": "webpack -w",
-    "develop": "npm run watch",
+    "develop": "yarn build:esm --watch",
     "build": "cross-env NODE_ENV=production webpack",
     "build:esm": "cross-env NODE_ENV=esm babel src --out-dir dist/esm --ignore src/**/__tests__/* --root-mode upward"
   },

--- a/packages/netlify-cms-backend-test/package.json
+++ b/packages/netlify-cms-backend-test/package.json
@@ -14,8 +14,7 @@
   ],
   "sideEffects": false,
   "scripts": {
-    "watch": "webpack -w",
-    "develop": "npm run watch",
+    "develop": "yarn build:esm --watch",
     "build": "cross-env NODE_ENV=production webpack",
     "build:esm": "cross-env NODE_ENV=esm babel src --out-dir dist/esm --ignore src/**/__tests__/* --root-mode upward"
   },

--- a/packages/netlify-cms-core/package.json
+++ b/packages/netlify-cms-core/package.json
@@ -11,7 +11,7 @@
     "dist/"
   ],
   "scripts": {
-    "develop": "webpack -w",
+    "develop": "yarn build:esm --watch",
     "build": "cross-env NODE_ENV=production webpack",
     "build:esm": "cross-env NODE_ENV=esm babel src --out-dir dist/esm --ignore src/**/__tests__/* --root-mode upward"
   },

--- a/packages/netlify-cms-default-exports/package.json
+++ b/packages/netlify-cms-default-exports/package.json
@@ -15,8 +15,7 @@
   ],
   "sideEffects": false,
   "scripts": {
-    "watch": "webpack -w",
-    "develop": "npm run watch",
+    "develop": "yarn build:esm --watch",
     "build": "cross-env NODE_ENV=production webpack",
     "build:esm": "cross-env NODE_ENV=esm babel src --out-dir dist/esm --ignore src/**/__tests__/* --root-mode upward"
   },

--- a/packages/netlify-cms-editor-component-image/package.json
+++ b/packages/netlify-cms-editor-component-image/package.json
@@ -15,8 +15,7 @@
   ],
   "sideEffects": false,
   "scripts": {
-    "watch": "webpack -w",
-    "develop": "npm run watch",
+    "develop": "yarn build:esm --watch",
     "build": "cross-env NODE_ENV=production webpack",
     "build:esm": "cross-env NODE_ENV=esm babel src --out-dir dist/esm --ignore src/**/__tests__/* --root-mode upward"
   },

--- a/packages/netlify-cms-lib-auth/package.json
+++ b/packages/netlify-cms-lib-auth/package.json
@@ -16,8 +16,7 @@
   ],
   "sideEffects": false,
   "scripts": {
-    "watch": "webpack -w",
-    "develop": "npm run watch",
+    "develop": "yarn build:esm --watch",
     "build": "cross-env NODE_ENV=production webpack",
     "build:esm": "cross-env NODE_ENV=esm babel src --out-dir dist/esm --ignore src/**/__tests__/* --root-mode upward"
   },

--- a/packages/netlify-cms-lib-util/package.json
+++ b/packages/netlify-cms-lib-util/package.json
@@ -12,8 +12,7 @@
   ],
   "sideEffects": false,
   "scripts": {
-    "watch": "webpack -w",
-    "develop": "npm run watch",
+    "develop": "yarn build:esm --watch",
     "build": "cross-env NODE_ENV=production webpack",
     "build:esm": "cross-env NODE_ENV=esm babel src --out-dir dist/esm --ignore src/**/__tests__/* --root-mode upward"
   },

--- a/packages/netlify-cms-media-library-cloudinary/package.json
+++ b/packages/netlify-cms-media-library-cloudinary/package.json
@@ -20,8 +20,7 @@
   ],
   "sideEffects": false,
   "scripts": {
-    "watch": "webpack -w",
-    "develop": "npm run watch",
+    "develop": "yarn build:esm --watch",
     "build": "cross-env NODE_ENV=production webpack",
     "build:esm": "cross-env NODE_ENV=esm babel src --out-dir dist/esm --ignore src/**/__tests__/* --root-mode upward"
   },

--- a/packages/netlify-cms-media-library-uploadcare/package.json
+++ b/packages/netlify-cms-media-library-uploadcare/package.json
@@ -18,8 +18,7 @@
   ],
   "sideEffects": false,
   "scripts": {
-    "watch": "webpack -w",
-    "develop": "npm run watch",
+    "develop": "yarn build:esm --watch",
     "build": "cross-env NODE_ENV=production webpack",
     "build:esm": "cross-env NODE_ENV=esm babel src --out-dir dist/esm --ignore src/**/__tests__/* --root-mode upward"
   },

--- a/packages/netlify-cms-ui-default/package.json
+++ b/packages/netlify-cms-ui-default/package.json
@@ -12,8 +12,7 @@
   ],
   "sideEffects": false,
   "scripts": {
-    "watch": "webpack -w",
-    "develop": "npm run watch",
+    "develop": "yarn build:esm --watch",
     "build": "cross-env NODE_ENV=production webpack",
     "build:esm": "cross-env NODE_ENV=esm babel src --out-dir dist/esm --ignore src/**/__tests__/* --root-mode upward"
   },

--- a/packages/netlify-cms-widget-boolean/package.json
+++ b/packages/netlify-cms-widget-boolean/package.json
@@ -16,8 +16,7 @@
   ],
   "sideEffects": false,
   "scripts": {
-    "watch": "webpack -w",
-    "develop": "npm run watch",
+    "develop": "yarn build:esm --watch",
     "build": "cross-env NODE_ENV=production webpack",
     "build:esm": "cross-env NODE_ENV=esm babel src --out-dir dist/esm --ignore src/**/__tests__/* --root-mode upward"
   },

--- a/packages/netlify-cms-widget-date/package.json
+++ b/packages/netlify-cms-widget-date/package.json
@@ -17,8 +17,7 @@
   ],
   "sideEffects": false,
   "scripts": {
-    "watch": "webpack -w",
-    "develop": "npm run watch",
+    "develop": "yarn build:esm --watch",
     "build": "cross-env NODE_ENV=production webpack",
     "build:esm": "cross-env NODE_ENV=esm babel src --out-dir dist/esm --ignore src/**/__tests__/* --root-mode upward"
   },

--- a/packages/netlify-cms-widget-date/src/index.js
+++ b/packages/netlify-cms-widget-date/src/index.js
@@ -9,3 +9,4 @@ const Widget = (opts = {}) => ({
 });
 
 export const NetlifyCmsWidgetDate = { Widget, controlComponent, previewComponent };
+export { Widget as default, controlComponent, previewComponent };

--- a/packages/netlify-cms-widget-datetime/package.json
+++ b/packages/netlify-cms-widget-datetime/package.json
@@ -18,8 +18,7 @@
   ],
   "sideEffects": false,
   "scripts": {
-    "watch": "webpack -w",
-    "develop": "npm run watch",
+    "develop": "yarn build:esm --watch",
     "build": "cross-env NODE_ENV=production webpack",
     "build:esm": "cross-env NODE_ENV=esm babel src --out-dir dist/esm --ignore src/**/__tests__/* --root-mode upward"
   },

--- a/packages/netlify-cms-widget-datetime/src/index.js
+++ b/packages/netlify-cms-widget-datetime/src/index.js
@@ -9,3 +9,4 @@ const Widget = (opts = {}) => ({
 });
 
 export const NetlifyCmsWidgetDatetime = { Widget, controlComponent, previewComponent };
+export { Widget as default, controlComponent, previewComponent };

--- a/packages/netlify-cms-widget-file/package.json
+++ b/packages/netlify-cms-widget-file/package.json
@@ -18,8 +18,7 @@
   ],
   "sideEffects": false,
   "scripts": {
-    "watch": "webpack -w",
-    "develop": "npm run watch",
+    "develop": "yarn build:esm --watch",
     "build": "cross-env NODE_ENV=production webpack",
     "build:esm": "cross-env NODE_ENV=esm babel src --out-dir dist/esm --ignore src/**/__tests__/* --root-mode upward"
   },

--- a/packages/netlify-cms-widget-image/package.json
+++ b/packages/netlify-cms-widget-image/package.json
@@ -18,8 +18,7 @@
   ],
   "sideEffects": false,
   "scripts": {
-    "watch": "webpack -w",
-    "develop": "npm run watch",
+    "develop": "yarn build:esm --watch",
     "build": "cross-env NODE_ENV=production webpack",
     "build:esm": "cross-env NODE_ENV=esm babel src --out-dir dist/esm --ignore src/**/__tests__/* --root-mode upward"
   },

--- a/packages/netlify-cms-widget-list/package.json
+++ b/packages/netlify-cms-widget-list/package.json
@@ -17,8 +17,7 @@
   ],
   "sideEffects": false,
   "scripts": {
-    "watch": "webpack -w",
-    "develop": "npm run watch",
+    "develop": "yarn build:esm --watch",
     "build": "cross-env NODE_ENV=production webpack",
     "build:esm": "cross-env NODE_ENV=esm babel src --out-dir dist/esm --ignore src/**/__tests__/* --root-mode upward"
   },

--- a/packages/netlify-cms-widget-map/package.json
+++ b/packages/netlify-cms-widget-map/package.json
@@ -17,8 +17,7 @@
   ],
   "sideEffects": false,
   "scripts": {
-    "watch": "webpack -w",
-    "develop": "npm run watch",
+    "develop": "yarn build:esm --watch",
     "build": "cross-env NODE_ENV=production webpack",
     "build:esm": "cross-env NODE_ENV=esm babel src --out-dir dist/esm --ignore src/**/__tests__/* --root-mode upward"
   },

--- a/packages/netlify-cms-widget-markdown/package.json
+++ b/packages/netlify-cms-widget-markdown/package.json
@@ -17,8 +17,7 @@
   ],
   "sideEffects": false,
   "scripts": {
-    "watch": "webpack -w",
-    "develop": "npm run watch",
+    "develop": "yarn build:esm --watch",
     "build": "cross-env NODE_ENV=production webpack",
     "build:esm": "cross-env NODE_ENV=esm babel src --out-dir dist/esm --ignore src/**/__tests__/* --root-mode upward"
   },

--- a/packages/netlify-cms-widget-number/package.json
+++ b/packages/netlify-cms-widget-number/package.json
@@ -16,8 +16,7 @@
   ],
   "sideEffects": false,
   "scripts": {
-    "watch": "webpack -w",
-    "develop": "npm run watch",
+    "develop": "yarn build:esm --watch",
     "build": "cross-env NODE_ENV=production webpack",
     "build:esm": "cross-env NODE_ENV=esm babel src --out-dir dist/esm --ignore src/**/__tests__/* --root-mode upward"
   },

--- a/packages/netlify-cms-widget-object/package.json
+++ b/packages/netlify-cms-widget-object/package.json
@@ -18,8 +18,7 @@
   ],
   "sideEffects": false,
   "scripts": {
-    "watch": "webpack -w",
-    "develop": "npm run watch",
+    "develop": "yarn build:esm --watch",
     "build": "cross-env NODE_ENV=production webpack",
     "build:esm": "cross-env NODE_ENV=esm babel src --out-dir dist/esm --ignore src/**/__tests__/* --root-mode upward"
   },

--- a/packages/netlify-cms-widget-relation/package.json
+++ b/packages/netlify-cms-widget-relation/package.json
@@ -17,8 +17,7 @@
   ],
   "sideEffects": false,
   "scripts": {
-    "watch": "webpack -w",
-    "develop": "npm run watch",
+    "develop": "yarn build:esm --watch",
     "build": "cross-env NODE_ENV=production webpack",
     "build:esm": "cross-env NODE_ENV=esm babel src --out-dir dist/esm --ignore src/**/__tests__/* --root-mode upward"
   },

--- a/packages/netlify-cms-widget-select/package.json
+++ b/packages/netlify-cms-widget-select/package.json
@@ -18,8 +18,7 @@
   ],
   "sideEffects": false,
   "scripts": {
-    "watch": "webpack -w",
-    "develop": "npm run watch",
+    "develop": "yarn build:esm --watch",
     "build": "cross-env NODE_ENV=production webpack",
     "build:esm": "cross-env NODE_ENV=esm babel src --out-dir dist/esm --ignore src/**/__tests__/* --root-mode upward"
   },

--- a/packages/netlify-cms-widget-string/package.json
+++ b/packages/netlify-cms-widget-string/package.json
@@ -16,8 +16,7 @@
   ],
   "sideEffects": false,
   "scripts": {
-    "watch": "webpack -w",
-    "develop": "npm run watch",
+    "develop": "yarn build:esm --watch",
     "build": "cross-env NODE_ENV=production webpack",
     "build:esm": "cross-env NODE_ENV=esm babel src --out-dir dist/esm --ignore src/**/__tests__/* --root-mode upward"
   },

--- a/packages/netlify-cms-widget-text/package.json
+++ b/packages/netlify-cms-widget-text/package.json
@@ -19,8 +19,7 @@
   ],
   "sideEffects": false,
   "scripts": {
-    "watch": "webpack -w",
-    "develop": "npm run watch",
+    "develop": "yarn build:esm --watch",
     "build": "cross-env NODE_ENV=production webpack",
     "build:esm": "cross-env NODE_ENV=esm babel src --out-dir dist/esm --ignore src/**/__tests__/* --root-mode upward"
   },

--- a/packages/netlify-cms/src/widgets.js
+++ b/packages/netlify-cms/src/widgets.js
@@ -11,8 +11,8 @@ import * as NetlifyCmsWidgetObject from 'netlify-cms-widget-object';
 import * as NetlifyCmsWidgetRelation from 'netlify-cms-widget-relation';
 import * as NetlifyCmsWidgetBoolean from 'netlify-cms-widget-boolean';
 import * as NetlifyCmsWidgetMap from 'netlify-cms-widget-map';
-import * as NetlifyCmsWidgetDate from 'netlify-cms-widget-date';
-import * as NetlifyCmsWidgetDateTime from 'netlify-cms-widget-datetime';
+import { NetlifyCmsWidgetDate } from 'netlify-cms-widget-date';
+import { NetlifyCmsWidgetDatetime } from 'netlify-cms-widget-datetime';
 
 registerWidget(
   'string',
@@ -66,4 +66,4 @@ registerWidget(
 );
 registerWidget('boolean', NetlifyCmsWidgetBoolean.controlComponent);
 registerWidget('map', NetlifyCmsWidgetMap.controlComponent, NetlifyCmsWidgetMap.previewComponent);
-registerWidget([NetlifyCmsWidgetDate.Widget(), NetlifyCmsWidgetDateTime.Widget()]);
+registerWidget([NetlifyCmsWidgetDate.Widget(), NetlifyCmsWidgetDatetime.Widget()]);


### PR DESCRIPTION
**Summary**

Development should target ES modules.

 UMD builds are based on esm as well as our main `netlify-cms` bundle. During development and during a build, webpack should be using the ES module code.

A `yarn start` will clean dist and build out `dist/esm` then run the watches in parallel. `netlify-cms` will build off the `dist/esm` code and all should be good.

**Test plan**

These fixes now show how https://github.com/netlify/netlify-cms/commit/00a176b34adbeefcc4a6d24030f17d7aed3737fd is breaking the builds.

**A picture of a cute animal (not mandatory but encouraged)**
🐧