### PR TITLE
👌 IMPROVE: Cloudinary Login Info

### DIFF
--- a/website/content/docs/cloudinary.md
+++ b/website/content/docs/cloudinary.md
@@ -25,7 +25,7 @@ media_library:
     api_key: your_api_key
 ```
 
-> ⚠️ Make sure you are logged in to the same Cloudinary account with the `your_cloud_name` you specified above otherwise the login will just fail. 
+**Note:** The user must be logged in to the Cloudinary account connected to the `api_key` used in your Netlify CMS configuration. 
 
 ## Netlify CMS configuration options
 

--- a/website/content/docs/cloudinary.md
+++ b/website/content/docs/cloudinary.md
@@ -25,6 +25,8 @@ media_library:
     api_key: your_api_key
 ```
 
+> ⚠️ Make sure you are logged in to the same Cloudinary account with the `your_cloud_name` you specified above otherwise the login will just fail. 
+
 ## Netlify CMS configuration options
 
 The following options are specific to the Netlify CMS integration for Cloudinary:


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines.

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first two fields are mandatory:
-->

**Summary**

Spent an hour figuring out why I was unable to login and the request was just failing with `401` account. Didn't realize I was logged in with my personal Cloudinary account instead of the companies account.

**Test plan**

Just a document update.

![](https://on.ahmda.ws/b302ca/c)

The failed image looked like

![](https://on.ahmda.ws/e57cec/c)

After I logged in to Cloudinary with the right account.
![](https://on.ahmda.ws/cf54e2/c)


⚠️ Sadly, the INSERT button still doesn't work, does nothing.



