### PR TITLE
Fix ListCard corners becoming un-rounded on hover

### DIFF
--- a/packages/netlify-cms-core/src/components/Collection/Entries/EntryCard.js
+++ b/packages/netlify-cms-core/src/components/Collection/Entries/EntryCard.js
@@ -12,6 +12,7 @@ const ListCard = styled.li`
   width: ${lengths.topCardWidth};
   margin-left: 12px;
   margin-bottom: 16px;
+  overflow: hidden;
 `;
 
 const ListCardLink = styled(Link)`


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines.

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first two fields are mandatory:
-->

<!--
Explain the **motivation** for making this change.
What existing problem does the pull request solve?
-->

Currently, when opening a Collection and viewing the list of cards, hovering over one of the cards turns the card's rounded corners into square corners. 

This has always bugged me so I decided to fix it as my first contribution to an open-source project. 

**Test plan**

<!--
Demonstrate the code is solid.
Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.
-->

I don't think tests are needed, it's just a single line of additional CSS in one commit. I have verified using the development environment that the corner-unrounding is no longer present in Chrome or Safari. 

**A picture of a cute animal (not mandatory but encouraged)**
![image](https://user-images.githubusercontent.com/30215449/65839928-20104680-e2e0-11e9-8607-601c2b49b7be.png)
_A diagram of the UI issue being addressed_