### PR TITLE
Add title attribute to Editor Toggle buttons to show info on hover

### DIFF
--- a/packages/netlify-cms-core/src/components/Editor/EditorInterface.js
+++ b/packages/netlify-cms-core/src/components/Editor/EditorInterface.js
@@ -255,12 +255,14 @@ class EditorInterface extends Component {
               active={previewVisible}
               onClick={this.handleTogglePreview}
               icon="eye"
+              title="Toggle preview"
             />
             <EditorToggle
               enabled={collectionPreviewEnabled && previewVisible}
               active={scrollSyncEnabled}
               onClick={this.handleToggleScrollSync}
               icon="scroll"
+              title="Sync scrolling"
             />
           </ViewControls>
           {collectionPreviewEnabled && this.state.previewVisible ? (

--- a/packages/netlify-cms-core/src/components/Editor/EditorToggle.js
+++ b/packages/netlify-cms-core/src/components/Editor/EditorToggle.js
@@ -18,9 +18,9 @@ const EditorToggleButton = styled.button`
   margin-bottom: 12px;
 `;
 
-const EditorToggle = ({ enabled, active, onClick, icon }) =>
+const EditorToggle = ({ enabled, active, onClick, icon, title }) =>
   !enabled ? null : (
-    <EditorToggleButton onClick={onClick} isActive={active}>
+    <EditorToggleButton onClick={onClick} isActive={active} title={title}>
       <Icon type={icon} size="large" />
     </EditorToggleButton>
   );
@@ -30,6 +30,7 @@ EditorToggle.propTypes = {
   active: PropTypes.bool,
   onClick: PropTypes.func.isRequired,
   icon: PropTypes.string.isRequired,
+  title: PropTypes.string.isRequired,
 };
 
 export default EditorToggle;


### PR DESCRIPTION
**Summary**

This pull request adds the `title` attribute to the Editor Toggle button, so that when a user hovers over the button icon, they can see some info about the button and what it does.

https://www.w3schools.com/tags/att_global_title.asp

**Motivation**
I usually try to figure out what an icon could mean when I first see it. On the post edit page I saw an `eye` icon, which seemed like it meant something to do with the _view_ and the other one looked like an up down arrow, so maybe something with _scroll_. Just to confirm my instinct, I tried to hover the icons to know what it did and I saw there was no info. 

Though there was no trouble for me to trying out clicking it and see what it did, but I would have appreciated that the button info could have helped me confirm my instinct in some way. I would have had more fun clicking the icons. 

So I made this PR, which I believe is a no harm addition to the repo. :)

![Screenshot from 2019-08-15 23-07-01](https://user-images.githubusercontent.com/10605794/63147092-fdd19c00-bfb1-11e9-9ab3-57e893b5ee7f.png)


**Test plan**
1. Go to any post entry to edit it: http://localhost:8080/#/collections/posts/entries/2019-8-16-post-number-20
2. On the right you see two icons, `eye` and `scrollsync` svg buttons
3. When you hover over them, you should see the buttons info `Toggle preview` and `Sync scrolling` respectively

**Baby Giraffe**
![Baby Giraffe](https://user-images.githubusercontent.com/10605794/63147264-6c165e80-bfb2-11e9-99be-6549fb27b40b.jpg)
