### PR TITLE
fix(github-backend): load media URLs via API

### DIFF
--- a/packages/netlify-cms-backend-github/src/API.js
+++ b/packages/netlify-cms-backend-github/src/API.js
@@ -293,9 +293,15 @@ export default class API {
     return text;
   }
 
-  async getMediaDisplayURL(sha) {
+  async getMediaDisplayURL(sha, path) {
     const response = await this.fetchBlob(sha, this.repoURL);
-    const blob = await response.blob();
+    let blob;
+    if (path.match(/.svg$/)) {
+      const svg = await response.text();
+      blob = new Blob([svg], { type: 'image/svg+xml' });
+    } else {
+      blob = await response.blob();
+    }
 
     return URL.createObjectURL(blob);
   }

--- a/packages/netlify-cms-backend-github/src/implementation.js
+++ b/packages/netlify-cms-backend-github/src/implementation.js
@@ -274,25 +274,17 @@ export default class GitHub {
 
   getMedia() {
     return this.api.listFiles(this.config.get('media_folder')).then(files =>
-      files.map(({ sha, name, size, download_url, path }) => {
-        if (download_url) {
-          const url = new URL(download_url);
-          if (url.pathname.match(/.svg$/)) {
-            url.search += (url.search.slice(1) === '' ? '?' : '&') + 'sanitize=true';
-          }
-          // if 'displayURL' is a string it will be loaded as is
-          return { id: sha, name, size, displayURL: url.href, path };
-        } else {
-          // if 'displayURL' is not a string it will be loaded using getMediaDisplayURL
-          return { id: sha, name, size, displayURL: { sha }, path };
-        }
+      files.map(({ sha, name, size, path }) => {
+        // load media using getMediaDisplayURL to avoid token expiration with GitHub raw content urls
+        // for private repositories
+        return { id: sha, name, size, displayURL: { sha, path }, path };
       }),
     );
   }
 
   async getMediaDisplayURL(displayURL) {
-    const { sha } = displayURL;
-    const mediaURL = await this.api.getMediaDisplayURL(sha);
+    const { sha, path } = displayURL;
+    const mediaURL = await this.api.getMediaDisplayURL(sha, path);
     return mediaURL;
   }
 


### PR DESCRIPTION
Fixes #787.

Downside - images load a bit slower on initial load.
Upside - images are not reloaded when they expire from browser cache (since it is not used anymore).