### PR TITLE
feat(netlify-cms-core) Overwrite language

### DIFF
--- a/packages/netlify-cms-core/src/bootstrap.js
+++ b/packages/netlify-cms-core/src/bootstrap.js
@@ -62,8 +62,8 @@ function bootstrap(opts = {}) {
    */
   const { overwriteLang } = config || {};
   const { CMS_OVERWRITE_LANG } = window;
-  const { locale , phrases } = overwriteLang || CMS_OVERWRITE_LANG || {locale : 'en'};
-  
+  const { locale, phrases } = overwriteLang || CMS_OVERWRITE_LANG || { locale: 'en' };
+
   /**
    * Create connected root component.
    */

--- a/packages/netlify-cms-core/src/bootstrap.js
+++ b/packages/netlify-cms-core/src/bootstrap.js
@@ -58,12 +58,19 @@ function bootstrap(opts = {}) {
   }
 
   /**
+   * Overwrite language.
+   */
+  const { overwriteLang } = config || {};
+  const { CMS_OVERWRITE_LANG } = window;
+  const { locale , phrases } = overwriteLang || CMS_OVERWRITE_LANG || {locale : 'en'};
+  
+  /**
    * Create connected root component.
    */
   const Root = () => (
     <>
       <GlobalStyles />
-      <I18n locale={'en'} messages={getPhrases()}>
+      <I18n locale={locale} messages={getPhrases(phrases)}>
         <ErrorBoundary showBackup>
           <Provider store={store}>
             <ConnectedRouter history={history}>

--- a/packages/netlify-cms-core/src/constants/defaultPhrases.js
+++ b/packages/netlify-cms-core/src/constants/defaultPhrases.js
@@ -175,5 +175,7 @@ export function getPhrases(overwritePhrases = {}) {
       },
     },
   };
-  return fromJS(phrases).mergeDeep(overwritePhrases).toJS();
+  return fromJS(phrases)
+    .mergeDeep(overwritePhrases)
+    .toJS();
 }

--- a/packages/netlify-cms-core/src/constants/defaultPhrases.js
+++ b/packages/netlify-cms-core/src/constants/defaultPhrases.js
@@ -1,5 +1,7 @@
-export function getPhrases() {
-  return {
+import { fromJS } from 'immutable';
+
+export function getPhrases(overwritePhrases = {}) {
+  const phrases = {
     app: {
       header: {
         content: 'Contents',
@@ -173,4 +175,5 @@ export function getPhrases() {
       },
     },
   };
+  return fromJS(phrases).mergeDeep(overwritePhrases).toJS();
 }

--- a/website/content/docs/beta-features.md
+++ b/website/content/docs/beta-features.md
@@ -227,3 +227,51 @@ Template tags produce the following output:
 - `{{collection}}`: the name of the collection containing the entry changed
 
 - `{{path}}`: the full path to the file changed
+
+## Overwrite language
+You can overwrite the default language of the environment with two means:
+- with global window variable `CMS_OVERWRITE_LANG`
+``` html
+<script>
+    window.CMS_OVERWRITE_LANG = {
+      locale: 'fr',
+      phrases: {
+        app: {
+          header: {
+            content: 'Contenus',
+            workflow: 'Flux de travail',
+            media: 'Médias',
+            quickAdd: 'Ajout rapide'
+          }
+        }
+      }
+    }
+</script>
+<!-- import netlify-cms after -->
+<script src="https://unpkg.com/netlify-cms@^2.0.0/dist/netlify-cms.js"></script>
+```
+- with [manual initialization](/docs/beta-features/#manual-initialization)
+``` js
+  init({
+    config:{
+      overwriteLang: {
+        locale: 'fr',
+        phrases: {
+          app: {
+            header: {
+              content: 'Contenus',
+              workflow: 'Flux de travail',
+              media: 'Médias',
+              quickAdd: 'Ajout rapide'
+            }
+          }
+        }
+      }
+    }
+  })
+```
+**You can access all the variables available [here](https://github.com/netlify/netlify-cms/blob/master/packages/netlify-cms-core/src/constants/defaultPhrases.js)**
+
+`locale` represents the expected language
+
+`phrases` will be merged with existing phrases object, and any part that conflicts with existing phrases will be overwritten.


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines.

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first two fields are mandatory:
-->

**Summary**

You can overwrite the default language of the environment with two means:
- with global window variable `CMS_OVERWRITE_LANG`
``` html
<script>
    window.CMS_OVERWRITE_LANG = {
      locale: 'fr',
      phrases: {
        app: {
          header: {
            content: 'Contenus',
            workflow: 'Flux de travail',
            media: 'Médias',
            quickAdd: 'Ajout rapide'
          }
        }
      }
    }
</script>
<!-- import netlify-cms after -->
<script src="https://unpkg.com/netlify-cms@^2.0.0/dist/netlify-cms.js"></script>
```
- with [manual initialization](https://www.netlifycms.org/docs/beta-features/#manual-initialization)
``` js
  init({
    config:{
      overwriteLang: {
        locale: 'fr',
        phrases: {
          app: {
            header: {
              content: 'Contenus',
              workflow: 'Flux de travail',
              media: 'Médias',
              quickAdd: 'Ajout rapide'
            }
          }
        }
      }
    }
  })
```
**You can access all the variables available [here](https://github.com/netlify/netlify-cms/blob/master/packages/netlify-cms-core/src/constants/defaultPhrases.js)**

`locale` represents the expected language

`phrases` will be merged with existing phrases object, and any part that conflicts with existing phrases will be overwritten.

Sorry for my english, i'm french =D

#789 
#2128 