### PR TITLE
fix(widget-markdown): keep markdown widget dropdowns on top

### DIFF
--- a/packages/netlify-cms-ui-default/src/Dropdown.js
+++ b/packages/netlify-cms-ui-default/src/Dropdown.js
@@ -37,7 +37,7 @@ const DropdownList = styled.ul`
   top: 0;
   left: 0;
   min-width: 100%;
-  z-index: 1;
+  z-index: 2;
 
   ${props => css`
     width: ${props.width};


### PR DESCRIPTION
**Summary**

I ran into #1391 in my own environment where dropdowns drop "behind" the markdown widget. Incrementing the `z-index` from 1 to 2 resolved this issue.

**Test plan**
Verifying:

- Append `- { label: "body", name: "body", widget: "markdown" }` to Kitchen Sink example after Typed List
- Click the drop down ![image](https://user-images.githubusercontent.com/2372558/57507834-bea9f580-72b4-11e9-97f9-88ff98b8a40a.png)
- Make change to `z-index: 2`
- Reload and click the drop down 
![image](https://user-images.githubusercontent.com/2372558/57507903-e8fbb300-72b4-11e9-84d2-d02899a30054.png)

**A picture of a cute animal (not mandatory but encouraged)**
![](https://images.unsplash.com/photo-1424709746721-b8fd0ff52499?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=680&q=80)