### PR TITLE
Update toml library from toml-j0.4 to @iarna/toml@2.2.3

### DIFF
--- a/packages/netlify-cms-core/package.json
+++ b/packages/netlify-cms-core/package.json
@@ -59,7 +59,7 @@
     "redux-thunk": "^2.3.0",
     "sanitize-filename": "^1.6.1",
     "semaphore": "^1.0.5",
-    "toml-j0.4": "^1.1.1",
+    "@iarna/toml": "2.2.3",
     "tomlify-j0.4": "^3.0.0-alpha.0",
     "url": "^0.11.0",
     "what-input": "^5.1.4"

--- a/packages/netlify-cms-core/src/formats/__tests__/frontmatter.spec.js
+++ b/packages/netlify-cms-core/src/formats/__tests__/frontmatter.spec.js
@@ -83,6 +83,16 @@ describe('Frontmatter', () => {
     });
   });
 
+  it('should parse TOML with 0.5 style dates', () => {
+    expect(
+      FrontmatterInfer.fromFile('+++\ntitle = "TOML"\ndate = 2018-12-24\n+++\nContent'),
+    ).toEqual({
+      title: 'TOML',
+      date: new Date('2018-12-24T00:00:00.000Z'),
+      body: 'Content',
+    });
+  });
+
   it('should parse TOML with +++ delimiters when it is explicitly set as the format without a custom delimiter', () => {
     expect(
       frontmatterTOML('~~~').fromFile(

--- a/packages/netlify-cms-core/src/formats/toml.js
+++ b/packages/netlify-cms-core/src/formats/toml.js
@@ -1,4 +1,4 @@
-import toml from 'toml-j0.4';
+import toml from '@iarna/toml';
 import tomlify from 'tomlify-j0.4';
 import moment from 'moment';
 import AssetProxy from 'ValueObjects/AssetProxy';

--- a/yarn.lock
+++ b/yarn.lock
@@ -981,6 +981,11 @@
     unique-filename "^1.1.1"
     which "^1.3.1"
 
+"@iarna/toml@2.2.3":
+  version "2.2.3"
+  resolved "https://registry.yarnpkg.com/@iarna/toml/-/toml-2.2.3.tgz#f060bf6eaafae4d56a7dac618980838b0696e2ab"
+  integrity sha512-FmuxfCuolpLl0AnQ2NHSzoUKWEJDFl63qXjzdoWBVyFCXzMGm1spBzk7LeHNoVCiWCF7mRVms9e6jEV9+MoPbg==
+
 "@jest/console@^24.7.1":
   version "24.7.1"
   resolved "https://registry.yarnpkg.com/@jest/console/-/console-24.7.1.tgz#32a9e42535a97aedfe037e725bd67e954b459545"
@@ -12187,11 +12192,6 @@ toidentifier@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/toidentifier/-/toidentifier-1.0.0.tgz#7e1be3470f1e77948bc43d94a3c8f4d7752ba553"
   integrity sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw==
-
-toml-j0.4@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/toml-j0.4/-/toml-j0.4-1.1.1.tgz#eb0c70348609a0263bb1d6e4a3dd191dcca60866"
-  integrity sha512-lYK5otg0+cto8YmsWcPEfeiTiC/VU6P6HA6ooaYI9K/KYT24Jg0BrYtRZK1K3cwakSMyh6nttfJL9RmQH0gyCg==
 
 tomlify-j0.4@^3.0.0-alpha.0:
   version "3.0.0"


### PR DESCRIPTION
**Summary**

Closes #2144 

**Test plan**

This is a drop in replacement for the existing toml parser, but I have added a new test for dates.

Here's a cute cuttlefish (well I think it's cute):

![67303937_10156434455701408_2271579117335871488_o](https://user-images.githubusercontent.com/6415435/63136455-44a2ae80-c011-11e9-9e8a-91c659aecd0d.jpg)



