### PR TITLE
Bugfix: map widget doesn't work when in list field

### DIFF
--- a/dev-test/config.yml
+++ b/dev-test/config.yml
@@ -83,6 +83,9 @@ collections: # A list of collections the CMS should be able to edit
             fields:
               - { label: 'Name', name: 'name', widget: 'string', hint: 'First and Last' }
               - { label: 'Description', name: 'description', widget: 'markdown' }
+              - label: location
+                name: location
+                widget: map
 
   - name: 'kitchenSink' # all the things in one entry, for documentation and quick testing
     label: 'Kitchen Sink'

--- a/packages/netlify-cms-core/src/components/Editor/EditorControlPane/EditorControl.js
+++ b/packages/netlify-cms-core/src/components/Editor/EditorControlPane/EditorControl.js
@@ -155,6 +155,7 @@ class EditorControl extends React.Component {
     clearFieldErrors: PropTypes.func.isRequired,
     loadEntry: PropTypes.func.isRequired,
     t: PropTypes.func.isRequired,
+    parentCollapsed: PropTypes.bool,
   };
 
   state = {
@@ -187,6 +188,7 @@ class EditorControl extends React.Component {
       clearFieldErrors,
       loadEntry,
       t,
+      parentCollapsed,
     } = this.props;
     const widgetName = field.get('widget');
     const widget = resolveWidget(widgetName);
@@ -290,6 +292,7 @@ class EditorControl extends React.Component {
               fieldsErrors={fieldsErrors}
               onValidateObject={onValidateObject}
               t={t}
+              parentCollapsed={parentCollapsed}
             />
             {fieldHint && (
               <ControlHint active={this.state.styleActive} error={!!errors}>

--- a/packages/netlify-cms-core/src/components/Editor/EditorControlPane/Widget.js
+++ b/packages/netlify-cms-core/src/components/Editor/EditorControlPane/Widget.js
@@ -54,6 +54,7 @@ export default class Widget extends Component {
     uniqueFieldId: PropTypes.string.isRequired,
     loadEntry: PropTypes.func.isRequired,
     t: PropTypes.func.isRequired,
+    parentCollapsed: PropTypes.bool,
   };
 
   shouldComponentUpdate(nextProps) {
@@ -236,6 +237,7 @@ export default class Widget extends Component {
       fieldsErrors,
       controlRef,
       t,
+      parentCollapsed,
     } = this.props;
     return React.createElement(controlComponent, {
       field,
@@ -273,6 +275,7 @@ export default class Widget extends Component {
       fieldsErrors,
       controlRef,
       t,
+      parentCollapsed,
     });
   }
 }

--- a/packages/netlify-cms-widget-list/src/ListControl.js
+++ b/packages/netlify-cms-widget-list/src/ListControl.js
@@ -381,6 +381,7 @@ export default class ListControl extends React.Component {
               fieldsErrors={fieldsErrors}
               ref={this.processControlRef}
               controlRef={controlRef}
+              parentCollapsed={collapsed}
             />
           )}
         </ClassNames>

--- a/packages/netlify-cms-widget-object/src/ObjectControl.js
+++ b/packages/netlify-cms-widget-object/src/ObjectControl.js
@@ -33,6 +33,7 @@ export default class ObjectControl extends React.Component {
     resolveWidget: PropTypes.func.isRequired,
     clearFieldErrors: PropTypes.func.isRequired,
     fieldsErrors: ImmutablePropTypes.map.isRequired,
+    parentCollapsed: PropTypes.bool,
   };
 
   static defaultProps = {
@@ -42,7 +43,7 @@ export default class ObjectControl extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
-      collapsed: false,
+      collapsed: false
     };
   }
 
@@ -76,6 +77,7 @@ export default class ObjectControl extends React.Component {
       fieldsErrors,
       editorControl: EditorControl,
       controlRef,
+      parentCollapsed,
     } = this.props;
 
     if (field.get('widget') === 'hidden') {
@@ -96,6 +98,7 @@ export default class ObjectControl extends React.Component {
         onValidate={onValidateObject}
         processControlRef={controlRef && controlRef.bind(this)}
         controlRef={controlRef}
+        parentCollapsed={parentCollapsed}
       />
     );
   }


### PR DESCRIPTION
**Summary**
Working with netlify-cms to create a list of Points of Interest, each with a Map field, I found that when a map widget is instantiated into a folded list field child (ie. an extant POI in a list of POIs), the OpenLayers Map does not render correctly. The map works as expected when a new list field child is created and the map widget is visible on screen when the OpenLayers Map object is instantiated.

I believe there are actually two issues, one I understand, and one I don't.

When a Map field is rendered into a folded list child:
- OpenLayers is not able to determine a height with which to instantiate the map. To solve this, we can tell the OpenLayers Map to .updateSize() when the map becomes visible. This I understand fairly well, and the bulk of this PR is to address this.
- The Map container has height 0. Not sure why this is happening, but to mitigate this, I set a style on the container defining a height of 500px. A bit brittle, but workable. Note that this change, alone, does not address the initial observed issue.

Looking forward to any feedback or questions!

I am not sure if a bug report exists for this issue.

**Test plan**
Let me know if you'd like more comprehensive testing.

Pre:
![image](https://media.giphy.com/media/dWwg07VkLxL7g5uuxN/giphy.gif)

Post:
![image](https://media.giphy.com/media/XyCPI1CM9lN1C9dj54/giphy.gif)


----

And here is a picture of a map with many animals:
![image](https://user-images.githubusercontent.com/15184/61680555-d7745580-acbe-11e9-9b27-1a8c685b182a.png)





