### PR TITLE
Added a locale property to date and datetime widgets

### DIFF
--- a/dev-test/config.yml
+++ b/dev-test/config.yml
@@ -26,6 +26,7 @@ collections: # A list of collections the CMS should be able to edit
           dateFormat: 'YYYY-MM-DD',
           timeFormat: 'HH:mm',
           format: 'YYYY-MM-DD HH:mm',
+          locale: 'fr-ch'
         }
       - label: 'Cover Image'
         name: 'image'

--- a/packages/netlify-cms-widget-date/src/DateControl.js
+++ b/packages/netlify-cms-widget-date/src/DateControl.js
@@ -29,6 +29,7 @@ export default class DateControl extends React.Component {
     setInactiveStyle: PropTypes.func.isRequired,
     value: PropTypes.oneOfType([PropTypes.object, PropTypes.string]),
     includeTime: PropTypes.bool,
+    locale: PropTypes.string,
   };
 
   getFormats() {
@@ -52,6 +53,14 @@ export default class DateControl extends React.Component {
   }
 
   formats = this.getFormats();
+
+  getLocale() {
+    const { field } = this.props;
+    const locale = field.get('locale');
+    return typeof locale === 'undefined' ? 'en' : locale;
+  }
+
+  locale = this.getLocale();
 
   componentDidMount() {
     warnDeprecated();
@@ -116,6 +125,7 @@ export default class DateControl extends React.Component {
   render() {
     const { forID, value, classNameWrapper, setActiveStyle } = this.props;
     const { format, dateFormat, timeFormat } = this.formats;
+    const locale = this.locale;
     return (
       <div
         css={css`
@@ -130,6 +140,7 @@ export default class DateControl extends React.Component {
           onFocus={setActiveStyle}
           onBlur={this.onBlur}
           inputProps={{ className: classNameWrapper, id: forID }}
+          locale={locale}
         />
       </div>
     );

--- a/packages/netlify-cms-widget-datetime/src/DateTimeControl.js
+++ b/packages/netlify-cms-widget-datetime/src/DateTimeControl.js
@@ -15,6 +15,7 @@ export default class DateTimeControl extends React.Component {
     setActiveStyle: PropTypes.func.isRequired,
     setInactiveStyle: PropTypes.func.isRequired,
     value: PropTypes.oneOfType([PropTypes.object, PropTypes.string]),
+    locale: PropTypes.string,
   };
 
   getFormats() {
@@ -38,6 +39,15 @@ export default class DateTimeControl extends React.Component {
   }
 
   formats = this.getFormats();
+
+  getLocale() {
+    const { field } = this.props;
+    const locale = field.get('locale');
+    console.log(`locale: ${locale}`);
+    return typeof locale === 'undefined' ? 'en' : locale;
+  }
+
+  locale = this.getLocale();
 
   componentDidMount() {
     const { value } = this.props;
@@ -101,6 +111,7 @@ export default class DateTimeControl extends React.Component {
   render() {
     const { forID, value, classNameWrapper, setActiveStyle } = this.props;
     const { format, dateFormat, timeFormat } = this.formats;
+    const locale = this.locale;
     return (
       <div
         css={css`
@@ -115,6 +126,7 @@ export default class DateTimeControl extends React.Component {
           onFocus={setActiveStyle}
           onBlur={this.onBlur}
           inputProps={{ className: classNameWrapper, id: forID }}
+          locale={locale}
         />
       </div>
     );

--- a/scripts/webpack.js
+++ b/scripts/webpack.js
@@ -33,7 +33,6 @@ const rules = () => ({
 const plugins = () => {
   return {
     ignoreEsprima: () => new webpack.IgnorePlugin(/^esprima$/, /js-yaml/),
-    ignoreMomentOptionalDeps: () => new webpack.IgnorePlugin(/^\.\/locale$/, /moment$/),
     friendlyErrors: () => new FriendlyErrorsWebpackPlugin(),
   };
 };

--- a/website/content/docs/beta-features.md
+++ b/website/content/docs/beta-features.md
@@ -241,3 +241,20 @@ When using the [GitHub backend](/docs/authentication-backends/#github-backend), 
 At the same time, any contributors who _do_ have write access to the repository can continue to use Netlify CMS normally.
 
 More details and setup instructions can be found on [the Open Authoring docs page](/docs/open-authoring).
+
+
+## Set the locale for datetime and date widget
+
+You can set the locale of the calendar widget (datetime and date).
+
+```yaml
+  - {
+    label: 'Date de publication',
+    name: 'date',
+    widget: 'datetime',
+    dateFormat: 'YYYY-MM-DD',
+    timeFormat: 'HH:mm',
+    format: 'YYYY-MM-DD HH:mm',
+    locale: 'fr-ch' # the locale for the calendar and the associated field.
+  }
+```

--- a/website/content/docs/widgets/date.md
+++ b/website/content/docs/widgets/date.md
@@ -15,6 +15,8 @@ The date widget translates a date picker input to a date string. For saving date
   - `format`: optional; accepts Moment.js [tokens](https://momentjs.com/docs/#/parsing/string-format/); defaults to raw Date object (if supported by output format)
   - `dateFormat`: optional; boolean or Moment.js [tokens](https://momentjs.com/docs/#/parsing/string-format/). If `true` use default locale format.
   - `timeFormat`: optional; boolean or Moment.js [tokens](https://momentjs.com/docs/#/parsing/string-format/). If `true` use default locale format, `false` hides time-picker. Defaults to false.
+  - `locale`: optional (defaults to en); set the locale of the popup calendar. Any valid momentjs locale should work.
+
 - **Example:**
   ```yaml
   - label: 'Birthdate'

--- a/website/content/docs/widgets/datetime.md
+++ b/website/content/docs/widgets/datetime.md
@@ -13,6 +13,8 @@ The datetime widget translates a datetime picker to a datetime string. For savin
   - `format`: optional; accepts Moment.js [tokens](https://momentjs.com/docs/#/parsing/string-format/); defaults to raw Date object (if supported by output format)
   - `dateFormat`: optional; boolean or Moment.js [tokens](https://momentjs.com/docs/#/parsing/string-format/). If `true` use default locale format.
   - `timeFormat`: optional; boolean or Moment.js [tokens](https://momentjs.com/docs/#/parsing/string-format/). If `true` use default locale format, `false` hides time-picker.
+  - `locale`: optional (defaults to en); set the locale of the popup calendar. Any valid Moment.js locale should work.
+
 - **Example:**
     ```yaml
     - label: "Start time"


### PR DESCRIPTION
**Summary**

Replaces pull request #2617 since the `date` widget has been deprecated in favor of the `datetime` widget.

The popup calendar for `date` and `datetime` widgets are always using `en` as locale. With a minor tweaks, `react-calendar` and `momentjs` make it easy to support other locales. That makes the calendar easier to use and less error prone for people being accustomed to week starting on Monday. 

**Test plan**

https://drive.google.com/open?id=1JSgjPAsiFoOnZMld0mWq6CTpEA9asNWw