### PR TITLE
WIP: Add naive support for action hooks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ cypress/screenshots
 /coverage/
 .cache
 *.log
+.idea/

--- a/dev-test/index.html
+++ b/dev-test/index.html
@@ -203,6 +203,8 @@
         );
       }
     });
+
+    CMS.registerActionHook('pre-publish', 'test-pre-publish', () => console.log('TESTING pre-publish hook'));
   </script>
 </body>
 </html>

--- a/packages/netlify-cms-core/src/backend.js
+++ b/packages/netlify-cms-core/src/backend.js
@@ -16,7 +16,7 @@ import {
 } from 'Reducers/collections';
 import { createEntry } from 'ValueObjects/Entry';
 import { sanitizeSlug } from 'Lib/urlHelper';
-import { getBackend } from 'Lib/registry';
+import { getBackend, doAction } from 'Lib/registry';
 import {
   localForage,
   Cursor,
@@ -718,6 +718,7 @@ class Backend {
   }
 
   publishUnpublishedEntry(collection, slug) {
+    doAction('pre-publish');
     return this.implementation.publishUnpublishedEntry(collection, slug);
   }
 

--- a/packages/netlify-cms-core/src/lib/registry.js
+++ b/packages/netlify-cms-core/src/lib/registry.js
@@ -2,6 +2,16 @@ import { Map } from 'immutable';
 import { oneLine } from 'common-tags';
 import EditorComponent from 'ValueObjects/EditorComponent';
 
+const allowedActionHooks = ['pre-publish'];
+
+function initActionHooks() {
+  const obj = {};
+  for (let hook of allowedActionHooks) {
+    obj[hook] = [];
+  }
+  return obj;
+}
+
 /**
  * Global Registry Object
  */
@@ -13,6 +23,7 @@ const registry = {
   editorComponents: Map(),
   widgetValueSerializers: {},
   mediaLibraries: [],
+  actionHooks: initActionHooks(),
 };
 
 export default {
@@ -31,7 +42,44 @@ export default {
   getBackend,
   registerMediaLibrary,
   getMediaLibrary,
+  registerActionHook,
+  getActionHooks,
 };
+
+export function registerActionHook(hookName, functionName, functionToAdd, priority = 10) {
+  // Priority currently does nothing
+
+  if (allowedActionHooks.indexOf(hookName) == -1) {
+    throw new Error(`Hook name '${hookName}' not recognised`);
+  }
+
+  registry.actionHooks[hookName].push({
+    functionName,
+    function: functionToAdd,
+    priority,
+  });
+}
+
+// eslint-disable-next-line no-unused-vars
+export function unregisterActionHook(hookName, functionName) {
+  throw new Error('Unimplemented');
+}
+
+// eslint-disable-next-line no-unused-vars
+export function unregisterActionHookAll(hookName) {
+  throw new Error('Unimplemented');
+}
+
+export function getActionHooks(hookName) {
+  return registry.actionHooks[hookName];
+}
+
+export function doAction(hookName, ...args) {
+  const actions = registry.actionHooks[hookName];
+  for (let action of actions) {
+    action.function(...args);
+  }
+}
 
 /**
  * Preview Styles


### PR DESCRIPTION
**Summary**

Related to #1348. This is just an outline of how hooks might be implemented. I don't anticipate working too much on this as I haven't the time, but maybe this is useful to the discussion.

Heavily inspired by WordPress' 'action hooks'. You register a function to run on a particular hook and can optionally assign it a priority (not implemented). This could be complemented or merged with WordPress' idea of filter hooks. I think the functionality provided by action/filter hooks could provide a lot of possibilities for netlify-cms.

**Test plan**

WIP

**A picture of a cute animal (not mandatory but encouraged)**
