### PR TITLE
docs: update 11ty default site publish folder

### DIFF
--- a/website/content/docs/add-to-your-site.md
+++ b/website/content/docs/add-to-your-site.md
@@ -22,7 +22,7 @@ A static `admin` folder contains all Netlify CMS files, stored at the root of yo
 | Pelican                            | `/content`            |
 | VuePress                           | `/.vuepress/public`   |
 | Elmstatic                          | `/_site`              |
-| 11ty                               | `/site`               |
+| 11ty                               | `/_site`              |
 | preact-cli                         | `/src/static`         |
 
 If your generator isn't listed here, you can check its documentation, or as a shortcut, look in your project for a `css` or `images` folder. The contents of folders like that are usually processed as static files, so it's likely you can store your `admin` folder next to those. (When you've found the location, feel free to add it to these docs by [filing a pull request](https://github.com/netlify/netlify-cms/blob/master/CONTRIBUTING.md#pull-requests)!)


### PR DESCRIPTION
**Summary**

Reading the documentation, I noticed that the default directory for 11ty generated sites was out of date and updated it accordingly.

**Test plan**

No test, but you can verify on the official 11ty docs here:

>This will compile any content templates in the current directory or subdirectories into the output folder (defaults to _site).

-- https://www.11ty.io/docs/getting-started/#step-4-create-some-templates

**A picture of a cute animal (not mandatory but encouraged)**

¯\\\_(ツ)\_/¯