### PR TITLE
Refactor (GitHub Backend): move getMediaDisplayURL from implementation to api

### DIFF
--- a/packages/netlify-cms-backend-github/src/API.js
+++ b/packages/netlify-cms-backend-github/src/API.js
@@ -276,10 +276,28 @@ export default class API {
     }
   }
 
-  retrieveBlob(sha, repoURL) {
-    return this.request(`${repoURL}/git/blobs/${sha}`, {
-      headers: { Accept: 'application/vnd.github.VERSION.raw' },
-    });
+  fetchBlob(sha, repoURL) {
+    return this.request(
+      `${repoURL}/git/blobs/${sha}`,
+      {
+        headers: { Accept: 'application/vnd.github.VERSION.raw' },
+      },
+      response => response,
+    );
+  }
+
+  async fetchBlobContent(sha, repoURL) {
+    const response = await this.fetchBlob(sha, repoURL);
+    const text = await response.text();
+
+    return text;
+  }
+
+  async getMediaDisplayURL(sha) {
+    const response = await this.fetchBlob(sha, this.repoURL);
+    const blob = await response.blob();
+
+    return URL.createObjectURL(blob);
   }
 
   getBlob(sha, { repoURL = this.repoURL } = {}) {
@@ -288,7 +306,7 @@ export default class API {
         return cached;
       }
 
-      return this.retrieveBlob(sha, repoURL).then(result => {
+      return this.fetchBlobContent(sha, repoURL).then(result => {
         localForage.setItem(`gh.${sha}`, result);
         return result;
       });

--- a/packages/netlify-cms-backend-github/src/GraphQLAPI.js
+++ b/packages/netlify-cms-backend-github/src/GraphQLAPI.js
@@ -156,7 +156,7 @@ export default class GraphQLAPI extends API {
     }
   }
 
-  async retrieveBlob(sha, repoURL) {
+  async fetchBlobContent(sha, repoURL) {
     const { owner, name } = this.getOwnerAndNameFromRepoUrl(repoURL);
     const { is_null, is_binary, text } = await this.retrieveBlobObject(
       owner,
@@ -170,7 +170,7 @@ export default class GraphQLAPI extends API {
     } else if (!is_binary) {
       return text;
     } else {
-      return super.retrieveBlob(sha, repoURL);
+      return super.fetchBlobContent(sha, repoURL);
     }
   }
 

--- a/packages/netlify-cms-backend-github/src/implementation.js
+++ b/packages/netlify-cms-backend-github/src/implementation.js
@@ -276,15 +276,8 @@ export default class GitHub {
 
   async getMediaDisplayURL(displayURL) {
     const { sha } = displayURL;
-    const blob = await this.api.request(
-      `${this.api.repoURL}/git/blobs/${sha}`,
-      {
-        headers: { Accept: 'application/vnd.github.VERSION.raw' },
-      },
-      response => response.blob(),
-    );
-
-    return URL.createObjectURL(blob);
+    const mediaURL = await this.api.getMediaDisplayURL(sha);
+    return mediaURL;
   }
 
   persistEntry(entry, mediaFiles = [], options = {}) {


### PR DESCRIPTION
Follow up on this comment: https://github.com/netlify/netlify-cms/pull/2652#pullrequestreview-283938073

Moved `getMediaDisplayURL` implementation to the API class and renamed some methods so they make more sense.