### PR TITLE
Uploading new media automatically sets that media to selected [Fixes #1983]

### DIFF
--- a/packages/netlify-cms-core/src/components/MediaLibrary/MediaLibrary.js
+++ b/packages/netlify-cms-core/src/components/MediaLibrary/MediaLibrary.js
@@ -177,6 +177,8 @@ class MediaLibrary extends React.Component {
 
     await persistMedia(file, { privateUpload });
 
+    this.setState({ selectedFile: this.props.files[0] });
+
     event.target.value = null;
 
     this.scrollToTop();


### PR DESCRIPTION
👋  Hey folks! 
## 📖 Summary
_See #1983 for more information!_

- Uploading a single image should in the MediaLibraryModal should set that image to the selected image. This is a UX improvement; 99% of the time, you're uploading an image to use it immediately.

## 🧪 Test Plan
1. Run the app and navigate to it in a browser.
2. Access any post with an image field, and click **Choose an image**.
3. Upload one image.
4. That image, once uploaded, should be automatically set as the _selected_ image.

### Additional Testing
5. **Try uploading an additional image**. The first image will no longer be selected, and the newest image will be selected. 
6. **Try selecting an image other than the most recently uploaded**.

## 🐶 A picture of a cute animal (not mandatory but encouraged)

> This is Jazzy, a another greyhound I used to foster. (Some kind of lab mix, clearly 😂)

![Jazzy the greyhound having a peep.](https://user-images.githubusercontent.com/13542610/63379810-59a17980-c352-11e9-83ac-3270d54de312.jpg)
![Jazzy the greyhound having a nap.](https://user-images.githubusercontent.com/13542610/63379811-59a17980-c352-11e9-8184-fa69d4fad01f.jpg)


