### PR TITLE
Added notice about Large Media option

### DIFF
--- a/website/content/docs/netlify-large-media.md
+++ b/website/content/docs/netlify-large-media.md
@@ -28,7 +28,7 @@ You can learn more about this feature in [Netlify's image transformation docs](h
 
 In repositories enabled with Netlify Large Media, Netlify CMS will use the image transformation query parameters to load thumbnail-sized images for the media gallery view. This makes images in the media gallery load significantly faster.
 
-*Important:* When using this option all tracked file types have to be imported into Large Media. For example if you track `*.jpg` but still have jpg-files that are not imported into Large Media the backend will throw an error. Check the [netlify docs](https://docs.netlify.com/large-media/setup/#migrate-files-from-git-history) on how to add previously commited files to Large Media.
+**Note:** When using this option all tracked file types have to be imported into Large Media. For example if you track `*.jpg` but still have jpg-files that are not imported into Large Media the backend will throw an error. Check the [netlify docs](https://docs.netlify.com/large-media/setup/#migrate-files-from-git-history) on how to add previously commited files to Large Media.
 
 You can disable the automatic image transformations with the `use_large_media_transforms_in_media_library` configuration setting, nested under `backend` in the CMS `config.yml` file:
 

--- a/website/content/docs/netlify-large-media.md
+++ b/website/content/docs/netlify-large-media.md
@@ -28,6 +28,8 @@ You can learn more about this feature in [Netlify's image transformation docs](h
 
 In repositories enabled with Netlify Large Media, Netlify CMS will use the image transformation query parameters to load thumbnail-sized images for the media gallery view. This makes images in the media gallery load significantly faster.
 
+*Important:* When using this option all tracked file types have to be imported into Large Media. For example if you track `*.jpg` but still have jpg-files that are not imported into Large Media the backend will throw an error. Check the [netlify docs](https://docs.netlify.com/large-media/setup/#migrate-files-from-git-history) on how to add previously commited files to Large Media.
+
 You can disable the automatic image transformations with the `use_large_media_transforms_in_media_library` configuration setting, nested under `backend` in the CMS `config.yml` file:
 
 ```


### PR DESCRIPTION
I ran into this issue when activating Large Media while still having not imported files.

**Summary**
When a file type (i.e. `*.jpg`) is tracked via lfs but there are still files of that type present that are not yet imported into lfs the CMS throws an error because it can't find a Large Media url for it.

**A picture of a cute animal (not mandatory but encouraged)**
Picture of the first offspring my mums tortoises produced roughly two months ago. For reference the little bugger is a bit wider than a (my) thumb.

![offspring](https://user-images.githubusercontent.com/6491588/67551634-ae25f400-f709-11e9-8e22-6385aea20066.jpg)