### PR TITLE
media-library-cloudinary: when 'multiple' is true, always return arrary (#2573)

### DIFF
--- a/packages/netlify-cms-media-library-cloudinary/src/__tests__/index.spec.js
+++ b/packages/netlify-cms-media-library-cloudinary/src/__tests__/index.spec.js
@@ -147,6 +147,17 @@ Object {
       expect(handleInsert).toHaveBeenCalledWith(expect.any(Array));
     });
 
+    it('calls insert function with array when only one asset is returned and config.multiple is true', async () => {
+      const options = {
+        config: {
+          multiple: true,
+        },
+      };
+      await cloudinary.init({ options, handleInsert });
+      cloudinaryInsertHandler({ assets: [asset] });
+      expect(handleInsert).toHaveBeenCalledWith(expect.any(Array));
+    });
+
     it('calls insert function with secure url', async () => {
       await cloudinary.init({ handleInsert });
       cloudinaryInsertHandler({ assets: [asset] });

--- a/packages/netlify-cms-media-library-cloudinary/src/index.js
+++ b/packages/netlify-cms-media-library-cloudinary/src/index.js
@@ -60,7 +60,7 @@ async function init({ options = {}, handleInsert } = {}) {
 
   const insertHandler = data => {
     const assets = data.assets.map(asset => getAssetUrl(asset, resolvedOptions));
-    handleInsert(assets.length > 1 ? assets : assets[0]);
+    handleInsert(providedConfig.multiple || assets.length > 1 ? assets : assets[0]);
   };
 
   const mediaLibrary = window.cloudinary.createMediaLibrary(cloudinaryConfig, { insertHandler });


### PR DESCRIPTION
**Summary**
When selecting 2 images via Cloudinary media_library, the image strings are saved in markdown as an array. When selecting 1 image, it is saved in markdown as a string. When `multiple=true` is set in the configuration, both of these cases should return an array.

See https://github.com/netlify/netlify-cms/issues/2573 for more information.

Fixes #2573 

**Test plan**

I added unit test coverage that supports this change.

![image](https://user-images.githubusercontent.com/22333813/64390870-87561600-d014-11e9-8648-6cc8d8efb5c8.png)
