### PR TITLE
Add Zola to static files directory table

### DIFF
--- a/website/content/docs/add-to-your-site.md
+++ b/website/content/docs/add-to-your-site.md
@@ -12,15 +12,15 @@ This tutorial guides you through the steps for adding Netlify CMS to a site that
 
 A static `admin` folder contains all Netlify CMS files, stored at the root of your published site. Where you store this folder in the source files depends on your static site generator. Here's the static file location for a few of the most popular static site generators:
 
-| These generators ...         | store static files in |
-| ---------------------------- | --------------------- |
-| Jekyll, GitBook              | `/` (project root)    |
-| Hugo, Gatsby, Nuxt, Gridsome | `/static`             |
-| Hexo, Middleman, Jigsaw      | `/source`             |
-| Spike                        | `/views`              |
-| Wyam                         | `/input`              |
-| Pelican                      | `/content`            |
-| VuePress                     | `/.vuepress/public`   |
+| These generators ...               | store static files in |
+| ---------------------------------- | --------------------- |
+| Jekyll, GitBook                    | `/` (project root)    |
+| Hugo, Gatsby, Nuxt, Gridsome, Zola | `/static`             |
+| Hexo, Middleman, Jigsaw            | `/source`             |
+| Spike                              | `/views`              |
+| Wyam                               | `/input`              |
+| Pelican                            | `/content`            |
+| VuePress                           | `/.vuepress/public`   |
 
 If your generator isn't listed here, you can check its documentation, or as a shortcut, look in your project for a `css` or `images` folder. The contents of folders like that are usually processed as static files, so it's likely you can store your `admin` folder next to those. (When you've found the location, feel free to add it to these docs by [filing a pull request](https://github.com/netlify/netlify-cms/blob/master/CONTRIBUTING.md)!)
 


### PR DESCRIPTION
**Summary**

This simply adds the static file directory information for Zola (documentation [here](https://www.getzola.org/documentation/getting-started/directory-structure/)) to the table found on the Add To Your Site page of the Netlify CMS docs ([here](https://www.netlifycms.org/docs/add-to-your-site/#app-file-structure)).


**Test plan**

I installed the website's dependencies and started a local server to test the modifications, using the instructions in the README.  I'm using Node.js 10.16.0 LTS and Yarn 1.16.0 locally.

```
yarn
yarn start
```

On the local version of the site, the modified table renders as expected (pictured below).

![app_file_structure-static_files_directory_table](https://user-images.githubusercontent.com/1584702/58750925-1aa40c00-8466-11e9-9fcf-74ff83e8ecb1.png)
