### PR TITLE
Persist editor split pane position

### DIFF
--- a/packages/netlify-cms-core/src/components/Editor/EditorInterface.js
+++ b/packages/netlify-cms-core/src/components/Editor/EditorInterface.js
@@ -13,6 +13,7 @@ import EditorToggle from './EditorToggle';
 
 const PREVIEW_VISIBLE = 'cms.preview-visible';
 const SCROLL_SYNC_ENABLED = 'cms.scroll-sync-enabled';
+const SPLIT_PANE_POSITION = 'cms.split-pane-position';
 
 const styles = {
   splitPane: css`
@@ -199,7 +200,8 @@ class EditorInterface extends Component {
           <ReactSplitPaneGlobalStyles />
           <StyledSplitPane
             maxSize={-100}
-            defaultSize="50%"
+            defaultSize={ parseInt(localStorage.getItem(SPLIT_PANE_POSITION), 10) || "50%" }
+            onChange={ size => localStorage.setItem(SPLIT_PANE_POSITION, size) }
             onDragStarted={this.handleSplitPaneDragStart}
             onDragFinished={this.handleSplitPaneDragFinished}
           >

--- a/packages/netlify-cms-core/src/components/Editor/EditorInterface.js
+++ b/packages/netlify-cms-core/src/components/Editor/EditorInterface.js
@@ -200,8 +200,8 @@ class EditorInterface extends Component {
           <ReactSplitPaneGlobalStyles />
           <StyledSplitPane
             maxSize={-100}
-            defaultSize={ parseInt(localStorage.getItem(SPLIT_PANE_POSITION), 10) || "50%" }
-            onChange={ size => localStorage.setItem(SPLIT_PANE_POSITION, size) }
+            defaultSize={parseInt(localStorage.getItem(SPLIT_PANE_POSITION), 10) || '50%'}
+            onChange={size => localStorage.setItem(SPLIT_PANE_POSITION, size)}
             onDragStarted={this.handleSplitPaneDragStart}
             onDragFinished={this.handleSplitPaneDragFinished}
           >


### PR DESCRIPTION
**Summary**

When working with the split pane in the editor, it's annoying to have to resize the split every time I edit an item to get the preview the size I want. This PR saves the split position to local storage and loads it when the split pane component is rerendered, persisting the split position across item views and page loads.

**Test plan**

![C5da5qekn1](https://user-images.githubusercontent.com/87216/56717546-30266780-673d-11e9-9bbf-6d1282598ab5.gif)

**A picture of a cute animal (not mandatory but encouraged)**

![image](https://user-images.githubusercontent.com/87216/56717029-10427400-673c-11e9-9592-8fed765fe293.png)
