### PR TITLE
Fix (GitHub - GraphQL): use getMediaDisplayURL to load media with authorization header

### DIFF
--- a/packages/netlify-cms-backend-github/src/API.js
+++ b/packages/netlify-cms-backend-github/src/API.js
@@ -102,14 +102,14 @@ export default class API {
     return textPromise;
   }
 
-  request(path, options = {}) {
+  request(path, options = {}, parseResponse = response => this.parseResponse(response)) {
     const headers = this.requestHeaders(options.headers || {});
     const url = this.urlFor(path, options);
     let responseStatus;
     return fetch(url, { ...options, headers })
       .then(response => {
         responseStatus = response.status;
-        return this.parseResponse(response);
+        return parseResponse(response);
       })
       .catch(error => {
         throw new APIError(error.message, responseStatus, 'GitHub');

--- a/packages/netlify-cms-backend-github/src/fragments.js
+++ b/packages/netlify-cms-backend-github/src/fragments.js
@@ -67,6 +67,7 @@ export const fileEntry = gql`
   fragment FileEntryParts on TreeEntry {
     name
     sha: oid
+    type
     blob: object {
       ... on Blob {
         size: byteSize

--- a/packages/netlify-cms-core/src/components/MediaLibrary/MediaLibraryCard.js
+++ b/packages/netlify-cms-core/src/components/MediaLibrary/MediaLibraryCard.js
@@ -100,6 +100,8 @@ MediaLibraryCard.propTypes = {
   margin: PropTypes.string.isRequired,
   isPrivate: PropTypes.bool,
   type: PropTypes.string,
+  isViewableImage: PropTypes.bool.isRequired,
+  loadDisplayURL: PropTypes.func.isRequired,
 };
 
 export default MediaLibraryCard;

--- a/packages/netlify-cms-core/src/components/MediaLibrary/MediaLibraryCardGrid.js
+++ b/packages/netlify-cms-core/src/components/MediaLibrary/MediaLibraryCardGrid.js
@@ -86,6 +86,7 @@ MediaLibraryCardGrid.propTypes = {
   cardMargin: PropTypes.string.isRequired,
   loadDisplayURL: PropTypes.func.isRequired,
   isPrivate: PropTypes.bool,
+  displayURLs: PropTypes.instanceOf(Map).isRequired,
 };
 
 export default MediaLibraryCardGrid;

--- a/packages/netlify-cms-core/src/components/MediaLibrary/MediaLibraryModal.js
+++ b/packages/netlify-cms-core/src/components/MediaLibrary/MediaLibraryModal.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import styled from '@emotion/styled';
+import { Map } from 'immutable';
 import { isEmpty } from 'lodash';
 import { translate } from 'react-polyglot';
 import { Modal } from 'UI';
@@ -219,6 +220,7 @@ MediaLibraryModal.propTypes = {
   handleLoadMore: PropTypes.func.isRequired,
   loadDisplayURL: PropTypes.func.isRequired,
   t: PropTypes.func.isRequired,
+  displayURLs: PropTypes.instanceOf(Map).isRequired,
 };
 
 export default translate()(MediaLibraryModal);


### PR DESCRIPTION
Fixes https://github.com/netlify/netlify-cms/issues/2633

The main issue was that I constructed the `download_url` manually since it is not available from the GraphQL API. The REST API returns it with a token query parameter. The token was missing from the constructed URL, thus failing on private repositories.

The solution was to use the built-in mechanism to load media URLs by implementing `getMediaDisplayURL`.

Other fixes related to the media library:

* Adding and deleting an image was broken since `getTree` return value was missing the tree `sha`.
* Media library listed directories as well, so I filtered the result of the GraphQL query (didn't find an option to filter it in the query itself).
* Added some missing prop types to the media library as I was already debugging that code and figured out the required types.