### PR TITLE
Remove Editor Interface's width constraint

### DIFF
--- a/packages/netlify-cms-core/src/components/Editor/EditorInterface.js
+++ b/packages/netlify-cms-core/src/components/Editor/EditorInterface.js
@@ -38,7 +38,7 @@ const ReactSplitPaneGlobalStyles = () => (
 
         &:before {
           content: '';
-          width: 1px;
+          width: 2px;
           height: 100%;
           position: relative;
           left: 10px;

--- a/packages/netlify-cms-core/src/components/Editor/EditorInterface.js
+++ b/packages/netlify-cms-core/src/components/Editor/EditorInterface.js
@@ -83,7 +83,6 @@ const EditorContainer = styled.div`
 `;
 
 const Editor = styled.div`
-  max-width: 1600px;
   height: 100%;
   margin: 0 auto;
   position: relative;


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines.

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first two fields are mandatory:
-->

closes #1122 

**Summary**

This PR removes the width constraint from the Editor Interface. 

<!--
Explain the **motivation** for making this change.
What existing problem does the pull request solve?
-->

**A picture of a cute animal (not mandatory but encouraged)**

![image](https://user-images.githubusercontent.com/372831/64036511-427d3b80-cb4b-11e9-8c2c-6713a9660c6e.png)


---

![image](https://user-images.githubusercontent.com/372831/64037048-90df0a00-cb4c-11e9-89e9-2582b32d711d.png)


I no longer have a large monitor, so please verify!

Thanks