### PR TITLE
create new repo via git API

### DIFF
--- a/website/content/docs/gatsby.md
+++ b/website/content/docs/gatsby.md
@@ -96,6 +96,7 @@ It's now time to commit your changes and push to GitHub. The Gatsby starter init
 ```bash
 git add .
 git commit -m "Initial Commit"
+curl -u 'YOUR_USERNAME' https://api.github.com/user/repos -d '{"name":"NEW_REPO_NAME""}'
 git remote add origin https://github.com/YOUR_USERNAME/NEW_REPO_NAME.git
 git push -u origin master
 ```


### PR DESCRIPTION
without the API call, git will return an error. 
```shell
 git push -u origin master
fatal: 'origin' does not appear to be a git repository
```
cannot create a new repo with CLI:

https://stackoverflow.com/questions/2423777/is-it-possible-to-create-a-remote-repo-on-github-from-the-cli-without-opening-br

fwiw, I used git protocol instead of https after creating the repo.

` git remote add origin git@github.com:YOUR_USERNAME/NEW_REPO.git`

<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines.

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first two fields are mandatory:
-->

**Summary**

<!--
Explain the **motivation** for making this change.
What existing problem does the pull request solve?
-->

**Test plan**

<!--
Demonstrate the code is solid.
Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.
-->

**A picture of a cute animal (not mandatory but encouraged)**
