### PR TITLE
enhancement: improve error with no existing widget

### DIFF
--- a/packages/netlify-cms-core/src/components/Editor/EditorControlPane/Widget.js
+++ b/packages/netlify-cms-core/src/components/Editor/EditorControlPane/Widget.js
@@ -2,6 +2,7 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import ImmutablePropTypes from 'react-immutable-proptypes';
 import { Map, List } from 'immutable';
+import { oneLine } from 'common-tags';
 import ValidationErrorTypes from 'Constants/validationErrorTypes';
 
 const truthy = () => ({ error: false });
@@ -153,7 +154,10 @@ export default class Widget extends Component {
   validateWrappedControl = field => {
     const t = this.props.t;
     if (typeof this.wrappedControlValid !== 'function') {
-      throw new Error(`The wrappedControlValid is not a function (widget: ${field.get('widget')}).`)
+      throw new Error(oneLine`
+        this.wrappedControlValid is not a function. Are you sure widget
+        "${field.get('widget')}" is registered?
+      `)
     }
 
     const response = this.wrappedControlValid();

--- a/packages/netlify-cms-core/src/components/Editor/EditorControlPane/Widget.js
+++ b/packages/netlify-cms-core/src/components/Editor/EditorControlPane/Widget.js
@@ -152,6 +152,10 @@ export default class Widget extends Component {
 
   validateWrappedControl = field => {
     const t = this.props.t;
+    if (typeof this.wrappedControlValid !== 'function') {
+      throw new Error(`The wrappedControlValid is not a function (widget: ${field.get('widget')}).`)
+    }
+
     const response = this.wrappedControlValid();
     if (typeof response === 'boolean') {
       const isValid = response;

--- a/packages/netlify-cms-core/src/components/Editor/EditorControlPane/Widget.js
+++ b/packages/netlify-cms-core/src/components/Editor/EditorControlPane/Widget.js
@@ -157,7 +157,7 @@ export default class Widget extends Component {
       throw new Error(oneLine`
         this.wrappedControlValid is not a function. Are you sure widget
         "${field.get('widget')}" is registered?
-      `)
+      `);
     }
 
     const response = this.wrappedControlValid();


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines.

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first two fields are mandatory:
-->

**Summary**

This PR improve error message if no widget exist. fixes #2717 

If add to collection field:

```
- { label: "content", name: "content", widget: "does-not-exist" }
```

Error message before:

```
Uncaught TypeError: this.wrappedControlValid is not a function
```

Error message now:

```
Error: The wrappedControlValid is not a function (widget: does-not-exist).
```

**Test plan**

1. Add to collection this field: `- { label: "content", name: "content", widget: "does-not-exist" }`
2. Create new collection
3. Try to push Save/Publish button and observe the error in console.

**A picture of a cute animal (not mandatory but encouraged)**

![3FF6822F00000578-4476288-Ms_Smith_runs_the_Kensmyth_Alpaca_Stud_breeding_alpacas_which_ca-a-2_1493977774274](https://user-images.githubusercontent.com/48512663/66160716-05650700-e62b-11e9-9183-c7dee10520f5.jpg)
