### PR TITLE
Nested Fields for Search/Filtering in Relation Widget

### DIFF
--- a/packages/netlify-cms-core/src/backend.js
+++ b/packages/netlify-cms-core/src/backend.js
@@ -134,8 +134,7 @@ const extractSearchFields = searchFields => entry =>
     let f = entry.data;
     for (let i = 0; i < nestedFields.length; i++) {
       f = f[nestedFields[i]];
-      if (!f)
-        break;
+      if (!f) break;
     }
     return f ? `${acc} ${f}` : acc;
   }, '');

--- a/packages/netlify-cms-core/src/backend.js
+++ b/packages/netlify-cms-core/src/backend.js
@@ -130,7 +130,11 @@ const commitMessageFormatter = (type, config, { slug, path, collection }) => {
 
 const extractSearchFields = searchFields => entry =>
   searchFields.reduce((acc, field) => {
-    const f = entry.data[field];
+    let nestedFields = field.split('.');
+    let f = entry.data;
+    for (let i = 0; i < nestedFields.length; i++) {
+      f = f[nestedFields[i]];
+    }
     return f ? `${acc} ${f}` : acc;
   }, '');
 

--- a/packages/netlify-cms-core/src/backend.js
+++ b/packages/netlify-cms-core/src/backend.js
@@ -134,6 +134,8 @@ const extractSearchFields = searchFields => entry =>
     let f = entry.data;
     for (let i = 0; i < nestedFields.length; i++) {
       f = f[nestedFields[i]];
+      if (!f)
+        break;
     }
     return f ? `${acc} ${f}` : acc;
   }, '');

--- a/packages/netlify-cms-widget-relation/src/RelationControl.js
+++ b/packages/netlify-cms-widget-relation/src/RelationControl.js
@@ -113,21 +113,35 @@ export default class RelationControl extends React.Component {
     }
   };
 
+  parseNestedFields = (targetObject, field) => {
+    let nestedDisplayField = field.split('.');
+    let f = targetObject;
+    for (let i = 0; i < nestedDisplayField.length; i++) {
+      f = f[nestedDisplayField[i]];
+      if (!f) break;
+    }
+    if (typeof f === 'object' && f !== null) {
+      return JSON.stringify(f);
+    }
+    return f;
+  }
+
   parseHitOptions = hits => {
     const { field } = this.props;
     const valueField = field.get('valueField');
     const displayField = field.get('displayFields') || field.get('valueField');
 
     return hits.map(hit => {
+      let labelReturn;
+      if (List.isList(displayField)) {
+        labelReturn = displayField.toJS().map(key => this.parseNestedFields(hit.data, key)).join(' ')
+      } else {
+        labelReturn = this.parseNestedFields(hit.data, displayField);
+      }
       return {
         data: hit.data,
         value: hit.data[valueField],
-        label: List.isList(displayField)
-          ? displayField
-              .toJS()
-              .map(key => hit.data[key])
-              .join(' ')
-          : hit.data[displayField],
+        label: labelReturn,
       };
     });
   };

--- a/packages/netlify-cms-widget-relation/src/RelationControl.js
+++ b/packages/netlify-cms-widget-relation/src/RelationControl.js
@@ -124,7 +124,7 @@ export default class RelationControl extends React.Component {
       return JSON.stringify(f);
     }
     return f;
-  }
+  };
 
   parseHitOptions = hits => {
     const { field } = this.props;
@@ -134,7 +134,10 @@ export default class RelationControl extends React.Component {
     return hits.map(hit => {
       let labelReturn;
       if (List.isList(displayField)) {
-        labelReturn = displayField.toJS().map(key => this.parseNestedFields(hit.data, key)).join(' ')
+        labelReturn = displayField
+          .toJS()
+          .map(key => this.parseNestedFields(hit.data, key))
+          .join(' ');
       } else {
         labelReturn = this.parseNestedFields(hit.data, displayField);
       }

--- a/packages/netlify-cms-widget-relation/src/RelationControl.js
+++ b/packages/netlify-cms-widget-relation/src/RelationControl.js
@@ -72,7 +72,7 @@ export default class RelationControl extends React.Component {
       if (value) {
         const listValue = List.isList(value) ? value : List([value]);
         listValue.forEach(val => {
-          const hit = hits.find(i => i.data[valueField] === val);
+          const hit = hits.find(i => this.parseNestedFields(i.data, valueField) === val);
           if (hit) {
             onChange(value, {
               [field.get('name')]: {
@@ -114,10 +114,10 @@ export default class RelationControl extends React.Component {
   };
 
   parseNestedFields = (targetObject, field) => {
-    let nestedDisplayField = field.split('.');
+    let nestedField = field.split('.');
     let f = targetObject;
-    for (let i = 0; i < nestedDisplayField.length; i++) {
-      f = f[nestedDisplayField[i]];
+    for (let i = 0; i < nestedField.length; i++) {
+      f = f[nestedField[i]];
       if (!f) break;
     }
     if (typeof f === 'object' && f !== null) {
@@ -140,7 +140,7 @@ export default class RelationControl extends React.Component {
       }
       return {
         data: hit.data,
-        value: hit.data[valueField],
+        value: this.parseNestedFields(hit.data, valueField),
         label: labelReturn,
       };
     });

--- a/packages/netlify-cms-widget-relation/src/__tests__/relation.spec.js
+++ b/packages/netlify-cms-widget-relation/src/__tests__/relation.spec.js
@@ -21,16 +21,16 @@ const deeplyNestedFieldConfig = {
   collection: 'posts',
   displayFields: ['title', 'slug', 'deeply.nested.post.field'],
   searchFields: ['deeply.nested.post.field'],
-  valueField: 'title'
-}
+  valueField: 'title',
+};
 
 const nestedFieldConfig = {
   name: 'post',
   collection: 'posts',
   displayFields: ['title', 'slug', 'nested.field_1'],
   searchFields: ['nested.field_1', 'nested.field_2'],
-  valueField: 'title'
-}
+  valueField: 'title',
+};
 
 const generateHits = length => {
   const hits = Array.from({ length }, (val, idx) => {
@@ -49,11 +49,11 @@ const generateHits = length => {
         deeply: {
           nested: {
             post: {
-              field: 'Deeply nested field'
-            }
-          }
-        }
-      }
+              field: 'Deeply nested field',
+            },
+          },
+        },
+      },
     },
     {
       collection: 'posts',
@@ -62,9 +62,9 @@ const generateHits = length => {
         slug: 'post-nested',
         nested: {
           field_1: 'Nested field 1',
-          field_2: 'Nested field 2'
-        }
-      }
+          field_2: 'Nested field 2',
+        },
+      },
     },
     {
       collection: 'posts',
@@ -93,9 +93,13 @@ class RelationController extends React.Component {
     if (last(args) === 'YAML') {
       return Promise.resolve({ payload: { response: { hits: [last(queryHits)] } } });
     } else if (last(args) === 'Nested') {
-      return Promise.resolve({ payload: { response: { hits: [queryHits[queryHits.length - 2]] }}});
+      return Promise.resolve({
+        payload: { response: { hits: [queryHits[queryHits.length - 2]] } },
+      });
     } else if (last(args) === 'Deeply nested') {
-      return Promise.resolve({ payload: { response: { hits: [queryHits[queryHits.length - 3]] }}});
+      return Promise.resolve({
+        payload: { response: { hits: [queryHits[queryHits.length - 3]] } },
+      });
     }
     return Promise.resolve({ payload: { response: { hits: queryHits } } });
   });
@@ -220,7 +224,9 @@ describe('Relation widget', () => {
     fireEvent.change(input, { target: { value: 'Deeply nested' } });
 
     await wait(() => {
-      expect(getAllByText('Deeply nested post post-deeply-nested Deeply nested field')).toHaveLength(1);
+      expect(
+        getAllByText('Deeply nested post post-deeply-nested Deeply nested field'),
+      ).toHaveLength(1);
     });
   });
 

--- a/website/content/docs/uploadcare.md
+++ b/website/content/docs/uploadcare.md
@@ -46,7 +46,7 @@ using the image or file widgets.
 ## Configuring the Uploadcare Widget
 
 The Uploadcare widget can be configured with settings that are outlined [in their
-docs](https://uploadcare.com/docs/uploads/widget/config/). The widget itself accepts configration
+docs](https://uploadcare.com/docs/file_uploads/widget/options/). The widget itself accepts configration
 through global variables and data properties on HTML elements, but with Netlify CMS you can pass
 configuration options directly through your `config.yml`.
 

--- a/website/content/docs/widgets/relation.md
+++ b/website/content/docs/widgets/relation.md
@@ -22,7 +22,7 @@ The relation widget allows you to reference items from another collection. It pr
       widget: "relation"
       collection: "authors"
       searchFields: ["name.first", "twitterHandle"]
-      valueField: "name"
+      valueField: "name.first"
       displayFields: ["twitterHandle", "followerCount"]
     ```
   The generated UI input will search the authors collection by name and twitterHandle, and display each author's handle and follower count. On selection, the author name will be saved for the field.

--- a/website/content/docs/widgets/relation.md
+++ b/website/content/docs/widgets/relation.md
@@ -12,16 +12,16 @@ The relation widget allows you to reference items from another collection. It pr
   - `default`: accepts any widget data type; defaults to an empty string
   - `collection`: (**required**) name of the collection being referenced (string)
   - `displayFields`: list of one or more names of fields in the referenced collection that will render in the autocomplete menu of the control. Defaults to `valueField`.
-  - `searchFields`: (**required**) list of one or more names of fields in the referenced collection to search for the typed value
+  - `searchFields`: (**required**) list of one or more names of fields in the referenced collection to search for the typed value. For nested fields, separate each subfield with a `.` (E.g. `name.first`).
   - `valueField`: (**required**) name of the field from the referenced collection whose value will be stored for the relation
   - `multiple` : accepts a boolean, defaults to `false`
-- **Example** (assuming a separate "authors" collection with "name" and "twitterHandle" fields):
+- **Example** (assuming a separate "authors" collection with "name" and "twitterHandle" fields with subfields "first" and "last" for the "name" field):
     ```yaml
     - label: "Post Author"
       name: "author"
       widget: "relation"
       collection: "authors"
-      searchFields: ["name", "twitterHandle"]
+      searchFields: ["name.first", "twitterHandle"]
       valueField: "name"
       displayFields: ["twitterHandle", "followerCount"]
     ```

--- a/website/content/docs/widgets/relation.md
+++ b/website/content/docs/widgets/relation.md
@@ -11,9 +11,9 @@ The relation widget allows you to reference items from another collection. It pr
 - **Options:**
   - `default`: accepts any widget data type; defaults to an empty string
   - `collection`: (**required**) name of the collection being referenced (string)
-  - `displayFields`: list of one or more names of fields in the referenced collection that will render in the autocomplete menu of the control. Defaults to `valueField`. For nested fields, separate each subfield with a `.` (E.g. `name.last`).
-  - `searchFields`: (**required**) list of one or more names of fields in the referenced collection to search for the typed value. For nested fields, separate each subfield with a `.` (E.g. `name.first`).
-  - `valueField`: (**required**) name of the field from the referenced collection whose value will be stored for the relation
+  - `displayFields`: list of one or more names of fields in the referenced collection that will render in the autocomplete menu of the control. Defaults to `valueField`. For nested fields, separate each subfield with a `.` (E.g. `name.first`).
+  - `searchFields`: (**required**) list of one or more names of fields in the referenced collection to search for the typed value. Syntax to reference nested fields is similar to that of *displayFields*.
+  - `valueField`: (**required**) name of the field from the referenced collection whose value will be stored for the relation. Syntax to reference nested fields is similar to that of *displayFields* and *searchFields*.
   - `multiple` : accepts a boolean, defaults to `false`
 - **Example** (assuming a separate "authors" collection with "name" and "twitterHandle" fields with subfields "first" and "last" for the "name" field):
     ```yaml

--- a/website/content/docs/widgets/relation.md
+++ b/website/content/docs/widgets/relation.md
@@ -11,7 +11,7 @@ The relation widget allows you to reference items from another collection. It pr
 - **Options:**
   - `default`: accepts any widget data type; defaults to an empty string
   - `collection`: (**required**) name of the collection being referenced (string)
-  - `displayFields`: list of one or more names of fields in the referenced collection that will render in the autocomplete menu of the control. Defaults to `valueField`.
+  - `displayFields`: list of one or more names of fields in the referenced collection that will render in the autocomplete menu of the control. Defaults to `valueField`. For nested fields, separate each subfield with a `.` (E.g. `name.last`).
   - `searchFields`: (**required**) list of one or more names of fields in the referenced collection to search for the typed value. For nested fields, separate each subfield with a `.` (E.g. `name.first`).
   - `valueField`: (**required**) name of the field from the referenced collection whose value will be stored for the relation
   - `multiple` : accepts a boolean, defaults to `false`


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines.

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first two fields are mandatory:
-->

**Summary**

Fixes #2356 

You can specify nested fields for the `displayFields` and `searchFields` options for the [Relation Widget](https://www.netlifycms.org/docs/widgets/#relation). The fields are referenced as if they were JSON objects.

Ex. The nested field in the collection:

```yaml
- name: "nestedFields"
  label: "Nested Fields"
  ...
  fields:
    - name: "title"
      label: "Title"
      widget: "string"
    - name: "nestedFields"
      label: "Nested Fields"
      widget: "object"
      fields:
        - name: "field1"
          label: "Field 1"
          widget: "string"
        - name: "field2"
          label: "Field 2"
          widget: "string"
      ...
```

can be referenced in the `displayFields` and `searchFields` options of the  [Relation Widget](https://www.netlifycms.org/docs/widgets/#relation) as so:

```
displayField: ['nestedFields.field1', ...]
searchField: ['nestedFields.field2', ...]
```

Here is an example of the UI:

![Netlify](https://user-images.githubusercontent.com/30060214/59726339-70aada80-91ee-11e9-992f-92124b209282.gif)


A gist describing the collection can be found [here](https://gist.github.com/WJXHenry/a170cc1e918c5359792a802c1dbe5684).

<!--
Explain the **motivation** for making this change.
What existing problem does the pull request solve?
-->

<!--
Demonstrate the code is solid.
Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.
-->

**A picture of a cute animal (not mandatory but encouraged)**

![Shiba Inu](https://thehappypuppysite.com/wp-content/uploads/2018/05/shiba-inu-header.jpg)