### PR TITLE
feat(netlify-cms-widget-markdown): add headings dropdown #1851

### DIFF
--- a/packages/netlify-cms-ui-default/src/Icon/images/_index.js
+++ b/packages/netlify-cms-ui-default/src/Icon/images/_index.js
@@ -18,6 +18,7 @@ import iconGitlab from './gitlab.svg';
 import iconGrid from './grid.svg';
 import iconH1 from './h1.svg';
 import iconH2 from './h2.svg';
+import iconHOptions from './h-options.svg';
 import iconHome from './home.svg';
 import iconImage from './image.svg';
 import iconItalic from './italic.svg';
@@ -66,6 +67,7 @@ const images = {
   grid: iconGrid,
   h1: iconH1,
   h2: iconH2,
+  hOptions: iconHOptions,
   home: iconHome,
   image: iconImage,
   italic: iconItalic,

--- a/packages/netlify-cms-ui-default/src/Icon/images/h-options.svg
+++ b/packages/netlify-cms-ui-default/src/Icon/images/h-options.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="22" height="20" viewBox="0 0 22 20"><path fill="#7A8291" d="M3 4h10v12H3V4zm2 0v5h6V4H5zm0 7v5h6v-5H5M17.874 16.91l-3.493-4.117h6.986l-3.493 4.117z"></path></svg>

--- a/packages/netlify-cms-ui-default/src/styles.js
+++ b/packages/netlify-cms-ui-default/src/styles.js
@@ -310,11 +310,13 @@ const components = {
     display: flex;
     justify-content: space-between;
     align-items: center;
+    white-space: nowrap;
 
     &:last-of-type {
       border-bottom: 0;
     }
 
+    &.active,
     &:hover,
     &:active,
     &:focus {

--- a/packages/netlify-cms-widget-markdown/src/MarkdownControl/Toolbar.js
+++ b/packages/netlify-cms-widget-markdown/src/MarkdownControl/Toolbar.js
@@ -58,6 +58,15 @@ const ToolbarToggleLabel = styled.span`
     `};
 `;
 
+const headingOptions = {
+  'heading-one': 'Heading 1',
+  'heading-two': 'Heading 2',
+  'heading-three': 'Heading 3',
+  'heading-four': 'Heading 4',
+  'heading-five': 'Heading 5',
+  'heading-six': 'Heading 6',
+};
+
 export default class Toolbar extends React.Component {
   static propTypes = {
     buttons: ImmutablePropTypes.list,
@@ -135,24 +144,37 @@ export default class Toolbar extends React.Component {
             isHidden={this.isHidden('link')}
             disabled={disabled}
           />
-          <ToolbarButton
-            type="heading-one"
-            label="Header 1"
-            icon="h1"
-            onClick={onBlockClick}
-            isActive={selectionHasBlock}
-            isHidden={this.isHidden('heading-one')}
-            disabled={disabled}
-          />
-          <ToolbarButton
-            type="heading-two"
-            label="Header 2"
-            icon="h2"
-            onClick={onBlockClick}
-            isActive={selectionHasBlock}
-            isHidden={this.isHidden('heading-two')}
-            disabled={disabled}
-          />
+          {!this.isHidden('headings') && (
+            <ToolbarDropdownWrapper>
+              <Dropdown
+                dropdownTopOverlap="36px"
+                renderButton={() => (
+                  <DropdownButton>
+                    <ToolbarButton
+                      type="headings"
+                      label="Headings"
+                      icon="hOptions"
+                      disabled={disabled}
+                      isActive={() =>
+                        Object.keys(headingOptions).some(optionKey => {
+                          return selectionHasBlock(optionKey);
+                        })
+                      }
+                    />
+                  </DropdownButton>
+                )}
+              >
+                {Object.keys(headingOptions).map((optionKey, idx) => (
+                  <DropdownItem
+                    key={idx}
+                    label={headingOptions[optionKey]}
+                    className={selectionHasBlock(optionKey) && 'active'}
+                    onClick={() => onBlockClick(undefined, optionKey)}
+                  />
+                ))}
+              </Dropdown>
+            </ToolbarDropdownWrapper>
+          )}
           <ToolbarButton
             type="quote"
             label="Quote"

--- a/packages/netlify-cms-widget-markdown/src/MarkdownControl/VisualEditor.js
+++ b/packages/netlify-cms-widget-markdown/src/MarkdownControl/VisualEditor.js
@@ -112,7 +112,9 @@ export default class Editor extends React.Component {
   };
 
   handleBlockClick = (event, type) => {
-    event.preventDefault();
+    if (event) {
+      event.preventDefault();
+    }
     let { value } = this.state;
     const { document: doc } = value;
     const { unwrapList, wrapInList } = EditListConfigured.changes;

--- a/website/content/docs/widgets/markdown.md
+++ b/website/content/docs/widgets/markdown.md
@@ -1,5 +1,5 @@
 ---
-label: "Markdown"
+label: 'Markdown'
 title: markdown
 ---
 
@@ -12,7 +12,7 @@ _Please note:_ If you want to use your markdown editor to fill a markdown file c
 - **Data type:** markdown
 - **Options:**
   - `default`: accepts markdown content
-  - `buttons`: an array of strings representing the formatting buttons to display, all buttons shown by default. Buttons include: `bold`, `italic`, `code`, `link`, `heading-one`, `heading-two`, `quote`, `code-block`, `bulleted-list`, and `numbered-list`.
+  - `buttons`: an array of strings representing the formatting buttons to display, all buttons shown by default. Buttons include: `bold`, `italic`, `code`, `link`, `headings`, `quote`, `code-block`, `bulleted-list`, and `numbered-list`.
 - **Example:**
 
   ```yaml


### PR DESCRIPTION
**Summary**

Added headings dropdown to allow 1-6 heading selection in markdown widget.

![Headings Dropdown Example](https://user-images.githubusercontent.com/22333813/66723820-bb7ade80-edeb-11e9-9f75-f569612421ff.gif)

Fixes #1851 

**Test plan**

I tested this by running it locally. I also tested adding/removing the `buttons` option in the configuration.

![image](https://user-images.githubusercontent.com/22333813/66723856-5673b880-edec-11e9-9e80-8b81e72c41fb.png)
