### PR TITLE
chore: Build cleanup

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -12,6 +12,7 @@
   },
   "globals": {
     "NETLIFY_CMS_VERSION": false,
+    "NETLIFY_CMS_APP_VERSION": false,
     "NETLIFY_CMS_CORE_VERSION": false,
     "CMS_ENV": false
   },

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,5 +1,5 @@
 const path = require('path');
-const version = require('./packages/netlify-cms/package.json').version;
+const appVersion = require('./packages/netlify-cms-app/package.json').version;
 const coreVersion = require('./packages/netlify-cms-core/package.json').version;
 const isProduction = process.env.NODE_ENV === 'production';
 const isTest = process.env.NODE_ENV === 'test';
@@ -82,7 +82,7 @@ const plugins = () => {
       [
         'transform-define',
         {
-          NETLIFY_CMS_VERSION: `${version}`,
+          NETLIFY_CMS_APP_VERSION: `${appVersion}`,
           NETLIFY_CMS_CORE_VERSION: `${coreVersion}`,
         },
       ],

--- a/babel.config.js
+++ b/babel.config.js
@@ -5,6 +5,8 @@ const isProduction = process.env.NODE_ENV === 'production';
 const isTest = process.env.NODE_ENV === 'test';
 const isESM = process.env.NODE_ENV === 'esm';
 
+console.log('Build Package:', path.basename(process.cwd()));
+
 const presets = () => {
   return ['@babel/preset-react', '@babel/preset-env'];
 };

--- a/packages/netlify-cms-app/package.json
+++ b/packages/netlify-cms-app/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "develop": "yarn build:esm --watch",
     "build": "cross-env NODE_ENV=production webpack",
-    "build:esm": "cross-env NODE_ENV=esm babel src --out-dir dist/esm --ignore src/**/__tests__/* --root-mode upward -s"
+    "build:esm": "cross-env NODE_ENV=esm babel src --out-dir dist/esm --ignore **/__tests__ --root-mode upward -s"
   },
   "keywords": [
     "netlify",

--- a/packages/netlify-cms-app/src/index.js
+++ b/packages/netlify-cms-app/src/index.js
@@ -3,6 +3,15 @@ import './backends';
 import './widgets';
 import './editor-components';
 
+if (typeof window !== 'undefined') {
+  /**
+   * Log the version number.
+   */
+  if (typeof NETLIFY_CMS_APP_VERSION === 'string') {
+    console.log(`netlify-cms-app ${NETLIFY_CMS_APP_VERSION}`);
+  }
+}
+
 export const NetlifyCmsApp = {
   ...CMS,
 };

--- a/packages/netlify-cms-app/webpack.config.js
+++ b/packages/netlify-cms-app/webpack.config.js
@@ -16,8 +16,7 @@ const baseConfig = {
       .filter(([key]) => key !== 'friendlyErrors')
       .map(([, plugin]) => plugin()),
     new webpack.DefinePlugin({
-      NETLIFY_CMS_VERSION: JSON.stringify(`- app - ${pkg.version}${isProduction ? '' : '-dev'}`),
-      NETLIFY_CMS_CORE_VERSION: null,
+      NETLIFY_CMS_APP_VERSION: JSON.stringify(`${pkg.version}${isProduction ? '' : '-dev'}`),
     }),
   ],
 };

--- a/packages/netlify-cms-app/webpack.config.js
+++ b/packages/netlify-cms-app/webpack.config.js
@@ -1,4 +1,3 @@
-const path = require('path');
 const webpack = require('webpack');
 const pkg = require('./package.json');
 const { getConfig, plugins } = require('../../scripts/webpack');
@@ -9,8 +8,6 @@ console.log(`${pkg.version}${isProduction ? '' : '-dev'}`);
 
 const baseConfig = {
   ...baseWebpackConfig,
-  context: path.join(__dirname, 'src'),
-  entry: './index.js',
   plugins: [
     ...Object.entries(plugins)
       .filter(([key]) => key !== 'friendlyErrors')

--- a/packages/netlify-cms-backend-bitbucket/package.json
+++ b/packages/netlify-cms-backend-bitbucket/package.json
@@ -17,7 +17,7 @@
   "scripts": {
     "develop": "yarn build:esm --watch",
     "build": "cross-env NODE_ENV=production webpack",
-    "build:esm": "cross-env NODE_ENV=esm babel src --out-dir dist/esm --ignore src/**/__tests__/* --root-mode upward -s"
+    "build:esm": "cross-env NODE_ENV=esm babel src --out-dir dist/esm --ignore **/__tests__ --root-mode upward -s"
   },
   "dependencies": {
     "js-base64": "^2.5.1",

--- a/packages/netlify-cms-backend-git-gateway/package.json
+++ b/packages/netlify-cms-backend-git-gateway/package.json
@@ -18,7 +18,7 @@
   "scripts": {
     "develop": "yarn build:esm --watch",
     "build": "cross-env NODE_ENV=production webpack",
-    "build:esm": "cross-env NODE_ENV=esm babel src --out-dir dist/esm --ignore src/**/__tests__/* --root-mode upward -s"
+    "build:esm": "cross-env NODE_ENV=esm babel src --out-dir dist/esm --ignore **/__tests__ --root-mode upward -s"
   },
   "dependencies": {
     "gotrue-js": "^0.9.24",

--- a/packages/netlify-cms-backend-github/package.json
+++ b/packages/netlify-cms-backend-github/package.json
@@ -17,7 +17,7 @@
   "scripts": {
     "develop": "yarn build:esm --watch",
     "build": "cross-env NODE_ENV=production webpack",
-    "build:esm": "cross-env NODE_ENV=esm babel src --out-dir dist/esm --ignore src/**/__tests__/* --root-mode upward -s"
+    "build:esm": "cross-env NODE_ENV=esm babel src --out-dir dist/esm --ignore **/__tests__ --root-mode upward -s"
   },
   "dependencies": {
     "common-tags": "^1.8.0",

--- a/packages/netlify-cms-backend-gitlab/package.json
+++ b/packages/netlify-cms-backend-gitlab/package.json
@@ -17,7 +17,7 @@
   "scripts": {
     "develop": "yarn build:esm --watch",
     "build": "cross-env NODE_ENV=production webpack",
-    "build:esm": "cross-env NODE_ENV=esm babel src --out-dir dist/esm --ignore src/**/__tests__/* --root-mode upward -s"
+    "build:esm": "cross-env NODE_ENV=esm babel src --out-dir dist/esm --ignore **/__tests__ --root-mode upward -s"
   },
   "dependencies": {
     "js-base64": "^2.5.1",

--- a/packages/netlify-cms-backend-test/package.json
+++ b/packages/netlify-cms-backend-test/package.json
@@ -16,7 +16,7 @@
   "scripts": {
     "develop": "yarn build:esm --watch",
     "build": "cross-env NODE_ENV=production webpack",
-    "build:esm": "cross-env NODE_ENV=esm babel src --out-dir dist/esm --ignore src/**/__tests__/* --root-mode upward -s"
+    "build:esm": "cross-env NODE_ENV=esm babel src --out-dir dist/esm --ignore **/__tests__ --root-mode upward -s"
   },
   "peerDependencies": {
     "@emotion/core": "^10.0.9",

--- a/packages/netlify-cms-core/package.json
+++ b/packages/netlify-cms-core/package.json
@@ -13,7 +13,7 @@
   "scripts": {
     "develop": "yarn build:esm --watch",
     "build": "cross-env NODE_ENV=production webpack",
-    "build:esm": "cross-env NODE_ENV=esm babel src --out-dir dist/esm --ignore src/**/__tests__/* --root-mode upward -s"
+    "build:esm": "cross-env NODE_ENV=esm babel src --out-dir dist/esm --ignore **/__tests__ --root-mode upward -s"
   },
   "keywords": [
     "netlify",

--- a/packages/netlify-cms-core/webpack.config.js
+++ b/packages/netlify-cms-core/webpack.config.js
@@ -5,7 +5,6 @@ const { getConfig } = require('../../scripts/webpack.js');
 const isProduction = process.env.NODE_ENV === 'production';
 
 const versionPlugin = new webpack.DefinePlugin({
-  NETLIFY_CMS_VERSION: null,
   NETLIFY_CMS_CORE_VERSION: JSON.stringify(`${pkg.version}${isProduction ? '' : '-dev'}`),
 });
 

--- a/packages/netlify-cms-default-exports/package.json
+++ b/packages/netlify-cms-default-exports/package.json
@@ -17,7 +17,7 @@
   "scripts": {
     "develop": "yarn build:esm --watch",
     "build": "cross-env NODE_ENV=production webpack",
-    "build:esm": "cross-env NODE_ENV=esm babel src --out-dir dist/esm --ignore src/**/__tests__/* --root-mode upward -s"
+    "build:esm": "cross-env NODE_ENV=esm babel src --out-dir dist/esm --ignore **/__tests__ --root-mode upward -s"
   },
   "dependencies": {
     "@emotion/core": "^10.0.9",

--- a/packages/netlify-cms-editor-component-image/package.json
+++ b/packages/netlify-cms-editor-component-image/package.json
@@ -17,7 +17,7 @@
   "scripts": {
     "develop": "yarn build:esm --watch",
     "build": "cross-env NODE_ENV=production webpack",
-    "build:esm": "cross-env NODE_ENV=esm babel src --out-dir dist/esm --ignore src/**/__tests__/* --root-mode upward -s"
+    "build:esm": "cross-env NODE_ENV=esm babel src --out-dir dist/esm --ignore **/__tests__ --root-mode upward -s"
   },
   "devDependencies": {
     "cross-env": "^5.2.0",

--- a/packages/netlify-cms-lib-auth/package.json
+++ b/packages/netlify-cms-lib-auth/package.json
@@ -18,7 +18,7 @@
   "scripts": {
     "develop": "yarn build:esm --watch",
     "build": "cross-env NODE_ENV=production webpack",
-    "build:esm": "cross-env NODE_ENV=esm babel src --out-dir dist/esm --ignore src/**/__tests__/* --root-mode upward -s"
+    "build:esm": "cross-env NODE_ENV=esm babel src --out-dir dist/esm --ignore **/__tests__ --root-mode upward -s"
   },
   "peerDependencies": {
     "immutable": "^3.7.6",

--- a/packages/netlify-cms-lib-util/package.json
+++ b/packages/netlify-cms-lib-util/package.json
@@ -14,7 +14,7 @@
   "scripts": {
     "develop": "yarn build:esm --watch",
     "build": "cross-env NODE_ENV=production webpack",
-    "build:esm": "cross-env NODE_ENV=esm babel src --out-dir dist/esm --ignore src/**/__tests__/* --root-mode upward -s"
+    "build:esm": "cross-env NODE_ENV=esm babel src --out-dir dist/esm --ignore **/__tests__ --root-mode upward -s"
   },
   "dependencies": {
     "js-sha256": "^0.9.0",

--- a/packages/netlify-cms-media-library-cloudinary/package.json
+++ b/packages/netlify-cms-media-library-cloudinary/package.json
@@ -22,7 +22,7 @@
   "scripts": {
     "develop": "yarn build:esm --watch",
     "build": "cross-env NODE_ENV=production webpack",
-    "build:esm": "cross-env NODE_ENV=esm babel src --out-dir dist/esm --ignore src/**/__tests__/* --root-mode upward -s"
+    "build:esm": "cross-env NODE_ENV=esm babel src --out-dir dist/esm --ignore **/__tests__ --root-mode upward -s"
   },
   "peerDependencies": {
     "netlify-cms-lib-util": "^2.1.3-beta.0"

--- a/packages/netlify-cms-media-library-uploadcare/package.json
+++ b/packages/netlify-cms-media-library-uploadcare/package.json
@@ -20,7 +20,7 @@
   "scripts": {
     "develop": "yarn build:esm --watch",
     "build": "cross-env NODE_ENV=production webpack",
-    "build:esm": "cross-env NODE_ENV=esm babel src --out-dir dist/esm --ignore src/**/__tests__/* --root-mode upward -s"
+    "build:esm": "cross-env NODE_ENV=esm babel src --out-dir dist/esm --ignore **/__tests__ --root-mode upward -s"
   },
   "dependencies": {
     "uploadcare-widget": "^3.7.0",

--- a/packages/netlify-cms-ui-default/package.json
+++ b/packages/netlify-cms-ui-default/package.json
@@ -14,7 +14,7 @@
   "scripts": {
     "develop": "yarn build:esm --watch",
     "build": "cross-env NODE_ENV=production webpack",
-    "build:esm": "cross-env NODE_ENV=esm babel src --out-dir dist/esm --ignore src/**/__tests__/* --root-mode upward -s"
+    "build:esm": "cross-env NODE_ENV=esm babel src --out-dir dist/esm --ignore **/__tests__ --root-mode upward -s"
   },
   "dependencies": {
     "react-aria-menubutton": "^6.0.0",

--- a/packages/netlify-cms-widget-boolean/package.json
+++ b/packages/netlify-cms-widget-boolean/package.json
@@ -18,7 +18,7 @@
   "scripts": {
     "develop": "yarn build:esm --watch",
     "build": "cross-env NODE_ENV=production webpack",
-    "build:esm": "cross-env NODE_ENV=esm babel src --out-dir dist/esm --ignore src/**/__tests__/* --root-mode upward -s"
+    "build:esm": "cross-env NODE_ENV=esm babel src --out-dir dist/esm --ignore **/__tests__ --root-mode upward -s"
   },
   "peerDependencies": {
     "@emotion/core": "^10.0.9",

--- a/packages/netlify-cms-widget-date/package.json
+++ b/packages/netlify-cms-widget-date/package.json
@@ -19,7 +19,7 @@
   "scripts": {
     "develop": "yarn build:esm --watch",
     "build": "cross-env NODE_ENV=production webpack",
-    "build:esm": "cross-env NODE_ENV=esm babel src --out-dir dist/esm --ignore src/**/__tests__/* --root-mode upward -s"
+    "build:esm": "cross-env NODE_ENV=esm babel src --out-dir dist/esm --ignore **/__tests__ --root-mode upward -s"
   },
   "dependencies": {
     "react-datetime": "^2.16.3"

--- a/packages/netlify-cms-widget-datetime/package.json
+++ b/packages/netlify-cms-widget-datetime/package.json
@@ -20,7 +20,7 @@
   "scripts": {
     "develop": "yarn build:esm --watch",
     "build": "cross-env NODE_ENV=production webpack",
-    "build:esm": "cross-env NODE_ENV=esm babel src --out-dir dist/esm --ignore src/**/__tests__/* --root-mode upward -s"
+    "build:esm": "cross-env NODE_ENV=esm babel src --out-dir dist/esm --ignore **/__tests__ --root-mode upward -s"
   },
   "peerDependencies": {
     "@emotion/core": "^10.0.9",

--- a/packages/netlify-cms-widget-file/package.json
+++ b/packages/netlify-cms-widget-file/package.json
@@ -20,7 +20,7 @@
   "scripts": {
     "develop": "yarn build:esm --watch",
     "build": "cross-env NODE_ENV=production webpack",
-    "build:esm": "cross-env NODE_ENV=esm babel src --out-dir dist/esm --ignore src/**/__tests__/* --root-mode upward -s"
+    "build:esm": "cross-env NODE_ENV=esm babel src --out-dir dist/esm --ignore **/__tests__ --root-mode upward -s"
   },
   "dependencies": {
     "common-tags": "^1.8.0"

--- a/packages/netlify-cms-widget-image/package.json
+++ b/packages/netlify-cms-widget-image/package.json
@@ -20,7 +20,7 @@
   "scripts": {
     "develop": "yarn build:esm --watch",
     "build": "cross-env NODE_ENV=production webpack",
-    "build:esm": "cross-env NODE_ENV=esm babel src --out-dir dist/esm --ignore src/**/__tests__/* --root-mode upward -s"
+    "build:esm": "cross-env NODE_ENV=esm babel src --out-dir dist/esm --ignore **/__tests__ --root-mode upward -s"
   },
   "peerDependencies": {
     "@emotion/core": "^10.0.9",

--- a/packages/netlify-cms-widget-list/package.json
+++ b/packages/netlify-cms-widget-list/package.json
@@ -19,7 +19,7 @@
   "scripts": {
     "develop": "yarn build:esm --watch",
     "build": "cross-env NODE_ENV=production webpack",
-    "build:esm": "cross-env NODE_ENV=esm babel src --out-dir dist/esm --ignore src/**/__tests__/* --root-mode upward -s"
+    "build:esm": "cross-env NODE_ENV=esm babel src --out-dir dist/esm --ignore **/__tests__ --root-mode upward -s"
   },
   "dependencies": {
     "react-sortable-hoc": "^1.0.0"

--- a/packages/netlify-cms-widget-map/package.json
+++ b/packages/netlify-cms-widget-map/package.json
@@ -19,7 +19,7 @@
   "scripts": {
     "develop": "yarn build:esm --watch",
     "build": "cross-env NODE_ENV=production webpack",
-    "build:esm": "cross-env NODE_ENV=esm babel src --out-dir dist/esm --ignore src/**/__tests__/* --root-mode upward -s"
+    "build:esm": "cross-env NODE_ENV=esm babel src --out-dir dist/esm --ignore **/__tests__ --root-mode upward -s"
   },
   "peerDependencies": {
     "@emotion/core": "^10.0.9",

--- a/packages/netlify-cms-widget-markdown/package.json
+++ b/packages/netlify-cms-widget-markdown/package.json
@@ -19,7 +19,7 @@
   "scripts": {
     "develop": "yarn build:esm --watch",
     "build": "cross-env NODE_ENV=production webpack",
-    "build:esm": "cross-env NODE_ENV=esm babel src --out-dir dist/esm --ignore src/**/__tests__/* --root-mode upward -s"
+    "build:esm": "cross-env NODE_ENV=esm babel src --out-dir dist/esm --ignore **/__tests__ --root-mode upward -s"
   },
   "dependencies": {
     "is-hotkey": "^0.1.4",

--- a/packages/netlify-cms-widget-number/package.json
+++ b/packages/netlify-cms-widget-number/package.json
@@ -18,7 +18,7 @@
   "scripts": {
     "develop": "yarn build:esm --watch",
     "build": "cross-env NODE_ENV=production webpack",
-    "build:esm": "cross-env NODE_ENV=esm babel src --out-dir dist/esm --ignore src/**/__tests__/* --root-mode upward -s"
+    "build:esm": "cross-env NODE_ENV=esm babel src --out-dir dist/esm --ignore **/__tests__ --root-mode upward -s"
   },
   "peerDependencies": {
     "netlify-cms-ui-default": "^2.6.0",

--- a/packages/netlify-cms-widget-object/package.json
+++ b/packages/netlify-cms-widget-object/package.json
@@ -20,7 +20,7 @@
   "scripts": {
     "develop": "yarn build:esm --watch",
     "build": "cross-env NODE_ENV=production webpack",
-    "build:esm": "cross-env NODE_ENV=esm babel src --out-dir dist/esm --ignore src/**/__tests__/* --root-mode upward -s"
+    "build:esm": "cross-env NODE_ENV=esm babel src --out-dir dist/esm --ignore **/__tests__ --root-mode upward -s"
   },
   "peerDependencies": {
     "@emotion/core": "^10.0.9",

--- a/packages/netlify-cms-widget-relation/package.json
+++ b/packages/netlify-cms-widget-relation/package.json
@@ -19,7 +19,7 @@
   "scripts": {
     "develop": "yarn build:esm --watch",
     "build": "cross-env NODE_ENV=production webpack",
-    "build:esm": "cross-env NODE_ENV=esm babel src --out-dir dist/esm --ignore src/**/__tests__/* --root-mode upward -s"
+    "build:esm": "cross-env NODE_ENV=esm babel src --out-dir dist/esm --ignore **/__tests__ --root-mode upward -s"
   },
   "dependencies": {
     "react-select": "^2.4.2"

--- a/packages/netlify-cms-widget-select/package.json
+++ b/packages/netlify-cms-widget-select/package.json
@@ -20,7 +20,7 @@
   "scripts": {
     "develop": "yarn build:esm --watch",
     "build": "cross-env NODE_ENV=production webpack",
-    "build:esm": "cross-env NODE_ENV=esm babel src --out-dir dist/esm --ignore src/**/__tests__/* --root-mode upward -s"
+    "build:esm": "cross-env NODE_ENV=esm babel src --out-dir dist/esm --ignore **/__tests__ --root-mode upward -s"
   },
   "peerDependencies": {
     "immutable": "^3.7.6",

--- a/packages/netlify-cms-widget-string/package.json
+++ b/packages/netlify-cms-widget-string/package.json
@@ -18,7 +18,7 @@
   "scripts": {
     "develop": "yarn build:esm --watch",
     "build": "cross-env NODE_ENV=production webpack",
-    "build:esm": "cross-env NODE_ENV=esm babel src --out-dir dist/esm --ignore src/**/__tests__/* --root-mode upward -s"
+    "build:esm": "cross-env NODE_ENV=esm babel src --out-dir dist/esm --ignore **/__tests__ --root-mode upward -s"
   },
   "peerDependencies": {
     "netlify-cms-ui-default": "^2.6.0",

--- a/packages/netlify-cms-widget-text/package.json
+++ b/packages/netlify-cms-widget-text/package.json
@@ -21,7 +21,7 @@
   "scripts": {
     "develop": "yarn build:esm --watch",
     "build": "cross-env NODE_ENV=production webpack",
-    "build:esm": "cross-env NODE_ENV=esm babel src --out-dir dist/esm --ignore src/**/__tests__/* --root-mode upward -s"
+    "build:esm": "cross-env NODE_ENV=esm babel src --out-dir dist/esm --ignore **/__tests__ --root-mode upward -s"
   },
   "dependencies": {
     "react-textarea-autosize": "^7.1.0"

--- a/packages/netlify-cms/src/media-libraries.js
+++ b/packages/netlify-cms/src/media-libraries.js
@@ -1,4 +1,4 @@
-import { NetlifyCmsCore as CMS } from 'netlify-cms-core';
+import { NetlifyCmsApp as CMS } from 'netlify-cms-app/dist/esm';
 import uploadcare from 'netlify-cms-media-library-uploadcare';
 import cloudinary from 'netlify-cms-media-library-cloudinary';
 

--- a/packages/netlify-cms/webpack.config.js
+++ b/packages/netlify-cms/webpack.config.js
@@ -25,7 +25,7 @@ const baseConfig = {
     new CopyWebpackPlugin([{ from: './shims/cms.css', to: './' }]),
   ],
   devServer: {
-    contentBase: '../dev-test',
+    contentBase: '../../dev-test',
     watchContentBase: true,
     publicPath: '/dist/',
     quiet: true,

--- a/packages/netlify-cms/webpack.config.js
+++ b/packages/netlify-cms/webpack.config.js
@@ -1,4 +1,3 @@
-const path = require('path');
 const webpack = require('webpack');
 const FriendlyErrorsWebpackPlugin = require('friendly-errors-webpack-plugin');
 const CopyWebpackPlugin = require('copy-webpack-plugin');
@@ -11,8 +10,6 @@ console.log(`${pkg.version}${isProduction ? '' : '-dev'}`);
 
 const baseConfig = {
   ...baseWebpackConfig,
-  context: path.join(__dirname, 'src'),
-  entry: './index.js',
   plugins: [
     ...Object.entries(plugins)
       .filter(([key]) => key !== 'friendlyErrors')
@@ -25,10 +22,10 @@ const baseConfig = {
         messages: ['Netlify CMS is now running at http://localhost:8080'],
       },
     }),
-    new CopyWebpackPlugin([{ from: '../shims/cms.css', to: './' }]),
+    new CopyWebpackPlugin([{ from: './shims/cms.css', to: './' }]),
   ],
   devServer: {
-    contentBase: '../../dev-test',
+    contentBase: '../dev-test',
     watchContentBase: true,
     publicPath: '/dist/',
     quiet: true,
@@ -47,7 +44,7 @@ if (isProduction) {
      */
     {
       ...baseConfig,
-      entry: [path.join(__dirname, 'shims/deprecate-old-dist.js'), baseConfig.entry],
+      entry: ['./shims/deprecate-old-dist.js', baseConfig.entry],
       output: {
         ...baseConfig.output,
         filename: 'cms.js',

--- a/packages/netlify-cms/webpack.config.js
+++ b/packages/netlify-cms/webpack.config.js
@@ -19,7 +19,6 @@ const baseConfig = {
       .map(([, plugin]) => plugin()),
     new webpack.DefinePlugin({
       NETLIFY_CMS_VERSION: JSON.stringify(`${pkg.version}${isProduction ? '' : '-dev'}`),
-      NETLIFY_CMS_CORE_VERSION: null,
     }),
     new FriendlyErrorsWebpackPlugin({
       compilationSuccessInfo: {

--- a/scripts/webpack.js
+++ b/scripts/webpack.js
@@ -103,6 +103,7 @@ const umdExternals = Object.keys(pkg.peerDependencies || {}).reduce((previous, k
  * Default: umd
  */
 const baseConfig = ({ target = isProduction ? 'umd' : 'umddir' } = {}) => ({
+  context: process.cwd(),
   mode: isProduction ? 'production' : 'development',
   entry: './src/index.js',
   output: targetOutputs()[target],


### PR DESCRIPTION
**Summary**

Some cleanup tasks for builds:

- Add version console.log for `netlify-cms-app`
Does create an extra log version in console. Should discuss whether we want to move it up as a shim for app.
- Move context to baseConfig for all projects to be package root. Adjusted paths accordingly.
- Fix missed import from app rather than core in media libraries.
- Fix ignore paths of `__tests__` folders in esm builds

**Test plan**

Normal tests for breaking builds.

**A picture of a cute animal (not mandatory but encouraged)**
🐶