### PR TITLE
Add new test to increase the test coverage in widget-number

### DIFF
--- a/packages/netlify-cms-widget-number/src/__tests__/number.spec.js
+++ b/packages/netlify-cms-widget-number/src/__tests__/number.spec.js
@@ -120,6 +120,18 @@ describe('Number widget', () => {
     expect(onChangeSpy).toHaveBeenCalledWith(parseInt(testValue, 10));
   });
 
+  it('should parse float numbers as float', () => {
+    const field = fromJS({ ...fieldSettings, valueType: 'float' });
+    const testValue = (Math.random() * (20 - -20 + 1) + -20).toFixed(2);
+    const { input, onChangeSpy } = setup({ field });
+
+    fireEvent.focus(input);
+    fireEvent.change(input, { target: { value: String(testValue) } });
+
+    expect(onChangeSpy).toHaveBeenCalledTimes(1);
+    expect(onChangeSpy).toHaveBeenCalledWith(parseFloat(testValue));
+  });
+
   it('should allow 0 as a value', () => {
     const field = fromJS(fieldSettings);
     const testValue = 0;


### PR DESCRIPTION
**Summary**

I've added the new test case to cover two if branches in this code:

https://github.com/netlify/netlify-cms/blob/3903acb431998b5a060825f2d600b4a7cb1a010a/packages/netlify-cms-widget-number/src/NumberControl.js#L34

Here the screenshot from test coverage report:

<img width="759" alt="Screen Shot 2019-09-14 at 20 58 08" src="https://user-images.githubusercontent.com/48512663/64912622-4788e000-d732-11e9-9439-5510dcb46f23.png">


<!--
Explain the **motivation** for making this change.
What existing problem does the pull request solve?
-->

**Test plan**

Please run the test with options:

```
$ npm run test:unit --coverage --coverageReporters=html
```

After test is passed please check the report for `netlify-cms-widget-number` package.
