### PR TITLE
ci: run workflow on push to master and tags OR pull requests

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -1,6 +1,14 @@
 name: Node CI
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+    tags:
+      - '*'
+
+  pull_request:
+    types: [opened, synchronize, reopened]
 
 jobs:
   build:


### PR DESCRIPTION
Currently since the workflow triggers are `push` and `pull_request` the same GitHub Actions workflow is executed twice for the same commit. Once the commit is pushed, and once again when the pull request is opened.
This change will run the workflow on any push to master (or tags), but will ignore non master branches. For the workflow to run on non master branches a PR needs to be created.