### PR TITLE
Fix #2469 : File collection entries not differentiated in Workflow

### DIFF
--- a/packages/netlify-cms-core/src/components/Workflow/WorkflowCard.js
+++ b/packages/netlify-cms-core/src/components/Workflow/WorkflowCard.js
@@ -43,7 +43,7 @@ const CardTitle = styled.h2`
   color: ${colors.textLead};
 `;
 
-const CardDate = styled.div`
+const CardDateContainer = styled.div`
   ${styles.text};
 `;
 
@@ -98,6 +98,25 @@ const WorkflowCardContainer = styled.div`
   }
 `;
 
+const lastChangePhraseKey = (date, author) => {
+  if (date && author) {
+    return 'lastChange';
+  } else if (date) {
+    return 'lastChangeNoAuthor';
+  } else if (author) {
+    return 'lastChangeNoDate';
+  }
+};
+
+const CardDate = translate()(({ t, date, author }) => {
+  const key = lastChangePhraseKey(date, author);
+  if (key) {
+    return (
+      <CardDateContainer>{t(`workflow.workflowCard.${key}`, { date, author })}</CardDateContainer>
+    );
+  }
+});
+
 const WorkflowCard = ({
   collectionName,
   title,
@@ -115,12 +134,7 @@ const WorkflowCard = ({
     <WorkflowLink to={editLink}>
       <CardCollection>{collectionName}</CardCollection>
       <CardTitle>{title}</CardTitle>
-      <CardDate>
-        {t('workflow.workflowCard.lastChange', {
-          date: timestamp || '',
-          author: authorLastChange || '',
-        })}
-      </CardDate>
+      {(timestamp || authorLastChange) && <CardDate date={timestamp} author={authorLastChange} />}
       <CardBody>{body}</CardBody>
     </WorkflowLink>
     <CardButtonContainer>
@@ -140,9 +154,9 @@ const WorkflowCard = ({
 
 WorkflowCard.propTypes = {
   collectionName: PropTypes.string.isRequired,
-  title: PropTypes.string.isRequired,
-  authorLastChange: PropTypes.string.isRequired,
-  body: PropTypes.string.isRequired,
+  title: PropTypes.string,
+  authorLastChange: PropTypes.string,
+  body: PropTypes.string,
   isModification: PropTypes.bool,
   editLink: PropTypes.string.isRequired,
   timestamp: PropTypes.string.isRequired,

--- a/packages/netlify-cms-core/src/components/Workflow/WorkflowList.js
+++ b/packages/netlify-cms-core/src/components/Workflow/WorkflowList.js
@@ -213,7 +213,6 @@ class WorkflowList extends React.Component {
           const collection = entry.getIn(['metaData', 'collection']);
           const isModification = entry.get('isModification');
           const canPublish = ownStatus === status.last() && !entry.get('isPersisting', false);
-          const title = entry.getIn(['data', 'title']) || slug;
           return (
             <DragSource
               namespace={DNDNamespace}
@@ -227,7 +226,7 @@ class WorkflowList extends React.Component {
                   <div>
                     <WorkflowCard
                       collectionName={collection}
-                      title={title}
+                      title={entry.get('label') || entry.getIn(['data', 'title'])}
                       authorLastChange={entry.getIn(['metaData', 'user'])}
                       body={entry.getIn(['data', 'body'])}
                       isModification={isModification}

--- a/packages/netlify-cms-core/src/components/Workflow/WorkflowList.js
+++ b/packages/netlify-cms-core/src/components/Workflow/WorkflowList.js
@@ -213,6 +213,7 @@ class WorkflowList extends React.Component {
           const collection = entry.getIn(['metaData', 'collection']);
           const isModification = entry.get('isModification');
           const canPublish = ownStatus === status.last() && !entry.get('isPersisting', false);
+          const title = entry.getIn(['data', 'title']) || slug;
           return (
             <DragSource
               namespace={DNDNamespace}
@@ -226,7 +227,7 @@ class WorkflowList extends React.Component {
                   <div>
                     <WorkflowCard
                       collectionName={collection}
-                      title={entry.getIn(['data', 'title'])}
+                      title={title}
                       authorLastChange={entry.getIn(['metaData', 'user'])}
                       body={entry.getIn(['data', 'body'])}
                       isModification={isModification}

--- a/packages/netlify-cms-core/src/constants/defaultPhrases.js
+++ b/packages/netlify-cms-core/src/constants/defaultPhrases.js
@@ -156,6 +156,8 @@ export function getPhrases() {
       },
       workflowCard: {
         lastChange: '%{date} by %{author}',
+        lastChangeNoAuthor: '%{date}',
+        lastChangeNoDate: 'by %{author}',
         deleteChanges: 'Delete changes',
         deleteNewEntry: 'Delete new entry',
         publishChanges: 'Publish changes',

--- a/packages/netlify-cms-core/src/reducers/collections.js
+++ b/packages/netlify-cms-core/src/reducers/collections.js
@@ -82,6 +82,11 @@ const selectors = {
         .get(0);
       return file && file.get('name');
     },
+    entryLabel(collection, slug) {
+      const path = this.entryPath(collection, slug);
+      const files = collection.get('files');
+      return files && files.find(f => f.get('file') === path).get('label');
+    },
     listMethod() {
       return 'entriesByFiles';
     },
@@ -101,6 +106,8 @@ export const selectFields = (collection, slug) =>
   selectors[collection.get('type')].fields(collection, slug);
 export const selectFolderEntryExtension = collection =>
   selectors[FOLDER].entryExtension(collection);
+export const selectFileEntryLabel = (collection, slug) =>
+  collection.get('files') && selectors[FILES].entryLabel(collection, slug);
 export const selectEntryPath = (collection, slug) =>
   selectors[collection.get('type')].entryPath(collection, slug);
 export const selectEntrySlug = (collection, path) =>

--- a/packages/netlify-cms-core/src/reducers/collections.js
+++ b/packages/netlify-cms-core/src/reducers/collections.js
@@ -65,7 +65,7 @@ const selectors = {
   [FILES]: {
     fileForEntry(collection, slug) {
       const files = collection.get('files');
-      return files.filter(f => f.get('name') === slug).get(0);
+      return files && files.filter(f => f.get('name') === slug).get(0);
     },
     fields(collection, slug) {
       const file = this.fileForEntry(collection, slug);
@@ -107,7 +107,7 @@ export const selectFields = (collection, slug) =>
 export const selectFolderEntryExtension = collection =>
   selectors[FOLDER].entryExtension(collection);
 export const selectFileEntryLabel = (collection, slug) =>
-  collection.get('files') && selectors[FILES].entryLabel(collection, slug);
+  selectors[FILES].entryLabel(collection, slug);
 export const selectEntryPath = (collection, slug) =>
   selectors[collection.get('type')].entryPath(collection, slug);
 export const selectEntrySlug = (collection, path) =>


### PR DESCRIPTION
**Summary**
Fixes #2469 

Editorial Workflow Entries like General Settings and Authors are not differentiated in the Workflow cards(because `title` is not available). 

In this PR, Added `Slug` as fallback for `title` if not available.(Couldn't get any entry like `label`, so went forward with `slug`)


**Test plan**
<img width="469" alt="Screenshot 2019-08-19 at 10 51 19 PM" src="https://user-images.githubusercontent.com/12773390/63285811-3afc9d80-c2d4-11e9-898c-3341ad6414cd.png">

** Cute Animal Pic **
![cute_dog](https://user-images.githubusercontent.com/12773390/63403492-194b0580-c3fd-11e9-812a-bc2bb8a9f611.jpg)

