### PR TITLE
Add info about using the getWidget method

### DIFF
--- a/website/content/docs/custom-widgets.md
+++ b/website/content/docs/custom-widgets.md
@@ -71,6 +71,23 @@ var CategoriesPreview = createClass({
 CMS.registerWidget('categories', CategoriesControl, CategoriesPreview);
 </script>
 ```
+### Using pre-existing widgets within a Custom Widget
+
+You can create a pre-existing widget by using the `CMS.getWidget(widget)` method.
+
+**Example:**
+
+```jsx
+const SlideControl = props => {
+  const MarkdownControl = CMS.getWidget("markdown").control;
+  return (
+    <div>
+      <SlideControlHeader>Slide</SlideControlHeader>
+      <MarkdownControl {...props} />
+    </div>
+  );
+};
+```
 
 ## `registerEditorComponent`
 


### PR DESCRIPTION
**Summary**

The documentation doesn't mention the `getWidget` method at all. It only shows up in a blog post about custom widgets located on the Netlify website. I thought it was important to provide this information as its useful to know that you can use pre-existing widgets within a custom widget.