### PR TITLE
Fix #1424: Set value for boolean field without default value

### DIFF
--- a/packages/netlify-cms-core/src/actions/entries.js
+++ b/packages/netlify-cms-core/src/actions/entries.js
@@ -427,6 +427,7 @@ export function createEmptyDraftData(fields, withNameKey = true) {
   return fields.reduce((acc, item) => {
     const subfields = item.get('field') || item.get('fields');
     const list = item.get('widget') == 'list';
+    const boolean = item.get('widget') == 'boolean';
     const name = item.get('name');
     const defaultValue = item.get('default', null);
     const isEmptyDefaultValue = val => [[{}], {}].some(e => isEqual(val, e));
@@ -448,6 +449,14 @@ export function createEmptyDraftData(fields, withNameKey = true) {
       if (!isEmptyDefaultValue(subDefaultValue)) {
         acc[name] = subDefaultValue;
       }
+      return acc;
+    }
+
+    // A boolean field without a default value defined will initially render
+    // render as false, but the field will fail the required check. So we are
+    // assinging false.
+    if (boolean && defaultValue === null) {
+      acc[name] = false;
       return acc;
     }
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines.

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first two fields are mandatory:
-->

**Summary**
 This fixes a validation issue for boolean fields without any default value for new posts.

<!--
Explain the **motivation** for making this change.
What existing problem does the pull request solve?
-->

**Test plan**
> 1. Define a field like this in config.yml:
> 
> ```yaml
> -
>   label: Awesome
>   name: awesome
>   widget: boolean
> ```
> 
> 1. Create a new item in the collection
> 2. Try to publish the item
> 
> You'll get an "AWESOME IS REQUIRED" error.
> 
> For the record, specifying `default: false` for the field makes the problem disappear.



<!--
Demonstrate the code is solid.
Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.
-->

**A picture of a cute animal (not mandatory but encouraged)**
![WhatsApp Image 2019-06-26 at 16 05 13](https://user-images.githubusercontent.com/731161/62736467-b4bb9e00-ba2d-11e9-8d08-e69bd6ea9247.jpeg)
