### PR TITLE
Feature/#2256 fix numbercontrol zero handling

### DIFF
--- a/packages/netlify-cms-widget-number/src/NumberControl.js
+++ b/packages/netlify-cms-widget-number/src/NumberControl.js
@@ -100,7 +100,7 @@ export default class NumberControl extends React.Component {
         className={classNameWrapper}
         onFocus={setActiveStyle}
         onBlur={setInactiveStyle}
-        value={value || ''}
+        value={value || (value === 0 ? value : '')}
         step={step}
         min={min}
         max={max}

--- a/packages/netlify-cms-widget-number/src/__tests__/number.spec.js
+++ b/packages/netlify-cms-widget-number/src/__tests__/number.spec.js
@@ -119,4 +119,15 @@ describe('Number widget', () => {
     expect(onChangeSpy).toHaveBeenCalledTimes(1);
     expect(onChangeSpy).toHaveBeenCalledWith(parseInt(testValue, 10));
   });
+
+  it('should allow 0 as a value', () => {
+    const field = fromJS(fieldSettings);
+    const testValue = 0;
+    const { input } = setup({ field });
+
+    fireEvent.focus(input);
+    fireEvent.change(input, { target: { value: String(testValue) } });
+
+    expect(input.value).toBe('0');
+  });
 });


### PR DESCRIPTION
**Summary**
Closes #2256 by making sure `0` is an allowed value in the input. When passing the `value` prop to the input, we were ruling out falsy values without checking for the special case of zero.

**Test plan**

A new unit test has been added to assert that using `0` as a test value no longer sets the input value as an empty string.

**A picture of a cute animal (not mandatory but encouraged)**

![IMG_20190214_153436](https://user-images.githubusercontent.com/8883545/55360383-1ee69400-54cc-11e9-9843-86ddf071718a.jpg)
