### PR TITLE
Accessing `/edit/:folder/:filename` routes to correct editor page [Fixes #697]

### DIFF
--- a/packages/netlify-cms-core/src/components/App/App.js
+++ b/packages/netlify-cms-core/src/components/App/App.js
@@ -162,21 +162,32 @@ class App extends React.Component {
 
     const getCustomEditRoute = props => {
       const { folder, filename } = props.match.params;
+      let redirect = null;
       const collections = config.get('collections');
-      let activeCollection = null;
-      collections.forEach(collection => {
-        if (folder === collection.get('folder')) {
-          activeCollection = collection;
-        }
-      });
-      if (activeCollection === null) return <NotFoundPage />;
+
       const setTypeOnCollection = collection => {
         if (collection.has('folder')) return collection.set('type', FOLDER);
         if (collection.has('files')) return collection.set('type', FILES);
       };
-      const typeSetCollection = setTypeOnCollection(activeCollection);
-      const slug = selectEntrySlug(typeSetCollection, filename);
-      return <Redirect to={`/collections/${typeSetCollection.get('name')}/entries/${slug}`} />;
+
+      collections.forEach(collection => {
+        const typedCollection = setTypeOnCollection(collection);
+        if (typedCollection.has('files')) {
+          const files = typedCollection.get('files');
+          files.forEach(file => {
+            if (file.get('file').includes(`${folder}/${filename}`)) {
+              redirect = `/collections/${filename}`;
+            }
+          });
+        } else if (typedCollection.has('folder') && folder === typedCollection.get('folder')) {
+          const slug = selectEntrySlug(typedCollection, filename);
+          redirect = `/collections/${typedCollection.get('name')}/entries/${slug}`;
+        }
+      });
+      if (redirect !== null) {
+        return <Redirect to={redirect} />;
+      }
+      return <NotFoundPage />;
     };
 
     return (


### PR DESCRIPTION
👋  Hey folks! This is my first PR for this project — I've used the repo for years, so I'm super excited. Let me know how I can improve this code or the PR itself. 

## 📖 Summary
_See #697 for more information!_

- For a lot of users, it adds utility and clarity to access files at `/edit/:folder/:filename`, so this PR allows users to do so.
- If a user accesses `/edit/:folder/:a-filename-that-does-not-exist`, it will create a new file with that slug. 
  - ex. `${baseUrl}/edit/_posts/fdjiosajfidosa` creates `posts/fdjiosajfidosa.md`.)
- If a user accesses `/edit/:a-files-based-collection/:filename`, they are redirected to the relevant collection for that file. 
- If a user accesses `/edit/:a-folder-that-does-not-exist`, they are redirected to a Not Found view.

## 🚧 Room For Improvement
- ~I've been informed by _some professionals_ that this solution won't work for files-based collections. What should it do in this case? Go to a notfound route always? Something with `/edit/:filename`? Working on this!~ ✅ _Solved! Sorta:_
  - _Should accessing `edit/:folder/:filename/:entry` do something?_
  - _Should accessing `edit/:folder/:filename` go to the first entry?_
- Maybe a toast informing that a new file was created when accessing `/edit/:folder/:a-filename-that-does-not-exist` could be a UX improvement.
- Accessing `/edit/:folder/` without a `:filename` could redirect to the relevant collection. 

## 🧪 Test Plan
1. **Access a file in the system by its folder and filename.**
  - Run the app.
  - Navigate to `http://localhost:8080/#/`.
  - Append `edit/_posts/2015-02-16-this-is-a-toml-frontmatter-post.md` to the URL. (This is a path in `netlify-cms/dev-test/index.html`.)
  - The app redirects to `collections/posts/entries/2015-02-16-this-is-a-toml-frontmatter-post`.

2. **Attempt to access a folder that does not exist.**
  - Run the app.
  - Navigate to `http://localhost:8080/#/`.
  - Append `edit/some-rando-folder` _(or whatever)_ to the URL.
  - The app renders a **Not Found** view.

3. **Access a file from a files-based collection.**
  - Run the app.
  - Navigate to `http://localhost:8080/#/`.
  - Append `edit/_data/settings` to the URL. (This is a file in a files-based collection.)
  - The app redirects to `collections/settings`.

4. **Attempt to access a filename that does not exist.**
  - Run the app.
  - Navigate to `http://localhost:8080/#/`.
  - Append `edit/_posts/some-rando-posty` to the URL.
  - The app redirects to route `collections/posts/entries/some-rando-posty`, which is a new file that will be saved as `some-rando-posty.md`.

## 🐶 A picture of a cute animal (not mandatory but encouraged)

> This is Jerry, a retired racing greyhound I fostered a while back. 

![Jerry waking from a quick snooze.](https://user-images.githubusercontent.com/13542610/63205468-be628880-c061-11e9-96e3-518b49e19456.jpg)
![Jerry enjoying a gentle jaunt.](https://user-images.githubusercontent.com/13542610/63205469-befb1f00-c061-11e9-8659-b5bf69d97927.jpg)

