### PR TITLE
Fix #2470: Show Test Repo is in use

### DIFF
--- a/packages/netlify-cms-core/src/components/App/App.js
+++ b/packages/netlify-cms-core/src/components/App/App.js
@@ -169,6 +169,7 @@ class App extends React.Component {
           openMediaLibrary={openMediaLibrary}
           hasWorkflow={hasWorkflow}
           displayUrl={config.get('display_url')}
+          isTestRepo={config.getIn(['backend', 'name']) === 'test-repo'}
           showMediaButton={showMediaButton}
         />
         <AppMainContainer>

--- a/packages/netlify-cms-core/src/components/App/Header.js
+++ b/packages/netlify-cms-core/src/components/App/Header.js
@@ -136,6 +136,7 @@ class Header extends React.Component {
       openMediaLibrary,
       hasWorkflow,
       displayUrl,
+      isTestRepo,
       t,
       showMediaButton,
     } = this.props;
@@ -198,6 +199,7 @@ class Header extends React.Component {
             )}
             <SettingsDropdown
               displayUrl={displayUrl}
+              isTestRepo={isTestRepo}
               imageUrl={user.get('avatar_url')}
               onLogoutClick={onLogoutClick}
             />

--- a/packages/netlify-cms-core/src/components/App/Header.js
+++ b/packages/netlify-cms-core/src/components/App/Header.js
@@ -118,6 +118,7 @@ class Header extends React.Component {
     openMediaLibrary: PropTypes.func.isRequired,
     hasWorkflow: PropTypes.bool.isRequired,
     displayUrl: PropTypes.string,
+    isTestRepo: PropTypes.bool,
     t: PropTypes.func.isRequired,
   };
 

--- a/packages/netlify-cms-core/src/components/UI/SettingsDropdown.js
+++ b/packages/netlify-cms-core/src/components/UI/SettingsDropdown.js
@@ -85,6 +85,7 @@ const SettingsDropdown = ({ displayUrl, isTestRepo, imageUrl, onLogoutClick, t }
 
 SettingsDropdown.propTypes = {
   displayUrl: PropTypes.string,
+  isTestRepo: PropTypes.bool,
   imageUrl: PropTypes.string,
   onLogoutClick: PropTypes.func.isRequired,
   t: PropTypes.func.isRequired,

--- a/packages/netlify-cms-core/src/components/UI/SettingsDropdown.js
+++ b/packages/netlify-cms-core/src/components/UI/SettingsDropdown.js
@@ -39,6 +39,13 @@ const AppHeaderSiteLink = styled.a`
   padding: 10px 16px;
 `;
 
+const AppHeaderTestRepoIndicator = styled.a`
+  font-size: 14px;
+  font-weight: 400;
+  color: #7b8290;
+  padding: 10px 16px;
+`;
+
 const Avatar = ({ imageUrl }) =>
   imageUrl ? <AvatarImage src={imageUrl} /> : <AvatarPlaceholderIcon type="user" size="large" />;
 
@@ -46,8 +53,16 @@ Avatar.propTypes = {
   imageUrl: PropTypes.string,
 };
 
-const SettingsDropdown = ({ displayUrl, imageUrl, onLogoutClick, t }) => (
+const SettingsDropdown = ({ displayUrl, isTestRepo, imageUrl, onLogoutClick, t }) => (
   <React.Fragment>
+    {isTestRepo && (
+      <AppHeaderTestRepoIndicator
+        href="https://www.netlifycms.org/docs/authentication-backends#test-repo-backend"
+        target="_blank"
+      >
+        Test Backend ↗
+      </AppHeaderTestRepoIndicator>
+    )}
     {displayUrl ? (
       <AppHeaderSiteLink href={displayUrl} target="_blank">
         {stripProtocol(displayUrl)}

--- a/packages/netlify-cms-core/src/components/UI/SettingsDropdown.js
+++ b/packages/netlify-cms-core/src/components/UI/SettingsDropdown.js
@@ -59,6 +59,7 @@ const SettingsDropdown = ({ displayUrl, isTestRepo, imageUrl, onLogoutClick, t }
       <AppHeaderTestRepoIndicator
         href="https://www.netlifycms.org/docs/authentication-backends#test-repo-backend"
         target="_blank"
+        rel="noopener noreferrer"
       >
         Test Backend ↗
       </AppHeaderTestRepoIndicator>


### PR DESCRIPTION
**Summary**
Fixes #2470 

>The test repo backend i indistinguishable from other backends in the UI. If a user doesn't know they're using it, the whole experience is confusing.

Added a flag, `isTestRepo` in the `Header` props. If its `true`, a Link with text `Text Backend` is shown to indicate Test Repo Mode which on click takes to [docs](https://www.netlifycms.org/docs/authentication-backends#test-repo-backend) page.

**Test plan**

<img width="448" alt="Screenshot 2019-09-14 at 11 26 50 PM" src="https://user-images.githubusercontent.com/12773390/64912156-dd2f6a00-d748-11e9-8bed-8ae40e8500e2.png">


**A picture of a cute animal (not mandatory but encouraged)**

![doggy_sipping](https://user-images.githubusercontent.com/12773390/64912194-621a8380-d749-11e9-9d98-a9a3a708c2b1.jpg)