### PR TITLE
Fix: don't pass ref to react-polyglot 'translate' function component

### DIFF
--- a/packages/netlify-cms-core/src/components/Editor/EditorControlPane/EditorControl.js
+++ b/packages/netlify-cms-core/src/components/Editor/EditorControlPane/EditorControl.js
@@ -329,7 +329,7 @@ const ConnectedEditorControl = connect(
   mapStateToProps,
   mapDispatchToProps,
   null,
-  { withRef: true },
+  { withRef: false },
 )(translate()(EditorControl));
 
 export default ConnectedEditorControl;


### PR DESCRIPTION
Fixes #2098 

`translate` creates a function component hence the warning.

If the `ref` is really needed (I'm assuming not at the moment) we can:

* Update to latest version of `react-redux` and use `forwardRef`:
https://react-redux.js.org/api/connect#options-object

or
* Wait for this pr https://github.com/nayaabkhan/react-polyglot/pull/20