### PR TITLE
Fix link to style guide

### DIFF
--- a/website/content/docs/contributor-guide.md
+++ b/website/content/docs/contributor-guide.md
@@ -15,7 +15,7 @@ The documentation for Netlify CMS is written in [Markdown](http://daringfireball
 The GitHub website allows you to submit issues, work with files, search for content, and browse changes that have been submitted in the past and those that are being submitted now (aka Pull Requests). 
 
 ## Style guidelines
-A [style guide](/website/content/docs/style-guide.md) is available to help provide context around grammar, code styling, syntax, etc. 
+A [style guide](/docs/writing-style-guide/) is available to help provide context around grammar, code styling, syntax, etc. 
 
 ## Filing issues
 If you have a GitHub account, you can file an [issue](https://github.com/netlify/netlify-cms/issues) (aka bug report) against the Netlify CMS docs. Even if you're not able to, or don't know how to, fix the issue (see [Improve existing content](#improve-existing-content)), it helps to start the conversation. 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines.

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first two fields are mandatory:
-->

**Summary**
In the [Contributor Guide](https://www.netlifycms.org/docs/contributor-guide/) for the Netlify CMS docs, the link to the style guide is broken.

**Test plan**

Build the site and ensure that the link on the page works.

**A picture of a cute animal (not mandatory but encouraged)**
![greyhound](https://user-images.githubusercontent.com/1299370/62646651-c5302380-b91c-11e9-8352-2b2dfdb9da7d.jpg)

_[Photo by Sebastian Yepes](https://unsplash.com/photos/NnRYWprcWkE)_