### PR TITLE
Editorial Workflow support for GitLab

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -4,6 +4,7 @@ module.exports = {
     '\\.js$': '<rootDir>/custom-preprocessor.js',
   },
   moduleNameMapper: {
+    'netlify-cms-lib-auth': '<rootDir>/packages/netlify-cms-lib-auth/src/index.js',
     'netlify-cms-lib-util': '<rootDir>/packages/netlify-cms-lib-util/src/index.js',
     'netlify-cms-ui-default': '<rootDir>/packages/netlify-cms-ui-default/src/index.js',
   },

--- a/package.json
+++ b/package.json
@@ -101,6 +101,8 @@
     "jest-dom": "^3.1.3",
     "jest-emotion": "^10.0.9",
     "ncp": "^2.0.0",
+    "nock": "^10.0.4",
+    "node-fetch": "^2.3.0",
     "npm-run-all": "^4.1.5",
     "prettier": "1.17.1",
     "react-test-renderer": "^16.8.4",

--- a/packages/netlify-cms-backend-gitlab/src/API.js
+++ b/packages/netlify-cms-backend-gitlab/src/API.js
@@ -1,7 +1,12 @@
-import { localForage, unsentRequest, then, APIError, Cursor } from 'netlify-cms-lib-util';
+import { localForage, then, unsentRequest } from 'netlify-cms-lib-util';
 import { Base64 } from 'js-base64';
 import { fromJS, List, Map } from 'immutable';
-import { flow, partial, result } from 'lodash';
+import { flow, get, partial, result, uniq } from 'lodash';
+import { filterPromises, resolvePromiseProperties } from 'netlify-cms-lib-util';
+import { APIError, Cursor, EditorialWorkflowError } from 'netlify-cms-lib-util';
+
+export const CMS_BRANCH_PREFIX = 'cms/';
+const CMS_METADATA_BRANCH = '_netlify_cms';
 
 export default class API {
   constructor(config) {
@@ -10,16 +15,29 @@ export default class API {
     this.branch = config.branch || 'master';
     this.repo = config.repo || '';
     this.repoURL = `/projects/${encodeURIComponent(this.repo)}`;
+    this.squash_merges = config.squash_merges || false;
+    this.initialWorkflowStatus = config.initialWorkflowStatus;
   }
 
   withAuthorizationHeaders = req =>
     unsentRequest.withHeaders(this.token ? { Authorization: `Bearer ${this.token}` } : {}, req);
 
+  withBody = body => req =>
+    flow(
+      body
+        ? [
+            r => unsentRequest.withHeaders({ 'Content-Type': 'application/json' }, r),
+            r => unsentRequest.withBody(JSON.stringify(body), r),
+          ]
+        : [],
+    )(req);
+
   buildRequest = req =>
     flow([
       unsentRequest.withRoot(this.api_root),
-      this.withAuthorizationHeaders,
       unsentRequest.withTimestamp,
+      this.withAuthorizationHeaders,
+      this.withBody(req.body),
     ])(req);
 
   request = async req =>
@@ -72,8 +90,13 @@ export default class API {
   responseToJSON = res => this.parseResponse(res, { expectingFormat: 'json' });
   responseToBlob = res => this.parseResponse(res, { expectingFormat: 'blob' });
   responseToText = res => this.parseResponse(res, { expectingFormat: 'text' });
+
   requestJSON = req => this.request(req).then(this.responseToJSON);
+  requestBlob = req => this.request(req).then(this.responseToBlob);
   requestText = req => this.request(req).then(this.responseToText);
+
+  toBase64 = str => Promise.resolve(Base64.encode(str));
+  fromBase64 = str => Promise.resolve(Base64.decode(str));
 
   user = () => this.requestJSON('/user');
 
@@ -90,22 +113,35 @@ export default class API {
       return false;
     });
 
-  readFile = async (path, sha, { ref = this.branch, parseText = true } = {}) => {
-    const cacheKey = parseText ? `gl.${sha}` : `gl.${sha}.blob`;
-    const cachedFile = sha ? await localForage.getItem(cacheKey) : null;
-    if (cachedFile) {
-      return cachedFile;
+  readFile(path, sha, { ref = this.branch, parseText = true } = {}) {
+    if (sha) {
+      return this.getBlob(sha, path, ref, parseText);
+    } else {
+      return this.fetchBlob(path, ref, parseText);
     }
-    const result = await this.request({
+  }
+
+  getBlob(sha, path, ref, parseText) {
+    const cacheKey = parseText ? `gl.${sha}` : `gl.${sha}.blob`;
+    return localForage.getItem(cacheKey).then(cached => {
+      if (cached) {
+        return cached;
+      }
+
+      return this.fetchBlob(path, ref, parseText).then(result => {
+        localForage.setItem(cacheKey, result);
+        return result;
+      });
+    });
+  }
+
+  fetchBlob(path, ref, parseText) {
+    return flow([parseText ? this.requestText : this.requestBlob])({
       url: `${this.repoURL}/repository/files/${encodeURIComponent(path)}/raw`,
       params: { ref },
       cache: 'no-store',
-    }).then(parseText ? this.responseToText : this.responseToBlob);
-    if (sha) {
-      localForage.setItem(cacheKey, result);
-    }
-    return result;
-  };
+    });
+  }
 
   getCursorFromHeaders = headers => {
     // indices and page counts are assumed to be zero-based, but the
@@ -228,58 +264,443 @@ export default class API {
     return entries.filter(({ type }) => type === 'blob');
   };
 
-  toBase64 = str => Promise.resolve(Base64.encode(str));
-  fromBase64 = str => Base64.decode(str);
-  uploadAndCommit = async (
-    item,
-    { commitMessage, updateFile = false, branch = this.branch, author = this.commitAuthor },
-  ) => {
-    const content = await result(item, 'toBase64', partial(this.toBase64, item.raw));
-    const file_path = item.path.replace(/^\//, '');
-    const action = updateFile ? 'update' : 'create';
-    const encoding = 'base64';
-
-    const commitParams = {
-      branch,
-      commit_message: commitMessage,
-      actions: [{ action, file_path, content, encoding }],
-    };
+  toCommitParams(commit_message, branch, author) {
+    const commitParams = { branch, commit_message };
     if (author) {
-      const { name, email } = author;
-      commitParams.author_name = name;
-      commitParams.author_email = email;
+      return {
+        ...commitParams,
+        author_email: author.email,
+        author_name: author.name,
+      };
+    } else {
+      return commitParams;
     }
+  }
 
-    await this.request({
-      url: `${this.repoURL}/repository/commits`,
+  async uploadAndCommit(
+    entry,
+    items,
+    { commitMessage, newEntry = true, branch = this.branch, author = this.commitAuthor },
+  ) {
+    const commitParams = this.toCommitParams(commitMessage, branch, author);
+    const action = newEntry ? 'create' : 'update';
+    const actions = await Promise.all(
+      items.map(async item => ({
+        action,
+        file_path: item.path.replace(/^\//, ''),
+        content: await result(item, 'toBase64', partial(this.toBase64, item.raw)),
+        encoding: 'base64',
+        ...(item.sha ? { last_commit_id: item.sha } : {}),
+      })),
+    );
+    const response = await this.requestJSON({
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(commitParams),
+      url: `${this.repoURL}/repository/commits`,
+      body: {
+        ...commitParams,
+        actions,
+      },
     });
+    return items.map(item => ({
+      ...item,
+      sha: response.id,
+      uploaded: true,
+    }));
+  }
 
-    return { ...item, uploaded: true };
-  };
+  persistFiles(entry, mediaFiles, options) {
+    const files = entry ? [entry, ...mediaFiles] : [...mediaFiles];
+    if (!options.useWorkflow) {
+      return this.uploadAndCommit(entry, files, options);
+    } else {
+      return this.editorialWorkflowGit(entry, files, options);
+    }
+  }
 
-  persistFiles = (files, { commitMessage, newEntry }) =>
-    Promise.all(
-      files.map(file =>
-        this.uploadAndCommit(file, { commitMessage, updateFile: newEntry === false }),
+  deleteFile(path, commitMessage, { branch = this.branch, author = this.commitAuthor }) {
+    const commitParams = this.toCommitParams(commitMessage, branch, author);
+    return this.request({
+      method: 'DELETE',
+      url: `${this.repoURL}/repository/files/${encodeURIComponent(path)}`,
+      params: commitParams,
+      // last_commit_id: ???,
+    });
+  }
+
+  // Metadata
+
+  checkMetadataBranch() {
+    return this.getBranch(CMS_METADATA_BRANCH).catch(error => {
+      if (error instanceof APIError && error.status === 404) {
+        return this.createMetadataBranch();
+      }
+      throw error;
+    });
+  }
+
+  createMetadataBranch() {
+    // The Branches API doesn't support creating orphan branches.
+    // The Commits API doesn't support creating orphan branches.
+    //   https://gitlab.com/gitlab-org/gitlab-ce/issues/2420 only works for empty repositories.
+    throw new Error(`Not Implemented - GitLab API does not support creating orphan branches.'`);
+    // TODO - rudolf - Update README / Installation and Configuration.
+    // Git could be used for creating orphan branches.
+    //   git checkout --orphan _netlify_cms
+    //   git rm --cached *
+    //   echo "# Netlify CMS\n\nThis branch is used by Netlify CMS to store metadata information for files, branches, merge requests.\n" > README.md
+    //   git add README.md
+    //   git commit -m "Initial commit by Netlify CMS"
+    //   git push --set-upstream origin _netlify_cms
+  }
+
+  retrieveMetadata(key) {
+    const metadataKey = `gl.meta.${key}`;
+    const metadataPath = `${key}.json`;
+    return localForage.getItem(metadataKey).then(cached => {
+      if (cached && cached.expires > Date.now()) {
+        return cached.data;
+      }
+      console.log(
+        '%c Checking for MetaData files of %s',
+        'line-height: 30px;text-align: center;font-weight: bold',
+        key,
+      );
+      return this.fetchBlob(metadataPath, CMS_METADATA_BRANCH, true)
+        .then(raw => JSON.parse(raw))
+        .catch(error => {
+          if (error instanceof APIError && error.status === 404) {
+            console.log(
+              '%c %s does not have metadata',
+              'line-height: 30px;text-align: center;font-weight: bold',
+              key,
+            );
+            throw error;
+          }
+          throw error;
+        });
+    });
+  }
+
+  storeMetadata(key, data, { create = false } = {}) {
+    const metadataKey = `gl.meta.${key}`;
+    const metadataPath = `${key}.json`;
+    return this.checkMetadataBranch().then(() =>
+      this.uploadAndCommit(
+        null, // entry is not used
+        [
+          {
+            path: metadataPath,
+            raw: JSON.stringify(data),
+          },
+        ],
+        {
+          commitMessage: (create ? 'Create' : 'Update') + ` '${key}' metadata`,
+          newEntry: create,
+          branch: CMS_METADATA_BRANCH,
+        },
+      ).then(() =>
+        localForage.setItem(metadataKey, {
+          expires: Date.now() + 300000, // in 5 minutes
+          data,
+        }),
       ),
     );
+  }
 
-  deleteFile = (path, commit_message, options = {}) => {
-    const branch = options.branch || this.branch;
-    const commitParams = { commit_message, branch };
-    if (this.commitAuthor) {
-      const { name, email } = this.commitAuthor;
-      commitParams.author_name = name;
-      commitParams.author_email = email;
+  deleteMetadata(key) {
+    const metadataKey = `gl.meta.${key}`;
+    const metadataPath = `${key}.json`;
+    return this.deleteFile(metadataPath, `Delete '${key}' metadata`, {
+      branch: CMS_METADATA_BRANCH,
+    }).then(() => localForage.removeItem(metadataKey));
+  }
+
+  // Editorial Workflow
+
+  editorialWorkflowGit(entry, items, options) {
+    const contentKey = entry.slug;
+    const branchName = this.generateBranchName(contentKey);
+    const unpublished = options.unpublished || false;
+    if (!unpublished) {
+      // Open new editorial review workflow for this entry - create new metadata and commit to new branch
+      // Note that the metadata branch is checked to fail fast and avoid inconsistent state.
+      return this.checkMetadataBranch().then(() =>
+        this.createBranch(branchName).then(branch =>
+          this.uploadAndCommit(entry, items, { ...options, branch: branch.name }).then(
+            updatedItems =>
+              this.createMR(options.commitMessage, branch.name).then(mr => {
+                const sha = updatedItems[0].sha;
+                const filesList = updatedItems.map(item => ({ path: item.path, sha: item.sha }));
+                const user = mr.author;
+                const metadata = {
+                  type: 'MR',
+                  mr: {
+                    number: mr.iid,
+                    head: sha, // === mr.sha
+                  },
+                  user: user.name || user.username,
+                  status: this.initialWorkflowStatus,
+                  branch: branch.name,
+                  collection: options.collectionName,
+                  title: options.parsedData && options.parsedData.title,
+                  description: options.parsedData && options.parsedData.description,
+                  objects: {
+                    // NOTE - rudolf - It looks like `entry.sha` is always `undefined`.
+                    entry: { path: entry.path, sha: entry.sha },
+                    files: filesList,
+                  },
+                  timeStamp: new Date().toISOString(),
+                };
+                return this.storeMetadata(contentKey, metadata, { create: true });
+              }),
+          ),
+        ),
+      );
+    } else {
+      // Entry is already on editorial review workflow - update metadata and commit to existing branch
+      return this.retrieveMetadata(contentKey).then(metadata =>
+        this.getBranch(branchName).then(branch =>
+          this.uploadAndCommit(entry, items, { ...options, branch: branch.name }).then(
+            updatedItems => {
+              const sha = updatedItems[0].sha;
+              const filesList = updatedItems.map(item => ({ path: item.path, sha: item.sha }));
+              // TODO - rudolf - Why does it matter whether an asset store is in use?
+              // if (options.hasAssetStore) {
+              //   /**
+              //    * If an asset store is in use, assets are always accessible, so we
+              //    * can just finish the persist operation here.
+              //    */
+              const metadataFiles = get(metadata.objects, 'files', []);
+              const files = [...metadataFiles, ...filesList];
+              const updatedMetadata = {
+                ...metadata,
+                mr: {
+                  ...metadata.mr,
+                  head: sha,
+                },
+                title: options.parsedData && options.parsedData.title,
+                description: options.parsedData && options.parsedData.description,
+                objects: {
+                  // NOTE - rudolf - It looks like `entry.sha` is always `undefined`.
+                  entry: { path: entry.path, sha: entry.sha },
+                  files: uniq(files),
+                },
+                timeStamp: new Date().toISOString(),
+              };
+              return this.storeMetadata(contentKey, updatedMetadata);
+              // } else {
+              //   /**
+              //    * If no asset store is in use, assets are being stored in the content
+              //    * repo, which means pull requests opened for editorial workflow
+              //    * entries must be rebased if assets have been added or removed.
+              //    */
+              //   return this.rebaseMR(mr.number, branch.name, contentKey, metadata, sha);
+              // }
+            },
+          ),
+        ),
+      );
     }
-    return flow([
-      unsentRequest.withMethod('DELETE'),
-      // TODO: only send author params if they are defined.
-      unsentRequest.withParams(commitParams),
-      this.request,
-    ])(`${this.repoURL}/repository/files/${encodeURIComponent(path)}`);
-  };
+  }
+
+  listUnpublishedBranches() {
+    console.log(
+      '%c Checking for Unpublished entries',
+      'line-height: 30px;text-align: center;font-weight: bold',
+    );
+    // Get branches with a `name` matching `CMS_BRANCH_PREFIX`.
+    // Note that this is a substring match, so we need to check that the `branch.name` was generated by us.
+    return this.requestJSON({
+      url: `${this.repoURL}/repository/branches`,
+      params: { search: CMS_BRANCH_PREFIX },
+    })
+      .then(branches =>
+        branches.filter(branch => this.assertBranchName(branch.name) && !branch.merged),
+      )
+      .then(branches =>
+        filterPromises(branches, branch =>
+          // Get MRs with a `source_branch` of `branch.name`.
+          // Note that this is *probably* a substring match, so we need to check that
+          // the `source_branch` of at least one of the returned objects matches `branch.name`.
+          this.requestJSON({
+            url: `${this.repoURL}/merge_requests`,
+            params: {
+              state: 'opened',
+              source_branch: branch.name,
+              target_branch: this.branch,
+            },
+          }).then(mrs => mrs.some(mr => mr.source_branch === branch.name)),
+        ),
+      )
+      .catch(error => {
+        console.log(
+          '%c No Unpublished entries',
+          'line-height: 30px;text-align: center;font-weight: bold',
+        );
+        throw error;
+      });
+  }
+
+  readUnpublishedBranchFile(contentKey) {
+    const metaDataPromise = this.retrieveMetadata(contentKey).then(
+      data => (data.objects.entry.path ? data : Promise.reject(null)),
+    );
+    return resolvePromiseProperties({
+      metaData: metaDataPromise,
+      fileData: metaDataPromise.then(data =>
+        this.readFile(data.objects.entry.path, null, { ref: data.branch }),
+      ),
+      isModification: metaDataPromise.then(data =>
+        this.isUnpublishedEntryModification(data.objects.entry.path, this.branch),
+      ),
+    }).catch(() => {
+      throw new EditorialWorkflowError('content is not under editorial workflow', true);
+    });
+  }
+
+  isUnpublishedEntryModification(path, branch) {
+    return this.readFile(path, null, { ref: branch })
+      .then(() => true)
+      .catch(error => {
+        if (error instanceof APIError && error.status === 404) {
+          return false;
+        }
+        throw error;
+      });
+  }
+
+  updateUnpublishedEntryStatus(collection, slug, status) {
+    const contentKey = slug;
+    return this.retrieveMetadata(contentKey)
+      .then(metadata => ({
+        ...metadata,
+        status,
+      }))
+      .then(updatedMetadata => this.storeMetadata(contentKey, updatedMetadata));
+  }
+
+  deleteUnpublishedEntry(collection, slug) {
+    const contentKey = slug;
+    const branchName = this.generateBranchName(contentKey);
+    return (
+      this.retrieveMetadata(contentKey)
+        .then(metadata => this.closeMR(metadata.mr))
+        .then(() => this.deleteBranch(branchName))
+        .then(() => this.deleteMetadata(contentKey))
+        // If the MR doesn't exist, then this has already been deleted.
+        // Deletion should be idempotent, so we can consider this a success.
+        .catch(error => {
+          if (error instanceof APIError && error.status === 404) {
+            return Promise.resolve();
+          }
+          throw error;
+        })
+    );
+  }
+
+  publishUnpublishedEntry(collection, slug) {
+    const contentKey = slug;
+    const branchName = this.generateBranchName(contentKey);
+    return this.retrieveMetadata(contentKey)
+      .then(metadata => this.mergeMR(metadata.mr, metadata.branch, metadata.objects))
+      .then(() => this.deleteBranch(branchName))
+      .then(() => this.deleteMetadata(contentKey));
+  }
+
+  // Branches
+
+  generateBranchName(name) {
+    return `${CMS_BRANCH_PREFIX}${name}`;
+  }
+
+  assertBranchName(name) {
+    return name.startsWith(CMS_BRANCH_PREFIX);
+  }
+
+  getBranch(branch = this.branch) {
+    return this.requestJSON(`${this.repoURL}/repository/branches/${encodeURIComponent(branch)}`);
+  }
+
+  createBranch(branch, ref = this.branch) {
+    return this.requestJSON({
+      method: 'POST',
+      url: `${this.repoURL}/repository/branches`,
+      params: { branch, ref },
+    });
+  }
+
+  deleteBranch(branch) {
+    return this.request({
+      method: 'DELETE',
+      url: `${this.repoURL}/repository/branches/${encodeURIComponent(branch)}`,
+    });
+  }
+
+  // Merge Requests
+
+  getMR(mrNumber) {
+    return this.requestJSON(
+      `${this.repoURL}/repository/merge_requests/${encodeURIComponent(mrNumber)}`,
+    );
+  }
+
+  createMR(title, source_branch, target_branch = this.branch) {
+    console.log('%c Creating MR', 'line-height: 30px;text-align: center;font-weight: bold');
+    return this.requestJSON({
+      method: 'POST',
+      url: `${this.repoURL}/merge_requests`,
+      body: {
+        source_branch,
+        target_branch,
+        title,
+        description: 'Generated by Netlify CMS',
+        remove_source_branch: false,
+        squash: this.squash_merges,
+      },
+    });
+  }
+
+  closeMR(mr) {
+    const mrNumber = mr.number;
+    console.log('%c Deleting MR', 'line-height: 30px;text-align: center;font-weight: bold');
+    return this.requestJSON({
+      method: 'PUT',
+      url: `${this.repoURL}/merge_requests/${encodeURIComponent(mrNumber)}`,
+      body: {
+        state_event: 'close',
+      },
+    });
+  }
+
+  mergeMR(mr, branch, objects) {
+    const mrNumber = mr.number;
+    const sha = mr.head;
+    console.log('%c Merging MR', 'line-height: 30px;text-align: center;font-weight: bold');
+    return this.requestJSON({
+      method: 'PUT',
+      url: `${this.repoURL}/merge_requests/${encodeURIComponent(mrNumber)}/merge`,
+      body: {
+        merge_commit_message:
+          'Merged by Netlify CMS\n' + `Merge branch '${branch}' into '${this.branch}'`,
+        sha,
+      },
+    }).catch(error => {
+      if (error instanceof APIError && error.status === 405) {
+        return this.forceMergeMR(mr, branch, objects);
+      }
+      throw error;
+    });
+  }
+
+  // eslint-disable-next-line no-unused-vars
+  forceMergeMR(mr, branch, objects) {
+    // TODO - rudolf - Why is this needed? How are merge conflicts possible?
+    throw new Error(`Not Implemented`);
+  }
+
+  // eslint-disable-next-line no-unused-vars
+  rebaseMR(mrNumber, branch, contentKey, metadata, sha) {
+    // TODO - rudolf - Why is this needed? How are assets affected by branches?
+    throw new Error(`Not Implemented`);
+  }
 }

--- a/packages/netlify-cms-backend-gitlab/src/__tests__/gitlab.spec.js
+++ b/packages/netlify-cms-backend-gitlab/src/__tests__/gitlab.spec.js
@@ -405,22 +405,18 @@ describe('gitlab backend', () => {
       expect(entries.entries).toHaveLength(2);
     });
 
-    it(
-      'returns all entries from folder collection',
-      async () => {
-        const tree = mockRepo.tree[collectionManyEntriesConfig.folder];
-        tree.forEach(file => interceptFiles(backend, file.path));
+    it('returns all entries from folder collection', async () => {
+      const tree = mockRepo.tree[collectionManyEntriesConfig.folder];
+      tree.forEach(file => interceptFiles(backend, file.path));
 
-        interceptCollection(backend, collectionManyEntriesConfig, { repeat: 5 });
-        const entries = await backend.listAllEntries(fromJS(collectionManyEntriesConfig));
+      interceptCollection(backend, collectionManyEntriesConfig, { repeat: 5 });
+      const entries = await backend.listAllEntries(fromJS(collectionManyEntriesConfig));
 
-        expect(entries).toEqual(
-          expect.arrayContaining(tree.map(file => expect.objectContaining({ path: file.path }))),
-        );
-        expect(entries).toHaveLength(500);
-      },
-      7000,
-    );
+      expect(entries).toEqual(
+        expect.arrayContaining(tree.map(file => expect.objectContaining({ path: file.path }))),
+      );
+      expect(entries).toHaveLength(500);
+    }, 7000);
 
     it('returns entries from file collection', async () => {
       const { files } = collectionFilesConfig;

--- a/packages/netlify-cms-backend-gitlab/src/__tests__/gitlab.spec.js
+++ b/packages/netlify-cms-backend-gitlab/src/__tests__/gitlab.spec.js
@@ -1,0 +1,458 @@
+jest.mock('netlify-cms-core/src/backend');
+import { fromJS } from 'immutable';
+import { partial } from 'lodash';
+import { oneLine, stripIndent } from 'common-tags';
+import nock from 'nock';
+import { Cursor } from 'netlify-cms-lib-util';
+import Gitlab from '../implementation';
+import AuthenticationPage from '../AuthenticationPage';
+
+const { Backend, LocalStorageAuthStore } = jest.requireActual('netlify-cms-core/src/backend');
+
+const generateEntries = (path, length) => {
+  const entries = Array.from({ length }, (val, idx) => {
+    const count = idx + 1;
+    const id = `00${count}`.slice(-3);
+    const fileName = `test${id}.md`;
+    return { id, fileName, filePath: `${path}/${fileName}` };
+  });
+
+  return {
+    tree: entries.map(({ id, fileName, filePath }) => ({
+      id: `d8345753a1d935fa47a26317a503e73e1192d${id}`,
+      name: fileName,
+      type: 'blob',
+      path: filePath,
+      mode: '100644',
+    })),
+    files: entries.reduce((acc, { id, filePath }) => ({
+      ...acc,
+      [filePath]: stripIndent`
+        ---
+        title: test ${id}
+        ---
+        # test ${id}
+      `,
+    }), {}),
+  };
+}
+
+const manyEntries = generateEntries('many-entries', 500);
+
+const mockRepo = {
+  tree: {
+    '/': [
+      {
+        id: '5d0620ebdbc92068a3e866866e928cc373f18429',
+        name: 'content',
+        type: 'tree',
+        path: 'content',
+        mode: '040000',
+      },
+    ],
+    content: [
+      {
+        id: 'b1a200e48be54fde12b636f9563d659d44c206a5',
+        name: 'test1.md',
+        type: 'blob',
+        path: 'content/test1.md',
+        mode: '100644',
+      },
+      {
+        id: 'd8345753a1d935fa47a26317a503e73e1192d623',
+        name: 'test2.md',
+        type: 'blob',
+        path: 'content/test2.md',
+        mode: '100644',
+      },
+    ],
+    'many-entries': manyEntries.tree,
+  },
+  files: {
+    'content/test1.md': stripIndent`
+      ---
+      title: test
+      ---
+      # test
+    `,
+    'content/test2.md': stripIndent`
+      ---
+      title: test2
+      ---
+      # test 2
+    `,
+    ...manyEntries.files,
+  },
+};
+
+const resp = {
+  user: {
+    success: {
+      id: 1,
+    },
+  },
+  project: {
+    success: {
+      permissions: {
+        project_access: {
+          access_level: 30,
+        },
+      },
+    },
+    readOnly: {
+      permissions: {
+        project_access: {
+          access_level: 10,
+        },
+      },
+    },
+  },
+};
+
+describe('gitlab backend', () => {
+  let authStore;
+  const repo = 'foo/bar';
+  const defaultConfig = {
+    backend: {
+      name: 'gitlab',
+      repo,
+    },
+  };
+  const mockCredentials = { token: 'MOCK_TOKEN' };
+  const expectedRepo = encodeURIComponent(repo);
+  const expectedRepoUrl = `/projects/${expectedRepo}`;
+
+  function resolveBackend(config = {}) {
+    authStore = new LocalStorageAuthStore();
+    return new Backend(
+      {
+        init: (...args) => new Gitlab(...args),
+      },
+      {
+        backendName: 'gitlab',
+        config: fromJS(config),
+        authStore,
+      },
+    );
+  }
+
+  function mockApi(backend) {
+    return nock(backend.implementation.api_root);
+  }
+
+  function interceptAuth(backend, { userResponse, projectResponse } = {}) {
+    const api = mockApi(backend);
+    api
+      .get('/user')
+      .query(true)
+      .reply(200, userResponse || resp.user.success);
+
+    api
+      .get(expectedRepoUrl)
+      .query(true)
+      .reply(200, projectResponse || resp.project.success);
+  }
+
+  function parseQuery(uri) {
+    const query = uri.split('?')[1];
+    if (!query) {
+      return {};
+    }
+    return query.split('&').reduce((acc, q) => {
+      const [ key, value ] = q.split('=');
+      acc[key] = value;
+      return acc;
+    }, {});
+  }
+
+  function createHeaders(backend, { basePath, path, page, perPage, pageCount, totalCount }) {
+    const pageNum = parseInt(page, 10);
+    const pageCountNum = parseInt(pageCount, 10);
+    const url = `${backend.implementation.api_root}${basePath}`
+    const link = linkPage =>
+      `<${url}?id=${expectedRepo}&page=${linkPage}&path=${path}&per_page=${perPage}&recursive=false>`
+
+    const linkHeader = oneLine`
+      ${link(1)}; rel="first",
+      ${link(pageCount)}; rel="last",
+      ${pageNum === 1 ? '' : `${link(pageNum - 1)}; rel="prev",`}
+      ${pageNum === pageCountNum ? '' : `${link(pageNum + 1)}; rel="next",`}
+    `.slice(0, -1);
+
+    return {
+      'X-Page': page,
+      'X-Total-Pages': pageCount,
+      'X-Per-Page': perPage,
+      'X-Total': totalCount,
+      'Link': linkHeader,
+    };
+  }
+
+  function interceptCollection(backend, collection, { verb = 'get', page: expectedPage } = {}) {
+    const api = mockApi(backend);
+    const url = `${expectedRepoUrl}/repository/tree`;
+    const { folder } = collection;
+    const tree = mockRepo.tree[folder];
+    api[verb](url)
+      .query(({ path, page }) => {
+        if (path !== folder) {
+          return false;
+        }
+        if (expectedPage && parseInt(page, 10) !== parseInt(expectedPage, 10)) {
+          return false;
+        }
+        return true;
+      })
+      .reply(uri => {
+        const { page = 1, per_page = 20 } = parseQuery(uri);
+        const pageCount = tree.length <= per_page ? 1 : Math.round(tree.length / per_page);
+        const pageLastIndex = page * per_page;
+        const pageFirstIndex = pageLastIndex - per_page;
+        const resp = tree.slice(pageFirstIndex, pageLastIndex);
+        return [
+          200,
+          verb === 'head' ? null : resp,
+          createHeaders(backend, {
+            basePath: url,
+            path: folder,
+            page,
+            perPage: per_page,
+            pageCount,
+            totalCount: tree.length,
+          }),
+        ];
+      });
+  }
+
+  function interceptFiles(backend, path) {
+    const api = mockApi(backend);
+    const url = `${expectedRepoUrl}/repository/files/${encodeURIComponent(path)}/raw`;
+    api
+      .get(url)
+      .query(true)
+      .reply(200, mockRepo.files[path]);
+  }
+
+  it('throws if configuration requires editorial workflow', () => {
+    const resolveBackendWithWorkflow = partial(resolveBackend, {
+      ...defaultConfig,
+      publish_mode: 'editorial_workflow',
+    });
+    expect(resolveBackendWithWorkflow).toThrowErrorMatchingInlineSnapshot(
+      `"The GitLab backend does not support the Editorial Workflow."`,
+    );
+  });
+
+  it('throws if configuration does not include repo', () => {
+    expect(resolveBackend).toThrowErrorMatchingInlineSnapshot(
+      `"The GitLab backend needs a \\"repo\\" in the backend configuration."`,
+    );
+  });
+
+  describe('authComponent', () => {
+    it('returns authentication page component', () => {
+      const backend = resolveBackend(defaultConfig);
+      expect(backend.authComponent()).toEqual(AuthenticationPage);
+    });
+  });
+
+  describe('authenticate', () => {
+    it('throws if user does not have access to project', async () => {
+      const backend = resolveBackend(defaultConfig);
+      interceptAuth(backend, { projectResponse: resp.project.readOnly });
+      await expect(
+        backend.authenticate(mockCredentials),
+      ).rejects.toThrowErrorMatchingInlineSnapshot(
+        `"Your GitLab user account does not have access to this repo."`,
+      );
+    });
+
+    it('stores and returns user object on success', async () => {
+      const backendName = defaultConfig.backend.name;
+      const backend = resolveBackend(defaultConfig);
+      interceptAuth(backend);
+      const user = await backend.authenticate(mockCredentials);
+      expect(authStore.retrieve()).toEqual(user);
+      expect(user).toEqual({ ...resp.user.success, ...mockCredentials, backendName });
+    });
+  });
+
+  describe('currentUser', () => {
+    it('returns null if no user', async () => {
+      const backend = resolveBackend(defaultConfig);
+      const user = await backend.currentUser();
+      expect(user).toEqual(null);
+    });
+
+    it('returns the stored user if exists', async () => {
+      const backendName = defaultConfig.backend.name;
+      const backend = resolveBackend(defaultConfig);
+      interceptAuth(backend);
+      interceptAuth(backend);
+      await backend.authenticate(mockCredentials);
+      const user = await backend.currentUser();
+      expect(user).toEqual({ ...resp.user.success, ...mockCredentials, backendName });
+    });
+  });
+
+  describe('getToken', () => {
+    it('returns the token for the current user', async () => {
+      const backend = resolveBackend(defaultConfig);
+      interceptAuth(backend);
+      await backend.authenticate(mockCredentials);
+      const token = await backend.getToken();
+      expect(token).toEqual(mockCredentials.token);
+    });
+  });
+
+  describe('logout', () => {
+    it('sets token to null', async () => {
+      const backend = resolveBackend(defaultConfig);
+      interceptAuth(backend);
+      await backend.authenticate(mockCredentials);
+      await backend.logout();
+      const token = await backend.getToken();
+      expect(token).toEqual(null);
+    });
+  });
+
+  describe('listEntries', () => {
+    it('returns entries from folder collection', async () => {
+      const collectionConfig = {
+        name: 'foo',
+        folder: 'content',
+        fields: [{ name: 'title' }],
+        // TODO: folder_based_collection is an internal string, we should not
+        // be depending on it here
+        type: 'folder_based_collection',
+      };
+      const backend = resolveBackend(defaultConfig);
+
+      interceptAuth(backend);
+      await backend.authenticate(mockCredentials);
+
+      const tree = mockRepo.tree[collectionConfig.folder];
+      tree.forEach(file => interceptFiles(backend, file.path));
+
+      interceptCollection(backend, collectionConfig, { verb: 'head' });
+      interceptCollection(backend, collectionConfig);
+      const entries = await backend.listEntries(fromJS(collectionConfig));
+
+      expect(entries).toEqual({
+        cursor: expect.any(Cursor),
+        entries: expect.arrayContaining(
+          tree.map(file => expect.objectContaining({ path: file.path }))
+        ),
+      });
+      expect(entries.entries).toHaveLength(2);
+    });
+
+    it('returns entries from file collection', async () => {
+      const collectionConfig = {
+        name: 'foo',
+        files: [
+          {
+            label: 'foo',
+            name: 'foo',
+            file: 'content/test1.md',
+            fields: [{ name: 'title' }],
+          },
+          {
+            label: 'bar',
+            name: 'bar',
+            file: 'content/test2.md',
+            fields: [{ name: 'title' }],
+          },
+        ],
+        type: 'file_based_collection',
+      };
+      const { files } = collectionConfig;
+      const backend = resolveBackend(defaultConfig);
+      interceptAuth(backend);
+      await backend.authenticate(mockCredentials);
+      files.forEach(file => interceptFiles(backend, file.file));
+      const entries = await backend.listEntries(fromJS(collectionConfig));
+      expect(entries).toEqual({
+        cursor: expect.any(Cursor),
+        entries: expect.arrayContaining(
+          files.map(file => expect.objectContaining({ path: file.file }))
+        ),
+      });
+      expect(entries.entries).toHaveLength(2);
+    });
+
+    it('returns last page from paginated folder collection tree', async () => {
+      const collectionConfig = {
+        name: 'foo',
+        folder: 'many-entries',
+        fields: [{ name: 'title' }],
+        // TODO: folder_based_collection is an internal string, we should not
+        // be depending on it here
+        type: 'folder_based_collection',
+      };
+      const tree = mockRepo.tree[collectionConfig.folder];
+      const backend = resolveBackend(defaultConfig);
+      interceptAuth(backend);
+      await backend.authenticate(mockCredentials);
+
+      const pageTree = tree.slice(-20);
+      pageTree.forEach(file => interceptFiles(backend, file.path));
+      interceptCollection(backend, collectionConfig, { verb: 'head' });
+      interceptCollection(backend, collectionConfig, { page: 25 });
+      const entries = await backend.listEntries(fromJS(collectionConfig));
+      expect(entries.entries).toEqual(expect.arrayContaining(
+        pageTree.map(file => expect.objectContaining({ path: file.path }))
+      ));
+      expect(entries.entries).toHaveLength(20);
+    });
+  });
+
+  describe('traverseCursor', () => {
+    const collectionConfig = {
+      name: 'foo',
+      folder: 'many-entries',
+      fields: [{ name: 'title' }],
+      // TODO: folder_based_collection is an internal string, we should not
+      // be depending on it here
+      type: 'folder_based_collection',
+    };
+    const tree = mockRepo.tree[collectionConfig.folder];
+    let backend;
+
+    beforeEach(async () => {
+      backend = resolveBackend(defaultConfig);
+      interceptAuth(backend);
+      await backend.authenticate(mockCredentials);
+      interceptCollection(backend, collectionConfig, { verb: 'head' });
+    });
+
+    it('returns complete last page of paginated tree', async () => {
+      tree.slice(-20).forEach(file => interceptFiles(backend, file.path));
+      interceptCollection(backend, collectionConfig, { page: 25 });
+      const entries = await backend.listEntries(fromJS(collectionConfig));
+
+      const nextPageTree = tree.slice(-40, -20);
+      nextPageTree.forEach(file => interceptFiles(backend, file.path));
+      interceptCollection(backend, collectionConfig, { page: 24 });
+      const nextPage = await backend.traverseCursor(entries.cursor, 'next');
+      expect(nextPage.entries).toEqual(expect.arrayContaining(
+        nextPageTree.map(file => expect.objectContaining({ path: file.path }))
+      ));
+      expect(nextPage.entries).toHaveLength(20);
+
+      const prevPageTree = tree.slice(-20);
+      interceptCollection(backend, collectionConfig, { page: 25 });
+      const prevPage = await backend.traverseCursor(nextPage.cursor, 'prev');
+      expect(prevPage.entries).toEqual(expect.arrayContaining(
+        prevPageTree.map(file => expect.objectContaining({ path: file.path }))
+      ));
+      expect(prevPage.entries).toHaveLength(20);
+    });
+  });
+
+  afterEach(() => {
+    nock.cleanAll();
+    authStore.logout();
+    expect(authStore.retrieve()).toEqual(null);
+  });
+});

--- a/packages/netlify-cms-backend-gitlab/src/__tests__/gitlab.spec.js
+++ b/packages/netlify-cms-backend-gitlab/src/__tests__/gitlab.spec.js
@@ -25,17 +25,20 @@ const generateEntries = (path, length) => {
       path: filePath,
       mode: '100644',
     })),
-    files: entries.reduce((acc, { id, filePath }) => ({
-      ...acc,
-      [filePath]: stripIndent`
+    files: entries.reduce(
+      (acc, { id, filePath }) => ({
+        ...acc,
+        [filePath]: stripIndent`
         ---
         title: test ${id}
         ---
         # test ${id}
       `,
-    }), {}),
+      }),
+      {},
+    ),
   };
-}
+};
 
 const manyEntries = generateEntries('many-entries', 500);
 
@@ -159,7 +162,7 @@ describe('gitlab backend', () => {
       return {};
     }
     return query.split('&').reduce((acc, q) => {
-      const [ key, value ] = q.split('=');
+      const [key, value] = q.split('=');
       acc[key] = value;
       return acc;
     }, {});
@@ -168,9 +171,9 @@ describe('gitlab backend', () => {
   function createHeaders(backend, { basePath, path, page, perPage, pageCount, totalCount }) {
     const pageNum = parseInt(page, 10);
     const pageCountNum = parseInt(pageCount, 10);
-    const url = `${backend.implementation.api_root}${basePath}`
+    const url = `${backend.implementation.api_root}${basePath}`;
     const link = linkPage =>
-      `<${url}?id=${expectedRepo}&page=${linkPage}&path=${path}&per_page=${perPage}&recursive=false>`
+      `<${url}?id=${expectedRepo}&page=${linkPage}&path=${path}&per_page=${perPage}&recursive=false>`;
 
     const linkHeader = oneLine`
       ${link(1)}; rel="first",
@@ -184,7 +187,7 @@ describe('gitlab backend', () => {
       'X-Total-Pages': pageCount,
       'X-Per-Page': perPage,
       'X-Total': totalCount,
-      'Link': linkHeader,
+      Link: linkHeader,
     };
   }
 
@@ -341,7 +344,7 @@ describe('gitlab backend', () => {
       expect(entries).toEqual({
         cursor: expect.any(Cursor),
         entries: expect.arrayContaining(
-          tree.map(file => expect.objectContaining({ path: file.path }))
+          tree.map(file => expect.objectContaining({ path: file.path })),
         ),
       });
       expect(entries.entries).toHaveLength(2);
@@ -375,7 +378,7 @@ describe('gitlab backend', () => {
       expect(entries).toEqual({
         cursor: expect.any(Cursor),
         entries: expect.arrayContaining(
-          files.map(file => expect.objectContaining({ path: file.file }))
+          files.map(file => expect.objectContaining({ path: file.file })),
         ),
       });
       expect(entries.entries).toHaveLength(2);
@@ -400,9 +403,9 @@ describe('gitlab backend', () => {
       interceptCollection(backend, collectionConfig, { verb: 'head' });
       interceptCollection(backend, collectionConfig, { page: 25 });
       const entries = await backend.listEntries(fromJS(collectionConfig));
-      expect(entries.entries).toEqual(expect.arrayContaining(
-        pageTree.map(file => expect.objectContaining({ path: file.path }))
-      ));
+      expect(entries.entries).toEqual(
+        expect.arrayContaining(pageTree.map(file => expect.objectContaining({ path: file.path }))),
+      );
       expect(entries.entries).toHaveLength(20);
     });
   });
@@ -435,17 +438,21 @@ describe('gitlab backend', () => {
       nextPageTree.forEach(file => interceptFiles(backend, file.path));
       interceptCollection(backend, collectionConfig, { page: 24 });
       const nextPage = await backend.traverseCursor(entries.cursor, 'next');
-      expect(nextPage.entries).toEqual(expect.arrayContaining(
-        nextPageTree.map(file => expect.objectContaining({ path: file.path }))
-      ));
+      expect(nextPage.entries).toEqual(
+        expect.arrayContaining(
+          nextPageTree.map(file => expect.objectContaining({ path: file.path })),
+        ),
+      );
       expect(nextPage.entries).toHaveLength(20);
 
       const prevPageTree = tree.slice(-20);
       interceptCollection(backend, collectionConfig, { page: 25 });
       const prevPage = await backend.traverseCursor(nextPage.cursor, 'prev');
-      expect(prevPage.entries).toEqual(expect.arrayContaining(
-        prevPageTree.map(file => expect.objectContaining({ path: file.path }))
-      ));
+      expect(prevPage.entries).toEqual(
+        expect.arrayContaining(
+          prevPageTree.map(file => expect.objectContaining({ path: file.path })),
+        ),
+      );
       expect(prevPage.entries).toHaveLength(20);
     });
   });

--- a/packages/netlify-cms-core/src/backend.js
+++ b/packages/netlify-cms-core/src/backend.js
@@ -32,7 +32,7 @@ import {
   dateParsers,
 } from 'Lib/stringTemplate';
 
-class LocalStorageAuthStore {
+export class LocalStorageAuthStore {
   storageKey = 'netlify-cms-user';
 
   retrieve() {
@@ -200,7 +200,7 @@ function createPreviewUrl(baseUrl, collection, slug, slugConfig, entry) {
   return `${basePath}/${previewPath}`;
 }
 
-class Backend {
+export class Backend {
   constructor(implementation, { backendName, authStore = null, config } = {}) {
     // We can't reliably run this on exit, so we do cleanup on load.
     this.deleteAnonymousBackup();
@@ -218,6 +218,7 @@ class Backend {
   }
 
   currentUser() {
+    // TODO: investigate, `this.user` doesn't look like it is ever true.
     if (this.user) {
       return this.user;
     }

--- a/setupTestFramework.js
+++ b/setupTestFramework.js
@@ -1,5 +1,7 @@
 /* eslint-disable emotion/no-vanilla */
+import fetch from 'node-fetch';
 import * as emotion from 'emotion';
 import { createSerializer } from 'jest-emotion';
 
+window.fetch = fetch;
 expect.addSnapshotSerializer(createSerializer(emotion));

--- a/yarn.lock
+++ b/yarn.lock
@@ -2520,6 +2520,11 @@ assert@^1.1.1:
     object-assign "^4.1.1"
     util "0.10.3"
 
+assertion-error@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/assertion-error/-/assertion-error-1.1.0.tgz#e60b6b0e8f301bd97e5375215bda406c85118c0b"
+  integrity sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==
+
 assign-symbols@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/assign-symbols/-/assign-symbols-1.0.0.tgz#59667f41fadd4f20ccbc2bb96b8d4f7f78ec0367"
@@ -3288,6 +3293,18 @@ ccount@^1.0.0:
   resolved "https://registry.yarnpkg.com/ccount/-/ccount-1.0.4.tgz#9cf2de494ca84060a2a8d2854edd6dfb0445f386"
   integrity sha512-fpZ81yYfzentuieinmGnphk0pLkOTMm6MZdVqwd77ROvhko6iujLNGrHH5E7utq3ygWklwfmwuG+A7P+NpqT6w==
 
+chai@^4.1.2:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/chai/-/chai-4.2.0.tgz#760aa72cf20e3795e84b12877ce0e83737aa29e5"
+  integrity sha512-XQU3bhBukrOsQCuwZndwGcCVQHyZi53fQ6Ys1Fym7E4olpIqqZZhhoFJoaKVvV17lWQoXYwgWN2nF5crA8J2jw==
+  dependencies:
+    assertion-error "^1.1.0"
+    check-error "^1.0.2"
+    deep-eql "^3.0.1"
+    get-func-name "^2.0.0"
+    pathval "^1.1.0"
+    type-detect "^4.0.5"
+
 chain-function@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/chain-function/-/chain-function-1.0.1.tgz#c63045e5b4b663fb86f1c6e186adaf1de402a1cc"
@@ -3337,6 +3354,11 @@ chardet@^0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.7.0.tgz#90094849f0937f2eedc2425d0d28a9e5f0cbad9e"
   integrity sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==
+
+check-error@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/check-error/-/check-error-1.0.2.tgz#574d312edd88bb5dd8912e9286dd6c0aed4aac82"
+  integrity sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=
 
 check-more-types@2.24.0:
   version "2.24.0"
@@ -4218,7 +4240,14 @@ dedent@^0.7.0:
   resolved "https://registry.yarnpkg.com/dedent/-/dedent-0.7.0.tgz#2495ddbaf6eb874abb0e1be9df22d2e5a544326c"
   integrity sha1-JJXduvbrh0q7Dhvp3yLS5aVEMmw=
 
-deep-equal@^1.0.1:
+deep-eql@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/deep-eql/-/deep-eql-3.0.1.tgz#dfc9404400ad1c8fe023e7da1df1c147c4b444df"
+  integrity sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==
+  dependencies:
+    type-detect "^4.0.0"
+
+deep-equal@^1.0.0, deep-equal@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/deep-equal/-/deep-equal-1.0.1.tgz#f5d260292b660e084eff4cdbc9f08ad3247448b5"
   integrity sha1-9dJgKStmDghO/0zbyfCK0yR0SLU=
@@ -5643,6 +5672,11 @@ get-document@1:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/get-document/-/get-document-1.0.0.tgz#4821bce66f1c24cb0331602be6cb6b12c4f01c4b"
   integrity sha1-SCG85m8cJMsDMWAr5strEsTwHEs=
+
+get-func-name@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/get-func-name/-/get-func-name-2.0.0.tgz#ead774abee72e20409433a066366023dd6887a41"
+  integrity sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=
 
 get-pkg-repo@^1.0.0:
   version "1.4.0"
@@ -8528,6 +8562,21 @@ nice-try@^1.0.4:
   resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"
   integrity sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==
 
+nock@^10.0.4:
+  version "10.0.6"
+  resolved "https://registry.yarnpkg.com/nock/-/nock-10.0.6.tgz#e6d90ee7a68b8cfc2ab7f6127e7d99aa7d13d111"
+  integrity sha512-b47OWj1qf/LqSQYnmokNWM8D88KvUl2y7jT0567NB3ZBAZFz2bWp2PC81Xn7u8F2/vJxzkzNZybnemeFa7AZ2w==
+  dependencies:
+    chai "^4.1.2"
+    debug "^4.1.0"
+    deep-equal "^1.0.0"
+    json-stringify-safe "^5.0.1"
+    lodash "^4.17.5"
+    mkdirp "^0.5.0"
+    propagate "^1.0.0"
+    qs "^6.5.1"
+    semver "^5.5.0"
+
 node-addon-api@^1.6.0:
   version "1.6.3"
   resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-1.6.3.tgz#3998d4593e2dca2ea82114670a4eb003386a9fe1"
@@ -9358,6 +9407,11 @@ path-type@^3.0.0:
   dependencies:
     pify "^3.0.0"
 
+pathval@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/pathval/-/pathval-1.1.0.tgz#b942e6d4bde653005ef6b71361def8727d0645e0"
+  integrity sha1-uULm1L3mUwBe9rcTYd74cn0GReA=
+
 pause-stream@0.0.11:
   version "0.0.11"
   resolved "https://registry.yarnpkg.com/pause-stream/-/pause-stream-0.0.11.tgz#fe5a34b0cbce12b5aa6a2b403ee2e73b602f1445"
@@ -9712,6 +9766,11 @@ prop-types@^15.0.0, prop-types@^15.5.10, prop-types@^15.5.4, prop-types@^15.5.6,
     object-assign "^4.1.1"
     react-is "^16.8.1"
 
+propagate@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/propagate/-/propagate-1.0.0.tgz#00c2daeedda20e87e3782b344adba1cddd6ad709"
+  integrity sha1-AMLa7t2iDofjeCs0Stuhzd1q1wk=
+
 property-information@^3.0.0, property-information@^3.1.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/property-information/-/property-information-3.2.0.tgz#fd1483c8fbac61808f5fe359e7693a1f48a58331"
@@ -9826,7 +9885,7 @@ q@^1.1.2, q@^1.5.1:
   resolved "https://registry.yarnpkg.com/q/-/q-1.5.1.tgz#7e32f75b41381291d04611f1bf14109ac00651d7"
   integrity sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc=
 
-qs@6.7.0:
+qs@6.7.0, qs@^6.5.1:
   version "6.7.0"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.7.0.tgz#41dc1a015e3d581f1621776be31afb2876a9b1bc"
   integrity sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ==
@@ -12259,6 +12318,11 @@ type-check@~0.3.2:
   integrity sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=
   dependencies:
     prelude-ls "~1.1.2"
+
+type-detect@^4.0.0, type-detect@^4.0.5:
+  version "4.0.8"
+  resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-4.0.8.tgz#7646fb5f18871cfbb7749e69bd39a6388eb7450c"
+  integrity sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==
 
 type-fest@^0.4.1:
   version "0.4.1"


### PR DESCRIPTION
Replaces #1817 (abandoned).

The code in this PR was authored by a community contributor, with the intent to add editorial workflow support for the GitLab backend.

This PR needs proper testing both in code and in practice to ensure against regressions. It's also highly likely that more work needs to be done in general, but again, that's difficult to ascertain without testing.

Rebased onto latest master as of 6/26/19, which provides _some_ regression tests.