### PR TITLE
Type specification of valueField

### DIFF
--- a/website/content/docs/widgets/relation.md
+++ b/website/content/docs/widgets/relation.md
@@ -13,7 +13,7 @@ The relation widget allows you to reference items from another collection. It pr
   - `collection`: (**required**) name of the collection being referenced (string)
   - `displayFields`: list of one or more names of fields in the referenced collection that will render in the autocomplete menu of the control. Defaults to `valueField`. For nested fields, separate each subfield with a `.` (E.g. `name.first`).
   - `searchFields`: (**required**) list of one or more names of fields in the referenced collection to search for the typed value. Syntax to reference nested fields is similar to that of *displayFields*.
-  - `valueField`: (**required**) name of the field from the referenced collection whose value will be stored for the relation. Syntax to reference nested fields is similar to that of *displayFields* and *searchFields*.
+  - `valueField`: (**required**) name of the field from the referenced collection whose value will be stored for the relation. Syntax to reference nested fields is similar to that of *displayFields* and *searchFields*. As `valueField` only allows for a single field, this parameter only accepts string.
   - `multiple` : accepts a boolean, defaults to `false`
 - **Example** (assuming a separate "authors" collection with "name" and "twitterHandle" fields with subfields "first" and "last" for the "name" field):
     ```yaml

--- a/website/content/docs/widgets/relation.md
+++ b/website/content/docs/widgets/relation.md
@@ -13,7 +13,7 @@ The relation widget allows you to reference items from another collection. It pr
   - `collection`: (**required**) name of the collection being referenced (string)
   - `displayFields`: list of one or more names of fields in the referenced collection that will render in the autocomplete menu of the control. Defaults to `valueField`. For nested fields, separate each subfield with a `.` (E.g. `name.first`).
   - `searchFields`: (**required**) list of one or more names of fields in the referenced collection to search for the typed value. Syntax to reference nested fields is similar to that of *displayFields*.
-  - `valueField`: (**required**) name of the field from the referenced collection whose value will be stored for the relation. Syntax to reference nested fields is similar to that of *displayFields* and *searchFields*. As `valueField` only allows for a single field, this parameter only accepts string.
+  - `valueField`: (**required**) name of the field from the referenced collection whose value will be stored for the relation. Syntax to reference nested fields is similar to that of *displayFields* and *searchFields*. As `valueField` only allows for a single field, this parameter only accepts a string.
   - `multiple` : accepts a boolean, defaults to `false`
 - **Example** (assuming a separate "authors" collection with "name" and "twitterHandle" fields with subfields "first" and "last" for the "name" field):
     ```yaml


### PR DESCRIPTION
Added a sentence on type specification of valueField option parameter.

**Summary**

This is related to an issue thread "Using array in valueField of relation widget causes TypeError #2445".

The purpose of this request is to give a guide to people referring to the doc so that they will not see the TypeError.

If you use array type for the valueField in the "relation" widget of collection, it shows an error screen when you access to the collection record in the admin dashboard.

To avoid this problem, String type of value needs to be set to the `valueField` option parameter.

The added sentence to the doc explicitly states so.

**Test plan**

Proofreading.