### PR TITLE
chore: remove duplicate bug fix for open authoring

### DIFF
--- a/packages/netlify-cms-backend-github/src/API.js
+++ b/packages/netlify-cms-backend-github/src/API.js
@@ -656,11 +656,6 @@ export default class API {
         await this.patchBranch(branchName, commit.sha, { force: true });
       }
 
-      // Update unpublished entries which don't have a PR. These are
-      // typically Open Authoring entries that have never been
-      // submitted for review.
-      await this.patchBranch(branchName, commit.sha);
-
       return this.storeMetadata(contentKey, updatedMetadata);
     }
   }


### PR DESCRIPTION
Related to #2593.

No need to patch the branch twice