### PR TITLE
fix(core): load more entries until viewport is filled

### DIFF
--- a/packages/netlify-cms-core/src/components/Collection/Entries/EntryListing.js
+++ b/packages/netlify-cms-core/src/components/Collection/Entries/EntryListing.js
@@ -25,10 +25,13 @@ export default class EntryListing extends React.Component {
     handleCursorActions: PropTypes.func.isRequired,
   };
 
+  hasMore = () => {
+    return Cursor.create(this.props.cursor).actions.has('append_next');
+  };
+
   handleLoadMore = () => {
-    const { cursor, handleCursorActions } = this.props;
-    if (Cursor.create(cursor).actions.has('append_next')) {
-      handleCursorActions('append_next');
+    if (this.hasMore()) {
+      this.props.handleCursorActions('append_next');
     }
   };
 
@@ -71,7 +74,7 @@ export default class EntryListing extends React.Component {
           {Map.isMap(collections)
             ? this.renderCardsForSingleCollection()
             : this.renderCardsForMultipleCollections()}
-          <Waypoint onEnter={this.handleLoadMore} />
+          {this.hasMore() && <Waypoint onEnter={this.handleLoadMore} />}
         </CardsGrid>
       </div>
     );


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines.

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first two fields are mandatory:
-->

**Summary**

<!--
Explain the **motivation** for making this change.
What existing problem does the pull request solve?
-->

Fixes #2414.

The invisible Waypoint that loads more entries for paginated backends like GitLab was always rendered, so when the backend asynchronously updates state to show that there are more entries to load, the Waypoint was already visible, so the new entries don't load.

This PR hides removes the Waypoint component if there are no entries, and renders it if there are entries, ensuring that a half (or entirely) empty screen won't occur.


