### PR TITLE
Update Open Authoring branches when a PR hasn't been created

### DIFF
--- a/packages/netlify-cms-backend-github/src/API.js
+++ b/packages/netlify-cms-backend-github/src/API.js
@@ -612,6 +612,11 @@ export default class API {
         return this.rebasePullRequest(pr.number, branchName, contentKey, metadata, commit);
       }
 
+      // Update unpublished entries which don't have a PR. These are
+      // typically Open Authoring entries that have never been
+      // submitted for review.
+      await this.patchBranch(branchName, commit.sha);
+
       return this.storeMetadata(contentKey, updatedMetadata);
     }
   }


### PR DESCRIPTION
**Summary**

Previously, `editorialWorkflowGit` would update the unpublished entry branch by using `rebasePullRequest` if the entry had a pr. Since the normal editorial workflow creates PRs for all unpublished entries, that runs for all of them. When Open Authoring is active, unpublished entries that have never been submitted for review have no PR (not even a closed one), so the backend was failing to update these entries.

The one-line fix in this commit updates the corresponding branch with `patchBranch` when an unpublished entry without a PR is updated.

<!--
Explain the **motivation** for making this change.
What existing problem does the pull request solve?
-->

**Test plan**

Tested manually after reproducing the bug.