### PR TITLE
docs: add community slack link

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -1,6 +1,6 @@
 name: Node CI
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   build:
@@ -27,5 +27,5 @@ jobs:
         yarn test:all:ci
       env:
         CI: true
-        CYPRESS_RECORD_KEY: ${{secrets.CYPRESS_RECORD_KEY}}
+        CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
         NODE_OPTIONS: --max-old-space-size=4096

--- a/website/content/pages/community.md
+++ b/website/content/pages/community.md
@@ -5,6 +5,9 @@ subhead: Get support, give support, and find out what's new through the channels
 sections:
   - title: support
     channels:
+      - title: Netlify CMS Slack
+        description: Live community chat for all things Netlify CMS.
+        url: /slack
       - title: Netlify Community
         description: Ask and answer questions on the Netlify CMS channel of the Netlify community forum.
         url: https://community.netlify.com/c/netlify-platform/netlify-cms
@@ -14,9 +17,6 @@ sections:
       - title: Stack Overflow
         description: Secondary forum. Questions should be tagged `netlify-cms`.
         url: https://stackoverflow.com/questions/tagged/netlify-cms
-      - title: Gitter Chat
-        description: Live community chat for all things Netlify CMS.
-        url: https://gitter.im/netlify/netlifycms
   - title: development
     channels:
     - title: Priorities

--- a/website/netlify.toml
+++ b/website/netlify.toml
@@ -5,3 +5,7 @@
 
   [build.environment]
     NODE_VERSION = "8"
+
+[[redirects]]
+  from = "/slack"
+  to = "https://join.slack.com/t/netlifycms/shared_invite/enQtODAzMTc3MDI0NDM2LWE1N2NjOTIxMjU4MjYyYTJjYzhmM2ExYWZiMDYzZmZmNWNlYjRkYTk3NGRlYTc3MzBiNWE3ZjQ5NjFkMzAzYjk"


### PR DESCRIPTION
We're not officially moving to Gitter, just trying it out. This PR will direct chat support seekers to Slack instead of Gitter. We're announcing a change and will switch back if we decide this is somehow worse.

Reasons for moving to Slack:
- Dedicated workspace, rather than a long list of unrelated/non-prioritized people and channels
- Mobile experience is 10,000% better - I very often am unable to respond to things because mobile Gitter is just pure pain
- Limited to 10k message history, but those 10k will be searchable in a way that's actually useful
- Lots of folks are already in multiple Slacks, so this is more meeting people where they are
- Generally better communication experience across platforms