### PR TITLE
fix(core): list widget default values

### DIFF
--- a/packages/netlify-cms-core/src/actions/__tests__/entries.spec.js
+++ b/packages/netlify-cms-core/src/actions/__tests__/entries.spec.js
@@ -1,0 +1,82 @@
+import { fromJS } from 'immutable';
+import { createEmptyDraftData } from '../entries';
+
+describe('entries', () => {
+  describe('createEmptyDraftData', () => {
+    it('should set default value for list field widget', () => {
+      const fields = fromJS([
+        {
+          name: 'images',
+          widget: 'list',
+          field: { name: 'url', widget: 'text', default: 'https://image.png' },
+        },
+      ]);
+      expect(createEmptyDraftData(fields)).toEqual({ images: ['https://image.png'] });
+    });
+
+    it('should set default values for list fields widget', () => {
+      const fields = fromJS([
+        {
+          name: 'images',
+          widget: 'list',
+          fields: [
+            { name: 'title', widget: 'text', default: 'default image' },
+            { name: 'url', widget: 'text', default: 'https://image.png' },
+          ],
+        },
+      ]);
+      expect(createEmptyDraftData(fields)).toEqual({
+        images: [{ title: 'default image', url: 'https://image.png' }],
+      });
+    });
+
+    it('should not set empty value for list fields widget', () => {
+      const fields = fromJS([
+        {
+          name: 'images',
+          widget: 'list',
+          fields: [{ name: 'title', widget: 'text' }, { name: 'url', widget: 'text' }],
+        },
+      ]);
+      expect(createEmptyDraftData(fields)).toEqual({});
+    });
+
+    it('should set default value for object field widget', () => {
+      const fields = fromJS([
+        {
+          name: 'post',
+          widget: 'object',
+          field: { name: 'image', widget: 'text', default: 'https://image.png' },
+        },
+      ]);
+      expect(createEmptyDraftData(fields)).toEqual({ post: { image: 'https://image.png' } });
+    });
+
+    it('should set default values for object fields widget', () => {
+      const fields = fromJS([
+        {
+          name: 'post',
+          widget: 'object',
+          fields: [
+            { name: 'title', widget: 'text', default: 'default title' },
+            { name: 'url', widget: 'text', default: 'https://image.png' },
+          ],
+        },
+      ]);
+      expect(createEmptyDraftData(fields)).toEqual({
+        post: { title: 'default title', url: 'https://image.png' },
+      });
+    });
+
+    it('should not set empty value for object fields widget', () => {
+      const fields = fromJS([
+        {
+          name: 'post',
+          widget: 'object',
+          fields: [{ name: 'title', widget: 'text' }, { name: 'url', widget: 'text' }],
+        },
+      ]);
+      expect(createEmptyDraftData(fields)).toEqual({});
+    });
+  });
+});

--- a/packages/netlify-cms-core/src/actions/entries.js
+++ b/packages/netlify-cms-core/src/actions/entries.js
@@ -430,10 +430,11 @@ export function createEmptyDraftData(fields, withNameKey = true) {
     const name = item.get('name');
     const defaultValue = item.get('default', null);
     const isEmptyDefaultValue = val => [[{}], {}].some(e => isEqual(val, e));
-    let subDefaultValue;
 
     if (List.isList(subfields)) {
-      subDefaultValue = list ? [createEmptyDraftData(subfields)] : createEmptyDraftData(subfields);
+      const subDefaultValue = list
+        ? [createEmptyDraftData(subfields)]
+        : createEmptyDraftData(subfields);
       if (!isEmptyDefaultValue(subDefaultValue)) {
         acc[name] = subDefaultValue;
       }
@@ -441,7 +442,7 @@ export function createEmptyDraftData(fields, withNameKey = true) {
     }
 
     if (Map.isMap(subfields)) {
-      subDefaultValue = list
+      const subDefaultValue = list
         ? [createEmptyDraftData([subfields], false)]
         : createEmptyDraftData([subfields]);
       if (!isEmptyDefaultValue(subDefaultValue)) {

--- a/packages/netlify-cms-core/src/actions/entries.js
+++ b/packages/netlify-cms-core/src/actions/entries.js
@@ -1,4 +1,5 @@
 import { fromJS, List, Map } from 'immutable';
+import { isEqual } from 'lodash';
 import { actions as notifActions } from 'redux-notifications';
 import { serializeValues } from 'Lib/serializeEntryValues';
 import { currentBackend } from 'coreSrc/backend';
@@ -422,24 +423,37 @@ export function createEmptyDraft(collection) {
   };
 }
 
-function createEmptyDraftData(fields) {
+export function createEmptyDraftData(fields, withNameKey = true) {
   return fields.reduce((acc, item) => {
     const subfields = item.get('field') || item.get('fields');
     const list = item.get('widget') == 'list';
     const name = item.get('name');
     const defaultValue = item.get('default', null);
+    const isEmptyDefaultValue = val => [[{}], {}].some(e => isEqual(val, e));
+    let subDefaultValue;
 
     if (List.isList(subfields)) {
-      acc[name] = list ? [createEmptyDraftData(subfields)] : createEmptyDraftData(subfields);
+      subDefaultValue = list ? [createEmptyDraftData(subfields)] : createEmptyDraftData(subfields);
+      if (!isEmptyDefaultValue(subDefaultValue)) {
+        acc[name] = subDefaultValue;
+      }
       return acc;
     }
 
     if (Map.isMap(subfields)) {
-      acc[name] = list ? [createEmptyDraftData([subfields])] : createEmptyDraftData([subfields]);
+      subDefaultValue = list
+        ? [createEmptyDraftData([subfields], false)]
+        : createEmptyDraftData([subfields]);
+      if (!isEmptyDefaultValue(subDefaultValue)) {
+        acc[name] = subDefaultValue;
+      }
       return acc;
     }
 
     if (defaultValue !== null) {
+      if (!withNameKey) {
+        return defaultValue;
+      }
       acc[name] = defaultValue;
     }
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines.

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first two fields are mandatory:
-->

**Summary**
Currently the `createEmptyDraftData`  function creates an empty array object `[{}]` and object `{}`value for `list` and `object` widgets without any default value specified in the config file which in turn forces an empty field(s) for the `list` widget  in the editor page. Also for single `list` `field` widget with config default key set, the default value generated should come like so `['default value']` but outputs something like `[{widget_name: 'default value'}]` which should be fine if it's a `list` `fields` widget. This PR fixes both issues.
<!--
Explain the **motivation** for making this change.
What existing problem does the pull request solve?
-->

<!--
Demonstrate the code is solid.
Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.
-->
