### PR TITLE
Feature/#2017 improve pristine input handling

### DIFF
--- a/packages/netlify-cms-ui-default/src/Toggle.js
+++ b/packages/netlify-cms-ui-default/src/Toggle.js
@@ -64,7 +64,7 @@ const Toggle = ({
         className={className}
         {...getTogglerProps({
           role: 'switch',
-          'aria-checked': on.toString(),
+          'aria-checked': on ? 'true' : 'false',
           'aria-expanded': null,
         })}
       >


### PR DESCRIPTION
**Summary**
Closes #2017, closes #1990 and closes #1449 , continuing on the spirit of #1662.
In essence, this PR:
* [ ] forces default values for the widgets to be set in the Redux store which in turn forces the data serializer to consider them when persisting entries
* [ ] introduces a fallback to the widget's default value when a default is not provided for the field in the settings
* [ ] introduces `emptyValue` as a new config options for fields such that a field left pristine will persist with this value (or not persist at all if this is set to `null`) **[<- I'm probably gonna suggest something else for this]**
* [ ] ...

**Test plan**
* **Coming soon**

**A picture of a cute animal (not mandatory but encouraged)**
* **Coming soon**