### PR TITLE
Prevent deletion of file collection entries by default

### DIFF
--- a/packages/netlify-cms-core/src/reducers/__tests__/collections.spec.js
+++ b/packages/netlify-cms-core/src/reducers/__tests__/collections.spec.js
@@ -1,6 +1,7 @@
 import { OrderedMap, fromJS } from 'immutable';
 import { configLoaded } from 'Actions/config';
-import collections from '../collections';
+import collections, { selectAllowDeletion } from '../collections';
+import { FILES, FOLDER } from 'Constants/collectionTypes';
 
 describe('collections', () => {
   it('should handle an empty state', () => {
@@ -29,9 +30,22 @@ describe('collections', () => {
           name: 'posts',
           folder: '_posts',
           fields: [{ name: 'title', widget: 'string' }],
-          type: 'folder_based_collection',
+          type: FOLDER,
         }),
       }),
     );
+  });
+
+  describe('selectAllowDeletions', () => {
+    it('should not allow deletions for file collections', () => {
+      expect(
+        selectAllowDeletion(
+          fromJS({
+            name: 'pages',
+            type: FILES,
+          }),
+        ),
+      ).toBe(false);
+    });
   });
 });

--- a/packages/netlify-cms-core/src/reducers/collections.js
+++ b/packages/netlify-cms-core/src/reducers/collections.js
@@ -89,7 +89,7 @@ const selectors = {
       return false;
     },
     allowDeletion(collection) {
-      return collection.get('delete', true);
+      return collection.get('delete', false);
     },
     templateName(collection, slug) {
       return slug;


### PR DESCRIPTION
Closes #2481 

**Summary**
Changes the default `delete` configuration value for file collections to `false`

**Test plan**
Wrote a test to check that querying a file-based collection with no explicit value returns false
