### PR TITLE
[WIP] feat: commit media with post

### DIFF
--- a/packages/netlify-cms-backend-github/src/API.js
+++ b/packages/netlify-cms-backend-github/src/API.js
@@ -1,6 +1,7 @@
 import { Base64 } from 'js-base64';
 import semaphore from 'semaphore';
-import { find, flow, get, hasIn, initial, last, partial, result } from 'lodash';
+import { find, flow, get, hasIn, initial, last, partial, result, differenceBy } from 'lodash';
+import trimStart from 'lodash/trimStart';
 import { map } from 'lodash/fp';
 import {
   getAllResponses,
@@ -503,14 +504,13 @@ export default class API {
     const fileTree = {};
 
     files.forEach(file => {
-      if (file.uploaded) {
+      if (file.skip) {
         return;
       }
       parts = file.path.split('/').filter(part => part);
       filename = parts.pop();
       subtree = fileTree;
       while ((part = parts.shift())) {
-        // eslint-disable-line no-cond-assign
         subtree[part] = subtree[part] || {};
         subtree = subtree[part];
       }
@@ -521,30 +521,35 @@ export default class API {
     return fileTree;
   }
 
-  persistFiles(entry, mediaFiles, options) {
-    const uploadPromises = [];
+  async persistFiles(entry, mediaFiles, options) {
     const files = entry ? mediaFiles.concat(entry) : mediaFiles;
 
+    // mark files to skip, has to be done here as uploadBlob sets the uploaded flag
     files.forEach(file => {
       if (file.uploaded) {
-        return;
-      }
-      uploadPromises.push(this.uploadBlob(file));
-    });
-
-    const fileTree = this.composeFileTree(files);
-
-    return Promise.all(uploadPromises).then(() => {
-      if (!options.useWorkflow) {
-        return this.getBranch()
-          .then(branchData => this.updateTree(branchData.commit.sha, '/', fileTree))
-          .then(changeTree => this.commit(options.commitMessage, changeTree))
-          .then(response => this.patchBranch(this.branch, response.sha));
+        file.skip = true;
       } else {
-        const mediaFilesList = mediaFiles.map(file => ({ path: file.path, sha: file.sha }));
-        return this.editorialWorkflowGit(fileTree, entry, mediaFilesList, options);
+        file.skip = false;
       }
     });
+
+    const uploadPromises = files.filter(file => !file.skip).map(file => this.uploadBlob(file));
+    await Promise.all(uploadPromises);
+
+    if (!options.useWorkflow) {
+      const fileTree = this.composeFileTree(files);
+
+      return this.getBranch()
+        .then(branchData => this.updateTree(branchData.commit.sha, '/', fileTree))
+        .then(changeTree => this.commit(options.commitMessage, changeTree))
+        .then(response => this.patchBranch(this.branch, response.sha));
+    } else {
+      const mediaFilesList = mediaFiles.map(({ sha, path }) => ({
+        path: trimStart(path, '/'),
+        sha,
+      }));
+      return this.editorialWorkflowGit(files, entry, mediaFilesList, options);
+    }
   }
 
   getFileSha(path, branch) {
@@ -591,12 +596,13 @@ export default class API {
     return this.createPR(commitMessage, branchName);
   }
 
-  async editorialWorkflowGit(fileTree, entry, mediaFilesList, options) {
+  async editorialWorkflowGit(files, entry, mediaFilesList, options) {
     const contentKey = this.generateContentKey(options.collectionName, entry.slug);
     const branchName = this.generateBranchName(contentKey);
     const unpublished = options.unpublished || false;
     if (!unpublished) {
       // Open new editorial review workflow for this entry - Create new metadata and commit to new branch
+      const fileTree = this.composeFileTree(files);
       const userPromise = this.user();
       const branchData = await this.getBranch();
       const changeTree = await this.updateTree(branchData.commit.sha, '/', fileTree);
@@ -640,20 +646,18 @@ export default class API {
       });
     } else {
       // Entry is already on editorial review workflow - just update metadata and commit to existing branch
+      const metadata = await this.retrieveMetadata(contentKey);
+      // mark media files to remove
+      const metadataMediaFiles = get(metadata, 'objects.files', []);
+      const mediaFilesToRemove = differenceBy(metadataMediaFiles, mediaFilesList, 'path').map(
+        file => ({ ...file, remove: true }),
+      );
+      const fileTree = this.composeFileTree(files.concat(mediaFilesToRemove));
       const branchData = await this.getBranch(branchName);
       const changeTree = await this.updateTree(branchData.commit.sha, '/', fileTree);
-      const commitPromise = this.commit(options.commitMessage, changeTree);
-      const metadataPromise = this.retrieveMetadata(contentKey);
-      const [commit, metadata] = await Promise.all([commitPromise, metadataPromise]);
+      const commit = await this.commit(options.commitMessage, changeTree);
       const { title, description } = options.parsedData || {};
 
-      // remove any existing media files
-      const metadataFiles = get(metadata.objects, 'files', []);
-      await Promise.all(
-        metadataFiles.map(file =>
-          this.deleteFile(file.path, options.commitMessage, { branch: branchName }),
-        ),
-      );
       const pr = metadata.pr ? { ...metadata.pr, head: commit.sha } : undefined;
       const objects = {
         entry: { path: entry.path, sha: entry.sha },
@@ -1073,26 +1077,30 @@ export default class API {
       for (let i = 0, len = tree.tree.length; i < len; i++) {
         obj = tree.tree[i];
         if ((fileOrDir = fileTree[obj.path])) {
-          // eslint-disable-line no-cond-assign
           added[obj.path] = true;
+
           if (fileOrDir.file) {
-            updates.push({ path: obj.path, mode: obj.mode, type: obj.type, sha: fileOrDir.sha });
+            const sha = fileOrDir.remove ? null : fileOrDir.sha;
+            updates.push({ path: obj.path, mode: obj.mode, type: obj.type, sha });
           } else {
             updates.push(this.updateTree(obj.sha, obj.path, fileOrDir));
           }
         }
       }
+
       for (filename in fileTree) {
         fileOrDir = fileTree[filename];
         if (added[filename]) {
           continue;
         }
-        updates.push(
-          fileOrDir.file
-            ? { path: filename, mode: '100644', type: 'blob', sha: fileOrDir.sha }
-            : this.updateTree(null, filename, fileOrDir),
-        );
+
+        if (fileOrDir.file) {
+          updates.push({ path: filename, mode: '100644', type: 'blob', sha: fileOrDir.sha });
+        } else {
+          updates.push(this.updateTree(null, filename, fileOrDir));
+        }
       }
+
       return Promise.all(updates)
         .then(tree => this.createTree(sha, tree))
         .then(response => ({

--- a/packages/netlify-cms-backend-github/src/API.js
+++ b/packages/netlify-cms-backend-github/src/API.js
@@ -1,6 +1,6 @@
 import { Base64 } from 'js-base64';
 import semaphore from 'semaphore';
-import { find, flow, get, hasIn, initial, last, partial, result, uniq } from 'lodash';
+import { find, flow, get, hasIn, initial, last, partial, result } from 'lodash';
 import { map } from 'lodash/fp';
 import {
   getAllResponses,
@@ -293,7 +293,7 @@ export default class API {
     return text;
   }
 
-  async getMediaDisplayURL(sha, path) {
+  async getMediaAsBlob(sha, path) {
     const response = await this.fetchBlob(sha, this.repoURL);
     let blob;
     if (path.match(/.svg$/)) {
@@ -302,6 +302,11 @@ export default class API {
     } else {
       blob = await response.blob();
     }
+    return blob;
+  }
+
+  async getMediaDisplayURL(sha, path) {
+    const blob = await this.getMediaAsBlob(sha, path);
 
     return URL.createObjectURL(blob);
   }
@@ -586,7 +591,7 @@ export default class API {
     return this.createPR(commitMessage, branchName);
   }
 
-  async editorialWorkflowGit(fileTree, entry, filesList, options) {
+  async editorialWorkflowGit(fileTree, entry, mediaFilesList, options) {
     const contentKey = this.generateContentKey(options.collectionName, entry.slug);
     const branchName = this.generateBranchName(contentKey);
     const unpublished = options.unpublished || false;
@@ -629,7 +634,7 @@ export default class API {
             path: entry.path,
             sha: entry.sha,
           },
-          files: filesList,
+          files: mediaFilesList,
         },
         timeStamp: new Date().toISOString(),
       });
@@ -641,12 +646,18 @@ export default class API {
       const metadataPromise = this.retrieveMetadata(contentKey);
       const [commit, metadata] = await Promise.all([commitPromise, metadataPromise]);
       const { title, description } = options.parsedData || {};
+
+      // remove any existing media files
       const metadataFiles = get(metadata.objects, 'files', []);
-      const files = [...metadataFiles, ...filesList];
+      await Promise.all(
+        metadataFiles.map(file =>
+          this.deleteFile(file.path, options.commitMessage, { branch: branchName }),
+        ),
+      );
       const pr = metadata.pr ? { ...metadata.pr, head: commit.sha } : undefined;
       const objects = {
         entry: { path: entry.path, sha: entry.sha },
-        files: uniq(files),
+        files: mediaFilesList,
       };
       const updatedMetadata = { ...metadata, pr, title, description, objects };
 

--- a/packages/netlify-cms-backend-github/src/__tests__/API.spec.js
+++ b/packages/netlify-cms-backend-github/src/__tests__/API.spec.js
@@ -1,39 +1,378 @@
 import API from '../API';
 
+global.fetch = jest.fn().mockRejectedValue(new Error('should not call fetch inside tests'));
+
 describe('github API', () => {
-  const mockAPI = (api, responses) => {
-    api.request = (path, options = {}) => {
-      const normalizedPath = path.indexOf('?') !== -1 ? path.substr(0, path.indexOf('?')) : path;
-      const response = responses[normalizedPath];
-      return typeof response === 'function'
-        ? Promise.resolve(response(options))
-        : Promise.reject(new Error(`No response for path '${normalizedPath}'`));
-    };
-  };
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
 
-  it('should create PR with correct base branch name when publishing with editorial workflow', () => {
-    let prBaseBranch = null;
-    const api = new API({ branch: 'gh-pages', repo: 'my-repo' });
-    const responses = {
-      '/repos/my-repo/branches/gh-pages': () => ({ commit: { sha: 'def' } }),
-      '/repos/my-repo/git/trees/def': () => ({ tree: [] }),
-      '/repos/my-repo/git/trees': () => ({}),
-      '/repos/my-repo/git/commits': () => ({}),
-      '/repos/my-repo/git/refs': () => ({}),
-      '/repos/my-repo/pulls': pullRequest => {
-        prBaseBranch = JSON.parse(pullRequest.body).base;
-        return { head: { sha: 'cbd' } };
+  describe('editorialWorkflowGit', () => {
+    const mockAPI = (api, responses) => {
+      api.request = (path, options = {}) => {
+        const normalizedPath = path.indexOf('?') !== -1 ? path.substr(0, path.indexOf('?')) : path;
+        const response = responses[normalizedPath];
+        return typeof response === 'function'
+          ? Promise.resolve(response(options))
+          : Promise.reject(new Error(`No response for path '${normalizedPath}'`));
+      };
+    };
+
+    it('should create PR with correct base branch name when publishing with editorial workflow', () => {
+      let prBaseBranch = null;
+      const api = new API({ branch: 'gh-pages', repo: 'my-repo' });
+      const responses = {
+        '/repos/my-repo/branches/gh-pages': () => ({ commit: { sha: 'def' } }),
+        '/repos/my-repo/git/trees/def': () => ({ tree: [] }),
+        '/repos/my-repo/git/trees': () => ({}),
+        '/repos/my-repo/git/commits': () => ({}),
+        '/repos/my-repo/git/refs': () => ({}),
+        '/repos/my-repo/pulls': pullRequest => {
+          prBaseBranch = JSON.parse(pullRequest.body).base;
+          return { head: { sha: 'cbd' } };
+        },
+        '/user': () => ({}),
+        '/repos/my-repo/git/blobs': () => ({}),
+        '/repos/my-repo/git/refs/meta/_netlify_cms': () => ({ object: {} }),
+      };
+      mockAPI(api, responses);
+
+      return expect(
+        api
+          .editorialWorkflowGit([], { slug: 'entry', sha: 'abc' }, null, {})
+          .then(() => prBaseBranch),
+      ).resolves.toEqual('gh-pages');
+    });
+  });
+
+  describe('composeFileTree', () => {
+    it('should return file tree', () => {
+      const api = new API({ branch: 'master', repo: 'owner/repo' });
+      const files = [{ path: 'static/media/image.jpeg' }, { path: 'content/posts/post.md' }];
+
+      expect(api.composeFileTree(files)).toEqual({
+        content: {
+          posts: {
+            'post.md': {
+              file: true,
+              path: 'content/posts/post.md',
+            },
+          },
+        },
+        static: {
+          media: {
+            'image.jpeg': {
+              file: true,
+              path: 'static/media/image.jpeg',
+            },
+          },
+        },
+      });
+    });
+  });
+
+  describe('updateTree', () => {
+    const mockedTrees = {
+      root: {
+        sha: 'root',
+        tree: [
+          {
+            path: 'content',
+            mode: '040000',
+            type: 'tree',
+            sha: 'content',
+          },
+          {
+            path: 'static',
+            mode: '040000',
+            type: 'tree',
+            sha: 'static',
+          },
+        ],
       },
-      '/user': () => ({}),
-      '/repos/my-repo/git/blobs': () => ({}),
-      '/repos/my-repo/git/refs/meta/_netlify_cms': () => ({ object: {} }),
+      content: {
+        sha: 'content',
+        tree: [
+          {
+            path: 'pages',
+            mode: '040000',
+            type: 'tree',
+            sha: 'pages',
+          },
+          {
+            path: 'posts',
+            mode: '040000',
+            type: 'tree',
+            sha: 'posts',
+          },
+        ],
+      },
+      static: {
+        sha: 'static',
+        tree: [
+          {
+            path: 'admin',
+            mode: '040000',
+            type: 'tree',
+            sha: 'admin',
+          },
+          {
+            path: 'images',
+            mode: '040000',
+            type: 'tree',
+            sha: 'images',
+          },
+          {
+            path: 'media',
+            mode: '040000',
+            type: 'tree',
+            sha: 'media',
+          },
+        ],
+      },
+      media: {
+        sha: 'media',
+        tree: [
+          {
+            path: 'image-1.png',
+            mode: '100644',
+            type: 'blob',
+            sha: 'image-1.png',
+            size: 1000,
+          },
+          {
+            path: 'image-2.png',
+            mode: '100644',
+            type: 'blob',
+            sha: 'image-2.png',
+            size: 2000,
+          },
+          {
+            path: 'image-3.png',
+            mode: '100644',
+            type: 'blob',
+            sha: 'image-3.png',
+            size: 3000,
+          },
+        ],
+      },
+      posts: {
+        sha: 'posts',
+        tree: [
+          {
+            path: 'post-1.md',
+            mode: '100644',
+            type: 'blob',
+            sha: 'post-1.md',
+            size: 100,
+          },
+          {
+            path: 'post-2.md',
+            mode: '100644',
+            type: 'blob',
+            sha: 'post-2.md',
+            size: 200,
+          },
+        ],
+      },
     };
-    mockAPI(api, responses);
 
-    return expect(
-      api
-        .editorialWorkflowGit(null, { slug: 'entry', sha: 'abc' }, null, {})
-        .then(() => prBaseBranch),
-    ).resolves.toEqual('gh-pages');
+    it('should create diff trees when updating existing files', async () => {
+      const api = new API({ branch: 'master', repo: 'owner/repo' });
+      api.createTree = jest.fn().mockImplementation(sha => Promise.resolve({ sha }));
+
+      api.getTree = jest.fn().mockImplementation(sha => Promise.resolve(mockedTrees[sha]));
+
+      const files = [{ path: 'content/posts/post-2.md', sha: 'post-2-new-sha.md' }];
+      const fileTree = api.composeFileTree(files);
+
+      await expect(api.updateTree('root', '/', fileTree)).resolves.toEqual({
+        mode: '040000',
+        parentSha: 'root',
+        path: '/',
+        sha: 'root',
+        type: 'tree',
+      });
+      expect(api.getTree).toHaveBeenCalledTimes(3);
+      expect(api.getTree).toHaveBeenCalledWith('root');
+      expect(api.getTree).toHaveBeenCalledWith('content');
+      expect(api.getTree).toHaveBeenCalledWith('posts');
+
+      expect(api.createTree).toHaveBeenCalledTimes(3);
+      // post-2 is a child of posts, and a tree should be created with the new sha
+      expect(api.createTree).toHaveBeenCalledWith('posts', [
+        {
+          path: 'post-2.md',
+          mode: '100644',
+          type: 'blob',
+          sha: 'post-2-new-sha.md',
+        },
+      ]);
+
+      // posts should be a child of content
+      expect(api.createTree).toHaveBeenCalledWith('content', [
+        {
+          path: 'posts',
+          mode: '040000',
+          type: 'tree',
+          sha: 'posts',
+          parentSha: 'posts',
+        },
+      ]);
+
+      // content and media should be children of root
+      expect(api.createTree).toHaveBeenCalledWith('root', [
+        {
+          path: 'content',
+          mode: '040000',
+          type: 'tree',
+          sha: 'content',
+          parentSha: 'content',
+        },
+      ]);
+    });
+
+    it('should create diff trees when adding new files', async () => {
+      const api = new API({ branch: 'master', repo: 'owner/repo' });
+      api.createTree = jest.fn().mockImplementation(sha => Promise.resolve({ sha }));
+
+      api.getTree = jest.fn().mockImplementation(sha => Promise.resolve(mockedTrees[sha]));
+
+      const files = [
+        { path: 'static/media/new-image.jpeg', sha: 'new-image.jpeg' },
+        { path: 'content/posts/new-post.md', sha: 'new-post.md' },
+      ];
+      const fileTree = api.composeFileTree(files);
+
+      await expect(api.updateTree('root', '/', fileTree)).resolves.toEqual({
+        mode: '040000',
+        parentSha: 'root',
+        path: '/',
+        sha: 'root',
+        type: 'tree',
+      });
+      expect(api.getTree).toHaveBeenCalledTimes(5);
+      expect(api.getTree).toHaveBeenCalledWith('root');
+      expect(api.getTree).toHaveBeenCalledWith('content');
+      expect(api.getTree).toHaveBeenCalledWith('posts');
+      expect(api.getTree).toHaveBeenCalledWith('static');
+      expect(api.getTree).toHaveBeenCalledWith('media');
+
+      expect(api.createTree).toHaveBeenCalledTimes(5);
+      // new post should be a child of posts
+      expect(api.createTree).toHaveBeenCalledWith('posts', [
+        {
+          path: 'new-post.md',
+          mode: '100644',
+          type: 'blob',
+          sha: 'new-post.md',
+        },
+      ]);
+
+      // new image should be a child of media
+      expect(api.createTree).toHaveBeenCalledWith('media', [
+        {
+          path: 'new-image.jpeg',
+          mode: '100644',
+          type: 'blob',
+          sha: 'new-image.jpeg',
+        },
+      ]);
+
+      // posts should be a child of content
+      expect(api.createTree).toHaveBeenCalledWith('content', [
+        {
+          path: 'posts',
+          mode: '040000',
+          type: 'tree',
+          sha: 'posts',
+          parentSha: 'posts',
+        },
+      ]);
+
+      // media should be a childe of static
+      expect(api.createTree).toHaveBeenCalledWith('static', [
+        {
+          path: 'media',
+          mode: '040000',
+          type: 'tree',
+          sha: 'media',
+          parentSha: 'media',
+        },
+      ]);
+
+      // content and media should be children of root
+      expect(api.createTree).toHaveBeenCalledWith('root', [
+        {
+          path: 'content',
+          mode: '040000',
+          type: 'tree',
+          sha: 'content',
+          parentSha: 'content',
+        },
+        {
+          path: 'static',
+          mode: '040000',
+          type: 'tree',
+          sha: 'static',
+          parentSha: 'static',
+        },
+      ]);
+    });
+
+    it('should create updated full trees when removing files', async () => {
+      const api = new API({ branch: 'master', repo: 'owner/repo' });
+      api.createTree = jest.fn().mockImplementation(sha => Promise.resolve({ sha }));
+
+      api.getTree = jest.fn().mockImplementation(sha => Promise.resolve(mockedTrees[sha]));
+
+      const files = [{ path: 'static/media/image-3.png', sha: 'image-3.png', remove: true }];
+      const fileTree = api.composeFileTree(files);
+
+      await expect(api.updateTree('root', '/', fileTree)).resolves.toEqual({
+        mode: '040000',
+        parentSha: 'root',
+        path: '/',
+        sha: 'root',
+        type: 'tree',
+      });
+      expect(api.getTree).toHaveBeenCalledTimes(3);
+      expect(api.getTree).toHaveBeenCalledWith('static');
+      expect(api.getTree).toHaveBeenCalledWith('media');
+
+      expect(api.createTree).toHaveBeenCalledTimes(3);
+
+      // should create a tree with no based tree and with all images except the one removed
+      expect(api.createTree).toHaveBeenCalledWith('media', [
+        {
+          path: 'image-3.png',
+          mode: '100644',
+          type: 'blob',
+          sha: null,
+        },
+      ]);
+
+      // media should be a childe of static
+      expect(api.createTree).toHaveBeenCalledWith('static', [
+        {
+          path: 'media',
+          mode: '040000',
+          type: 'tree',
+          sha: 'media',
+          parentSha: 'media',
+        },
+      ]);
+
+      // content and media should be children of root
+      expect(api.createTree).toHaveBeenCalledWith('root', [
+        {
+          path: 'static',
+          mode: '040000',
+          type: 'tree',
+          sha: 'static',
+          parentSha: 'static',
+        },
+      ]);
+    });
   });
 });

--- a/packages/netlify-cms-backend-github/src/__tests__/implementation.spec.js
+++ b/packages/netlify-cms-backend-github/src/__tests__/implementation.spec.js
@@ -1,0 +1,118 @@
+import GitHubImplementation from '../implementation';
+
+describe('github backend implementation', () => {
+  describe('persistMedia', () => {
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    const persistFiles = jest.fn();
+    const mockAPI = {
+      persistFiles,
+    };
+
+    persistFiles.mockImplementation((_, files) => {
+      files.forEach((file, index) => {
+        file.sha = index;
+      });
+    });
+
+    const createObjectURL = jest.fn();
+    global.URL = {
+      createObjectURL,
+    };
+
+    createObjectURL.mockReturnValue('displayURL');
+
+    const config = {
+      getIn: jest.fn().mockImplementation(array => {
+        if (array[0] === 'backend' && array[1] === 'repo') {
+          return 'owner/repo';
+        }
+        if (array[0] === 'backend' && array[1] === 'open_authoring') {
+          return false;
+        }
+        if (array[0] === 'backend' && array[1] === 'branch') {
+          return 'master';
+        }
+      }),
+    };
+
+    beforeEach(() => {
+      jest.clearAllMocks();
+    });
+
+    it('should persist media file when not draft', async () => {
+      const gitHubImplementation = new GitHubImplementation(config);
+      gitHubImplementation.api = mockAPI;
+
+      const mediaFile = {
+        value: 'image.png',
+        fileObj: { size: 100 },
+        path: '/media/image.png',
+      };
+
+      expect.assertions(5);
+      await expect(gitHubImplementation.persistMedia(mediaFile)).resolves.toEqual({
+        id: 0,
+        name: 'image.png',
+        size: 100,
+        displayURL: 'displayURL',
+        path: 'media/image.png',
+        draft: undefined,
+      });
+
+      expect(persistFiles).toHaveBeenCalledTimes(1);
+      expect(persistFiles).toHaveBeenCalledWith(null, [mediaFile], {});
+      expect(createObjectURL).toHaveBeenCalledTimes(1);
+      expect(createObjectURL).toHaveBeenCalledWith(mediaFile.fileObj);
+    });
+
+    it('should not persist media file when draft', async () => {
+      const gitHubImplementation = new GitHubImplementation(config);
+      gitHubImplementation.api = mockAPI;
+
+      createObjectURL.mockReturnValue('displayURL');
+
+      const mediaFile = {
+        value: 'image.png',
+        fileObj: { size: 100 },
+        path: '/media/image.png',
+      };
+
+      expect.assertions(4);
+      await expect(gitHubImplementation.persistMedia(mediaFile, { draft: true })).resolves.toEqual({
+        id: undefined,
+        name: 'image.png',
+        size: 100,
+        displayURL: 'displayURL',
+        path: 'media/image.png',
+        draft: true,
+      });
+
+      expect(persistFiles).toHaveBeenCalledTimes(0);
+      expect(createObjectURL).toHaveBeenCalledTimes(1);
+      expect(createObjectURL).toHaveBeenCalledWith(mediaFile.fileObj);
+    });
+
+    it('should log and throw error on "persistFiles" error', async () => {
+      const gitHubImplementation = new GitHubImplementation(config);
+      gitHubImplementation.api = mockAPI;
+
+      const error = new Error('failed to persist files');
+      persistFiles.mockRejectedValue(error);
+
+      const mediaFile = {
+        value: 'image.png',
+        fileObj: { size: 100 },
+        path: '/media/image.png',
+      };
+
+      expect.assertions(5);
+      await expect(gitHubImplementation.persistMedia(mediaFile)).rejects.toThrowError(error);
+
+      expect(persistFiles).toHaveBeenCalledTimes(1);
+      expect(createObjectURL).toHaveBeenCalledTimes(0);
+      expect(console.error).toHaveBeenCalledTimes(1);
+      expect(console.error).toHaveBeenCalledWith(error);
+    });
+  });
+});

--- a/packages/netlify-cms-backend-github/src/implementation.js
+++ b/packages/netlify-cms-backend-github/src/implementation.js
@@ -4,6 +4,7 @@ import semaphore from 'semaphore';
 import { stripIndent } from 'common-tags';
 import { asyncLock } from 'netlify-cms-lib-util';
 import AuthenticationPage from './AuthenticationPage';
+import { get } from 'lodash';
 import API from './API';
 import GraphQLAPI from './GraphQLAPI';
 
@@ -346,6 +347,24 @@ export default class GitHub {
     return this.api.deleteFile(path, commitMessage, options);
   }
 
+  async getMediaFiles(data) {
+    const files = get(data, 'metaData.objects.files', []);
+    const mediaFiles = await Promise.all(
+      files.map(file =>
+        this.api.getMediaAsBlob(file.sha, file.path).then(blob => {
+          const name = file.path.substring(file.path.lastIndexOf('/') + 1);
+          return {
+            ...file,
+            id: file.sha,
+            file: new File([blob], name),
+          };
+        }),
+      ),
+    );
+
+    return mediaFiles;
+  }
+
   unpublishedEntries() {
     return this.api
       .listUnpublishedBranches()
@@ -365,10 +384,9 @@ export default class GitHub {
                       resolve(null);
                       sem.leave();
                     } else {
-                      const path = data.metaData.objects.entry.path;
                       resolve({
                         slug,
-                        file: { path },
+                        file: { path: data.metaData.objects.entry.path },
                         data: data.fileData,
                         metaData: data.metaData,
                         isModification: data.isModification,
@@ -394,18 +412,18 @@ export default class GitHub {
       });
   }
 
-  unpublishedEntry(collection, slug) {
+  async unpublishedEntry(collection, slug) {
     const contentKey = this.api.generateContentKey(collection.get('name'), slug);
-    return this.api.readUnpublishedBranchFile(contentKey).then(data => {
-      if (!data) return null;
-      return {
-        slug,
-        file: { path: data.metaData.objects.entry.path },
-        data: data.fileData,
-        metaData: data.metaData,
-        isModification: data.isModification,
-      };
-    });
+    const data = await this.api.readUnpublishedBranchFile(contentKey);
+    const mediaFiles = await this.getMediaFiles(data);
+    return {
+      slug,
+      file: { path: data.metaData.objects.entry.path },
+      data: data.fileData,
+      metaData: data.metaData,
+      mediaFiles,
+      isModification: data.isModification,
+    };
   }
 
   /**

--- a/packages/netlify-cms-backend-github/src/implementation.js
+++ b/packages/netlify-cms-backend-github/src/implementation.js
@@ -316,12 +316,7 @@ export default class GitHub {
   persistEntry(entry, mediaFiles = [], options = {}) {
     // persistEntry is a transactional operation
     return this.runWithLock(
-      () =>
-        this.api.persistFiles(
-          entry,
-          mediaFiles.map(file => ({ ...file, path: trimStart(file.path, '/') })),
-          options,
-        ),
+      () => this.api.persistFiles(entry, mediaFiles, options),
       'Failed to acquire persist entry lock',
     );
   }
@@ -358,10 +353,15 @@ export default class GitHub {
       files.map(file =>
         this.api.getMediaAsBlob(file.sha, file.path).then(blob => {
           const name = file.path.substring(file.path.lastIndexOf('/') + 1);
+          const fileObj = new File([blob], name);
           return {
-            ...file,
             id: file.sha,
-            file: new File([blob], name),
+            sha: file.sha,
+            displayURL: URL.createObjectURL(fileObj),
+            path: file.path,
+            name: name,
+            size: fileObj.size,
+            file: fileObj,
           };
         }),
       ),

--- a/packages/netlify-cms-backend-github/src/implementation.js
+++ b/packages/netlify-cms-backend-github/src/implementation.js
@@ -322,7 +322,9 @@ export default class GitHub {
 
   async persistMedia(mediaFile, options = {}) {
     try {
-      await this.api.persistFiles(null, [mediaFile], options);
+      if (!options.draft) {
+        await this.api.persistFiles(null, [mediaFile], options);
+      }
 
       const { sha, value, path, fileObj } = mediaFile;
       const displayURL = URL.createObjectURL(fileObj);
@@ -332,6 +334,7 @@ export default class GitHub {
         size: fileObj.size,
         displayURL,
         path: trimStart(path, '/'),
+        draft: options.draft,
       };
     } catch (error) {
       console.error(error);

--- a/packages/netlify-cms-backend-github/src/implementation.js
+++ b/packages/netlify-cms-backend-github/src/implementation.js
@@ -316,7 +316,12 @@ export default class GitHub {
   persistEntry(entry, mediaFiles = [], options = {}) {
     // persistEntry is a transactional operation
     return this.runWithLock(
-      () => this.api.persistFiles(entry, mediaFiles, options),
+      () =>
+        this.api.persistFiles(
+          entry,
+          mediaFiles.map(file => ({ ...file, path: trimStart(file.path, '/') })),
+          options,
+        ),
       'Failed to acquire persist entry lock',
     );
   }

--- a/packages/netlify-cms-core/src/actions/__tests__/entries.spec.js
+++ b/packages/netlify-cms-core/src/actions/__tests__/entries.spec.js
@@ -1,5 +1,23 @@
-import { fromJS } from 'immutable';
-import { createEmptyDraftData } from '../entries';
+import { fromJS, List, Map } from 'immutable';
+import {
+  createEmptyDraftData,
+  retrieveLocalBackup,
+  persistLocalBackup,
+  localBackupRetrieved,
+  discardDraft,
+  DRAFT_DISCARD,
+} from '../entries';
+
+jest.mock('coreSrc/backend');
+jest.mock('Reducers', () => {
+  return {
+    getAsset: jest.fn().mockReturnValue({}),
+  };
+});
+jest.mock('../mediaLibrary');
+jest.mock('ValueObjects/AssetProxy');
+jest.mock('../media');
+jest.mock('netlify-cms-lib-util');
 
 describe('entries', () => {
   describe('createEmptyDraftData', () => {
@@ -77,6 +95,113 @@ describe('entries', () => {
         },
       ]);
       expect(createEmptyDraftData(fields)).toEqual({});
+    });
+  });
+
+  const dispatch = jest.fn();
+  const getState = jest.fn();
+
+  describe('discardDraft', () => {
+    beforeEach(() => {
+      jest.clearAllMocks();
+    });
+
+    it('should delete media files on discard draft', () => {
+      const { deleteMedia } = require('../mediaLibrary');
+
+      deleteMedia.mockImplementation(file => file);
+
+      const mediaFiles = [{ draft: false }, { draft: true }];
+      const state = {
+        config: {},
+        entryDraft: Map({
+          mediaFiles: List(mediaFiles),
+        }),
+      };
+
+      getState.mockReturnValue(state);
+
+      discardDraft()(dispatch, getState);
+
+      expect(deleteMedia).toHaveBeenCalledTimes(1);
+      expect(deleteMedia).toHaveBeenCalledWith(mediaFiles[1]);
+
+      expect(dispatch).toHaveBeenCalledTimes(2);
+      expect(dispatch).toHaveBeenCalledWith(mediaFiles[1]);
+      expect(dispatch).toHaveBeenCalledWith({ type: DRAFT_DISCARD });
+    });
+  });
+
+  describe('persistLocalBackup', () => {
+    beforeEach(() => {
+      jest.clearAllMocks();
+    });
+
+    it('should persist local backup with media files', () => {
+      const { currentBackend } = require('coreSrc/backend');
+      const { getAsset } = require('Reducers');
+
+      const backend = {
+        persistLocalDraftBackup: jest.fn((...args) => args),
+      };
+
+      const state = { config: {} };
+
+      currentBackend.mockReturnValue(backend);
+      getAsset.mockImplementation((state, path) => path);
+      getState.mockReturnValue(state);
+
+      const entry = Map();
+      const collection = Map();
+      const mediaFiles = [{ public_path: '/static/media/image.png' }];
+
+      const result = persistLocalBackup(entry, collection, mediaFiles)(dispatch, getState);
+
+      expect(result).toEqual([entry, collection, mediaFiles, ['/static/media/image.png']]);
+    });
+  });
+
+  describe('retrieveLocalBackup', () => {
+    beforeEach(() => {
+      jest.clearAllMocks();
+    });
+
+    it('should retrieve media files with local backup', async () => {
+      const { currentBackend } = require('coreSrc/backend');
+      const { createAssetProxy } = require('ValueObjects/AssetProxy');
+      const { addAsset } = require('../media');
+
+      const backend = {
+        getLocalDraftBackup: jest.fn((...args) => args),
+      };
+
+      const state = { config: {} };
+
+      currentBackend.mockReturnValue(backend);
+      createAssetProxy.mockImplementation((value, fileObj) => ({ value, fileObj }));
+      addAsset.mockImplementation(asset => asset);
+      getState.mockReturnValue(state);
+
+      const collection = Map({
+        name: 'collection',
+      });
+      const slug = 'slug';
+
+      const entry = {};
+      const mediaFiles = [{ public_path: '/static/media/image.png' }];
+      const assets = [{ value: 'image.png', fileObj: {} }];
+
+      backend.getLocalDraftBackup.mockReturnValue({ entry, mediaFiles, assets });
+
+      await retrieveLocalBackup(collection, slug)(dispatch, getState);
+
+      expect(createAssetProxy).toHaveBeenCalledTimes(1);
+      expect(createAssetProxy).toHaveBeenCalledWith(assets[0].value, assets[0].fileObj);
+      expect(addAsset).toHaveBeenCalledTimes(1);
+      expect(addAsset).toHaveBeenCalledWith(assets[0]);
+      expect(dispatch).toHaveBeenCalledTimes(2);
+      expect(dispatch).toHaveBeenCalledWith(assets[0]);
+      expect(dispatch).toHaveBeenCalledWith(localBackupRetrieved(entry, mediaFiles));
     });
   });
 });

--- a/packages/netlify-cms-core/src/actions/__tests__/entries.spec.js
+++ b/packages/netlify-cms-core/src/actions/__tests__/entries.spec.js
@@ -169,7 +169,7 @@ describe('entries', () => {
     it('should retrieve media files with local backup', async () => {
       const { currentBackend } = require('coreSrc/backend');
       const { createAssetProxy } = require('ValueObjects/AssetProxy');
-      const { addAsset } = require('../media');
+      const { addAssets } = require('../media');
 
       const backend = {
         getLocalDraftBackup: jest.fn((...args) => args),
@@ -179,7 +179,7 @@ describe('entries', () => {
 
       currentBackend.mockReturnValue(backend);
       createAssetProxy.mockImplementation((value, fileObj) => ({ value, fileObj }));
-      addAsset.mockImplementation(asset => asset);
+      addAssets.mockImplementation(assets => assets);
       getState.mockReturnValue(state);
 
       const collection = Map({
@@ -197,10 +197,10 @@ describe('entries', () => {
 
       expect(createAssetProxy).toHaveBeenCalledTimes(1);
       expect(createAssetProxy).toHaveBeenCalledWith(assets[0].value, assets[0].fileObj);
-      expect(addAsset).toHaveBeenCalledTimes(1);
-      expect(addAsset).toHaveBeenCalledWith(assets[0]);
+      expect(addAssets).toHaveBeenCalledTimes(1);
+      expect(addAssets).toHaveBeenCalledWith(assets);
       expect(dispatch).toHaveBeenCalledTimes(2);
-      expect(dispatch).toHaveBeenCalledWith(assets[0]);
+      expect(dispatch).toHaveBeenCalledWith(assets);
       expect(dispatch).toHaveBeenCalledWith(localBackupRetrieved(entry, mediaFiles));
     });
   });

--- a/packages/netlify-cms-core/src/actions/editorialWorkflow.js
+++ b/packages/netlify-cms-core/src/actions/editorialWorkflow.js
@@ -3,11 +3,11 @@ import { actions as notifActions } from 'redux-notifications';
 import { BEGIN, COMMIT, REVERT } from 'redux-optimist';
 import { serializeValues } from 'Lib/serializeEntryValues';
 import { currentBackend } from 'coreSrc/backend';
-import { getAsset, selectPublishedSlugs, selectUnpublishedSlugs } from 'Reducers';
+import { selectPublishedSlugs, selectUnpublishedSlugs } from 'Reducers';
 import { selectFields } from 'Reducers/collections';
 import { EDITORIAL_WORKFLOW } from 'Constants/publishModes';
 import { EDITORIAL_WORKFLOW_ERROR } from 'netlify-cms-lib-util';
-import { loadEntry } from './entries';
+import { loadEntry, getMediaAssets } from './entries';
 import ValidationErrorTypes from 'Constants/validationErrorTypes';
 
 const { notifSend } = notifActions;
@@ -314,7 +314,7 @@ export function persistUnpublishedEntry(collection, existingUnpublishedEntry) {
 
     const backend = currentBackend(state.config);
     const transactionID = uuid();
-    const assetProxies = entryDraft.get('mediaFiles').map(path => getAsset(state, path));
+    const assetProxies = getMediaAssets(state, entryDraft.get('mediaFiles'));
     const entry = entryDraft.get('entry');
 
     /**

--- a/packages/netlify-cms-core/src/actions/editorialWorkflow.js
+++ b/packages/netlify-cms-core/src/actions/editorialWorkflow.js
@@ -8,6 +8,7 @@ import { selectFields } from 'Reducers/collections';
 import { EDITORIAL_WORKFLOW } from 'Constants/publishModes';
 import { EDITORIAL_WORKFLOW_ERROR } from 'netlify-cms-lib-util';
 import { loadEntry, getMediaAssets } from './entries';
+import { persistMedia } from './mediaLibrary';
 import ValidationErrorTypes from 'Constants/validationErrorTypes';
 
 const { notifSend } = notifActions;
@@ -236,7 +237,13 @@ export function loadUnpublishedEntry(collection, slug) {
     dispatch(unpublishedEntryLoading(collection, slug));
     backend
       .unpublishedEntry(collection, slug)
-      .then(entry => dispatch(unpublishedEntryLoaded(collection, entry)))
+      .then(entry => {
+        const mediaFiles = entry.mediaFiles;
+        mediaFiles.forEach(mediaFile => {
+          dispatch(persistMedia(mediaFile.file));
+        });
+        dispatch(unpublishedEntryLoaded(collection, entry));
+      })
       .catch(error => {
         if (error.name === EDITORIAL_WORKFLOW_ERROR && error.notUnderEditorialWorkflow) {
           dispatch(unpublishedEntryRedirected(collection, slug));

--- a/packages/netlify-cms-core/src/actions/entries.js
+++ b/packages/netlify-cms-core/src/actions/entries.js
@@ -9,7 +9,10 @@ import { selectFields } from 'Reducers/collections';
 import { selectCollectionEntriesCursor } from 'Reducers/cursors';
 import { Cursor } from 'netlify-cms-lib-util';
 import { createEntry } from 'ValueObjects/Entry';
+import { createAssetProxy } from 'ValueObjects/AssetProxy';
 import ValidationErrorTypes from 'Constants/validationErrorTypes';
+import { deleteMedia } from './mediaLibrary';
+import { addAsset } from './media';
 
 const { notifSend } = notifActions;
 
@@ -41,6 +44,9 @@ export const ENTRY_PERSIST_FAILURE = 'ENTRY_PERSIST_FAILURE';
 export const ENTRY_DELETE_REQUEST = 'ENTRY_DELETE_REQUEST';
 export const ENTRY_DELETE_SUCCESS = 'ENTRY_DELETE_SUCCESS';
 export const ENTRY_DELETE_FAILURE = 'ENTRY_DELETE_FAILURE';
+
+export const ADD_DRAFT_ENTRY_MEDIA_FILE = 'ADD_DRAFT_ENTRY_MEDIA_FILE';
+export const REMOVE_DRAFT_ENTRY_MEDIA_FILE = 'REMOVE_DRAFT_ENTRY_MEDIA_FILE';
 
 /*
  * Simple Action Creators (Internal)
@@ -185,16 +191,23 @@ export function emptyDraftCreated(entry) {
 /*
  * Exported simple Action Creators
  */
-export function createDraftFromEntry(entry, metadata) {
+export function createDraftFromEntry(entry, metadata, mediaFiles) {
   return {
     type: DRAFT_CREATE_FROM_ENTRY,
-    payload: { entry, metadata },
+    payload: { entry, metadata, mediaFiles },
   };
 }
 
 export function discardDraft() {
-  return {
-    type: DRAFT_DISCARD,
+  return (dispatch, getState) => {
+    const state = getState();
+    const mediaDrafts = state.entryDraft.get('mediaFiles').filter(file => file.draft);
+
+    mediaDrafts.forEach(file => {
+      dispatch(deleteMedia(file));
+    });
+
+    dispatch({ type: DRAFT_DISCARD });
   };
 }
 
@@ -223,10 +236,10 @@ export function clearFieldErrors() {
   return { type: DRAFT_CLEAR_ERRORS };
 }
 
-export function localBackupRetrieved(entry) {
+export function localBackupRetrieved(entry, mediaFiles) {
   return {
     type: DRAFT_LOCAL_BACKUP_RETRIEVED,
-    payload: { entry },
+    payload: { entry, mediaFiles },
   };
 }
 
@@ -236,11 +249,23 @@ export function loadLocalBackup() {
   };
 }
 
-export function persistLocalBackup(entry, collection) {
+export function addDraftEntryMediaFile(file) {
+  return { type: ADD_DRAFT_ENTRY_MEDIA_FILE, payload: file };
+}
+
+export function removeDraftEntryMediaFile(file) {
+  return { type: REMOVE_DRAFT_ENTRY_MEDIA_FILE, payload: file };
+}
+
+export function persistLocalBackup(entry, collection, mediaFiles) {
   return (dispatch, getState) => {
     const state = getState();
     const backend = currentBackend(state.config);
-    return backend.persistLocalDraftBackup(entry, collection);
+
+    // persist any pending related media files and assets
+    const assets = getMediaAssets(state, mediaFiles);
+
+    return backend.persistLocalDraftBackup(entry, collection, mediaFiles, assets);
   };
 }
 
@@ -248,9 +273,16 @@ export function retrieveLocalBackup(collection, slug) {
   return async (dispatch, getState) => {
     const state = getState();
     const backend = currentBackend(state.config);
-    const entry = await backend.getLocalDraftBackup(collection, slug);
+    const { entry, mediaFiles, assets } = await backend.getLocalDraftBackup(collection, slug);
+
     if (entry) {
-      return dispatch(localBackupRetrieved(entry));
+      // load any pending related media files and assets
+      const assetProxies = await Promise.all(
+        assets.map(asset => createAssetProxy(asset.value, asset.fileObj)),
+      );
+      assetProxies.forEach(assetProxy => dispatch(addAsset(assetProxy)));
+
+      return dispatch(localBackupRetrieved(entry, mediaFiles));
     }
   };
 }
@@ -462,6 +494,10 @@ export function createEmptyDraftData(fields, withNameKey = true) {
   }, {});
 }
 
+export function getMediaAssets(state, mediaFiles) {
+  return mediaFiles.map(file => getAsset(state, file.public_path));
+}
+
 export function persistEntry(collection) {
   return (dispatch, getState) => {
     const state = getState();
@@ -491,7 +527,7 @@ export function persistEntry(collection) {
     }
 
     const backend = currentBackend(state.config);
-    const assetProxies = entryDraft.get('mediaFiles').map(path => getAsset(state, path));
+    const assetProxies = getMediaAssets(state, entryDraft.get('mediaFiles'));
     const entry = entryDraft.get('entry');
 
     /**

--- a/packages/netlify-cms-core/src/actions/entries.js
+++ b/packages/netlify-cms-core/src/actions/entries.js
@@ -12,7 +12,7 @@ import { createEntry } from 'ValueObjects/Entry';
 import { createAssetProxy } from 'ValueObjects/AssetProxy';
 import ValidationErrorTypes from 'Constants/validationErrorTypes';
 import { deleteMedia } from './mediaLibrary';
-import { addAsset } from './media';
+import { addAssets } from './media';
 
 const { notifSend } = notifActions;
 
@@ -46,6 +46,7 @@ export const ENTRY_DELETE_SUCCESS = 'ENTRY_DELETE_SUCCESS';
 export const ENTRY_DELETE_FAILURE = 'ENTRY_DELETE_FAILURE';
 
 export const ADD_DRAFT_ENTRY_MEDIA_FILE = 'ADD_DRAFT_ENTRY_MEDIA_FILE';
+export const ADD_DRAFT_ENTRY_MEDIA_FILES = 'ADD_DRAFT_ENTRY_MEDIA_FILES';
 export const REMOVE_DRAFT_ENTRY_MEDIA_FILE = 'REMOVE_DRAFT_ENTRY_MEDIA_FILE';
 
 /*
@@ -253,6 +254,10 @@ export function addDraftEntryMediaFile(file) {
   return { type: ADD_DRAFT_ENTRY_MEDIA_FILE, payload: file };
 }
 
+export function addDraftEntryMediaFiles(files) {
+  return { type: ADD_DRAFT_ENTRY_MEDIA_FILES, payload: files };
+}
+
 export function removeDraftEntryMediaFile(file) {
   return { type: REMOVE_DRAFT_ENTRY_MEDIA_FILE, payload: file };
 }
@@ -280,7 +285,7 @@ export function retrieveLocalBackup(collection, slug) {
       const assetProxies = await Promise.all(
         assets.map(asset => createAssetProxy(asset.value, asset.fileObj)),
       );
-      assetProxies.forEach(assetProxy => dispatch(addAsset(assetProxy)));
+      dispatch(addAssets(assetProxies));
 
       return dispatch(localBackupRetrieved(entry, mediaFiles));
     }

--- a/packages/netlify-cms-core/src/actions/media.js
+++ b/packages/netlify-cms-core/src/actions/media.js
@@ -1,5 +1,10 @@
+export const ADD_ASSETS = 'ADD_ASSETS';
 export const ADD_ASSET = 'ADD_ASSET';
 export const REMOVE_ASSET = 'REMOVE_ASSET';
+
+export function addAssets(assets) {
+  return { type: ADD_ASSETS, payload: assets };
+}
 
 export function addAsset(assetProxy) {
   return { type: ADD_ASSET, payload: assetProxy };

--- a/packages/netlify-cms-core/src/actions/mediaLibrary.js
+++ b/packages/netlify-cms-core/src/actions/mediaLibrary.js
@@ -29,6 +29,7 @@ export const MEDIA_DELETE_FAILURE = 'MEDIA_DELETE_FAILURE';
 export const MEDIA_DISPLAY_URL_REQUEST = 'MEDIA_DISPLAY_URL_REQUEST';
 export const MEDIA_DISPLAY_URL_SUCCESS = 'MEDIA_DISPLAY_URL_SUCCESS';
 export const MEDIA_DISPLAY_URL_FAILURE = 'MEDIA_DISPLAY_URL_FAILURE';
+export const ADD_MEDIA_FILES_TO_LIBRARY = 'ADD_MEDIA_FILES_TO_LIBRARY';
 
 export function createMediaLibrary(instance) {
   const api = {
@@ -200,7 +201,12 @@ export function persistMedia(file, opts = {}) {
         const displayURL = asset.displayURL || URL.createObjectURL(file);
 
         dispatch(
-          addDraftEntryMediaFile({ id: assetId, draft, public_path: assetProxy.public_path }),
+          addDraftEntryMediaFile({
+            ...asset,
+            id: assetId,
+            draft,
+            public_path: assetProxy.public_path,
+          }),
         );
 
         return dispatch(
@@ -349,6 +355,13 @@ export function mediaPersisted(asset, opts = {}) {
   return {
     type: MEDIA_PERSIST_SUCCESS,
     payload: { file: asset, privateUpload },
+  };
+}
+
+export function addMediaFilesToLibrary(mediaFiles) {
+  return {
+    type: ADD_MEDIA_FILES_TO_LIBRARY,
+    payload: { mediaFiles },
   };
 }
 

--- a/packages/netlify-cms-core/src/actions/mediaLibrary.js
+++ b/packages/netlify-cms-core/src/actions/mediaLibrary.js
@@ -2,10 +2,12 @@ import { Map } from 'immutable';
 import { actions as notifActions } from 'redux-notifications';
 import { resolveMediaFilename, getBlobSHA } from 'netlify-cms-lib-util';
 import { currentBackend } from 'coreSrc/backend';
+import { EDITORIAL_WORKFLOW } from 'Constants/publishModes';
 import { createAssetProxy } from 'ValueObjects/AssetProxy';
 import { selectIntegration } from 'Reducers';
 import { getIntegrationProvider } from 'Integrations';
 import { addAsset } from './media';
+import { addDraftEntryMediaFile, removeDraftEntryMediaFile } from './entries';
 import { sanitizeSlug } from 'Lib/urlHelper';
 
 const { notifSend } = notifActions;
@@ -186,14 +188,34 @@ export function persistMedia(file, opts = {}) {
       const id = await getBlobSHA(file);
       const assetProxy = await createAssetProxy(fileName, file, false, privateUpload);
       dispatch(addAsset(assetProxy));
+
+      const entry = state.entryDraft.get('entry');
+      const useWorkflow = state.config.getIn(['publish_mode']) === EDITORIAL_WORKFLOW;
+      const draft = entry && !entry.isEmpty() && useWorkflow;
+
       if (!integration) {
-        const asset = await backend.persistMedia(state.config, assetProxy);
+        const asset = await backend.persistMedia(state.config, assetProxy, draft);
+
+        const assetId = asset.id || id;
         const displayURL = asset.displayURL || URL.createObjectURL(file);
-        return dispatch(mediaPersisted({ id, displayURL, ...asset }));
+
+        dispatch(
+          addDraftEntryMediaFile({ id: assetId, draft, public_path: assetProxy.public_path }),
+        );
+
+        return dispatch(
+          mediaPersisted({
+            ...asset,
+            id: assetId,
+            displayURL,
+            draft,
+          }),
+        );
       }
+
       return dispatch(
         mediaPersisted(
-          { id, displayURL: URL.createObjectURL(file), ...assetProxy.asset },
+          { id, displayURL: URL.createObjectURL(file), ...assetProxy.asset, draft },
           { privateUpload },
         ),
       );
@@ -213,37 +235,18 @@ export function persistMedia(file, opts = {}) {
 
 export function deleteMedia(file, opts = {}) {
   const { privateUpload } = opts;
-  return (dispatch, getState) => {
+  return async (dispatch, getState) => {
     const state = getState();
     const backend = currentBackend(state.config);
     const integration = selectIntegration(state, null, 'assetStore');
     if (integration) {
       const provider = getIntegrationProvider(state.integrations, backend.getToken, integration);
       dispatch(mediaDeleting());
-      return provider
-        .delete(file.id)
-        .then(() => {
-          return dispatch(mediaDeleted(file, { privateUpload }));
-        })
-        .catch(error => {
-          console.error(error);
-          dispatch(
-            notifSend({
-              message: `Failed to delete media: ${error.message}`,
-              kind: 'danger',
-              dismissAfter: 8000,
-            }),
-          );
-          return dispatch(mediaDeleteFailed({ privateUpload }));
-        });
-    }
-    dispatch(mediaDeleting());
-    return backend
-      .deleteMedia(state.config, file.path)
-      .then(() => {
-        return dispatch(mediaDeleted(file));
-      })
-      .catch(error => {
+
+      try {
+        await provider.delete(file.id);
+        return dispatch(mediaDeleted(file, { privateUpload }));
+      } catch (error) {
         console.error(error);
         dispatch(
           notifSend({
@@ -252,8 +255,30 @@ export function deleteMedia(file, opts = {}) {
             dismissAfter: 8000,
           }),
         );
-        return dispatch(mediaDeleteFailed());
-      });
+        return dispatch(mediaDeleteFailed({ privateUpload }));
+      }
+    }
+    dispatch(mediaDeleting());
+
+    try {
+      dispatch(removeDraftEntryMediaFile({ id: file.id }));
+
+      if (!file.draft) {
+        await backend.deleteMedia(state.config, file.path);
+      }
+
+      return dispatch(mediaDeleted(file));
+    } catch (error) {
+      console.error(error);
+      dispatch(
+        notifSend({
+          message: `Failed to delete media: ${error.message}`,
+          kind: 'danger',
+          dismissAfter: 8000,
+        }),
+      );
+      return dispatch(mediaDeleteFailed());
+    }
   };
 }
 

--- a/packages/netlify-cms-core/src/actions/mediaLibrary.js
+++ b/packages/netlify-cms-core/src/actions/mediaLibrary.js
@@ -6,7 +6,7 @@ import { EDITORIAL_WORKFLOW } from 'Constants/publishModes';
 import { createAssetProxy } from 'ValueObjects/AssetProxy';
 import { selectIntegration } from 'Reducers';
 import { getIntegrationProvider } from 'Integrations';
-import { addAsset } from './media';
+import { addAsset, removeAsset } from './media';
 import { addDraftEntryMediaFile, removeDraftEntryMediaFile } from './entries';
 import { sanitizeSlug } from 'Lib/urlHelper';
 
@@ -261,6 +261,7 @@ export function deleteMedia(file, opts = {}) {
     dispatch(mediaDeleting());
 
     try {
+      dispatch(removeAsset(file.public_path));
       dispatch(removeDraftEntryMediaFile({ id: file.id }));
 
       if (!file.draft) {

--- a/packages/netlify-cms-core/src/backend.js
+++ b/packages/netlify-cms-core/src/backend.js
@@ -406,22 +406,31 @@ export class Backend {
     const key = getEntryBackupKey(collection.get('name'), slug);
     const backup = await localForage.getItem(key);
     if (!backup || !backup.raw.trim()) {
-      return;
+      return {};
     }
-    const { raw, path } = backup;
+    const { raw, path, mediaFiles = [], assets = [] } = backup;
+
     const label = getLabelForFileCollectionEntry(collection, path);
-    return this.entryWithFormat(collection, slug)(
+    const entry = this.entryWithFormat(collection, slug)(
       createEntry(collection.get('name'), slug, path, { raw, label }),
     );
+
+    return { entry, mediaFiles, assets };
   }
 
-  async persistLocalDraftBackup(entry, collection) {
+  async persistLocalDraftBackup(entry, collection, mediaFiles, assets) {
     const key = getEntryBackupKey(collection.get('name'), entry.get('slug'));
     const raw = this.entryToRaw(collection, entry);
     if (!raw.trim()) {
       return;
     }
-    await localForage.setItem(key, { raw, path: entry.get('path') });
+
+    await localForage.setItem(key, {
+      raw,
+      path: entry.get('path'),
+      mediaFiles: mediaFiles.toJS(),
+      assets: assets.toJS(),
+    });
     return localForage.setItem(getEntryBackupKey(), raw);
   }
 
@@ -669,7 +678,7 @@ export class Backend {
     return this.implementation.persistEntry(entryObj, MediaFiles, opts).then(() => entryObj.slug);
   }
 
-  async persistMedia(config, file) {
+  async persistMedia(config, file, draft) {
     const user = await this.currentUser();
     const options = {
       commitMessage: commitMessageFormatter(
@@ -682,6 +691,7 @@ export class Backend {
         },
         user.useOpenAuthoring,
       ),
+      draft,
     };
     return this.implementation.persistMedia(file, options);
   }

--- a/packages/netlify-cms-core/src/backend.js
+++ b/packages/netlify-cms-core/src/backend.js
@@ -526,6 +526,7 @@ export class Backend {
           isModification: loadedEntry.isModification,
         });
         entry.metaData = loadedEntry.metaData;
+        entry.mediaFiles = loadedEntry.mediaFiles;
         return entry;
       })
       .then(this.entryWithFormat(collection, slug));

--- a/packages/netlify-cms-core/src/components/Editor/Editor.js
+++ b/packages/netlify-cms-core/src/components/Editor/Editor.js
@@ -190,7 +190,11 @@ class Editor extends React.Component {
     }
 
     if (this.props.hasChanged) {
-      this.createBackup(this.props.entryDraft.get('entry'), this.props.collection);
+      this.createBackup(
+        this.props.entryDraft.get('entry'),
+        this.props.collection,
+        this.props.entryDraft.get('mediaFiles'),
+      );
     }
 
     if (prevProps.entry === this.props.entry) return;
@@ -205,7 +209,8 @@ class Editor extends React.Component {
       const values = deserializeValues(entry.get('data'), fields);
       const deserializedEntry = entry.set('data', values);
       const fieldsMetaData = this.props.entryDraft && this.props.entryDraft.get('fieldsMetaData');
-      this.createDraft(deserializedEntry, fieldsMetaData);
+      const mediaFiles = this.props.entryDraft && this.props.entryDraft.get('mediaFiles');
+      this.createDraft(deserializedEntry, fieldsMetaData, mediaFiles);
     } else if (newEntry) {
       prevProps.createEmptyDraft(collection);
     }
@@ -217,12 +222,12 @@ class Editor extends React.Component {
     window.removeEventListener('beforeunload', this.exitBlocker);
   }
 
-  createBackup = debounce(function(entry, collection) {
-    this.props.persistLocalBackup(entry, collection);
+  createBackup = debounce(function(entry, collection, mediaFiles) {
+    this.props.persistLocalBackup(entry, collection, mediaFiles);
   }, 2000);
 
-  createDraft = (entry, metadata) => {
-    if (entry) this.props.createDraftFromEntry(entry, metadata);
+  createDraft = (entry, metadata, mediaFiles) => {
+    if (entry) this.props.createDraftFromEntry(entry, metadata, mediaFiles);
   };
 
   handleChangeStatus = newStatusName => {

--- a/packages/netlify-cms-core/src/components/Editor/Editor.js
+++ b/packages/netlify-cms-core/src/components/Editor/Editor.js
@@ -80,7 +80,7 @@ class Editor extends React.Component {
     hasChanged: PropTypes.bool,
     t: PropTypes.func.isRequired,
     retrieveLocalBackup: PropTypes.func,
-    localBackup: PropTypes.bool,
+    localBackup: ImmutablePropTypes.map,
     loadLocalBackup: PropTypes.func,
     persistLocalBackup: PropTypes.func,
     deleteLocalBackup: PropTypes.func,

--- a/packages/netlify-cms-core/src/components/MediaLibrary/MediaLibrary.js
+++ b/packages/netlify-cms-core/src/components/MediaLibrary/MediaLibrary.js
@@ -118,7 +118,7 @@ class MediaLibrary extends React.Component {
   toTableData = files => {
     const tableData =
       files &&
-      files.map(({ key, name, id, size, queryOrder, url, urlIsPublicPath, displayURL }) => {
+      files.map(({ key, name, id, size, queryOrder, url, urlIsPublicPath, displayURL, draft }) => {
         const ext = fileExtension(name).toLowerCase();
         return {
           key,
@@ -130,6 +130,7 @@ class MediaLibrary extends React.Component {
           url,
           urlIsPublicPath,
           displayURL,
+          draft,
           isImage: IMAGE_EXTENSIONS.includes(ext),
           isViewableImage: IMAGE_EXTENSIONS_VIEWABLE.includes(ext),
         };

--- a/packages/netlify-cms-core/src/components/MediaLibrary/MediaLibraryCard.js
+++ b/packages/netlify-cms-core/src/components/MediaLibrary/MediaLibraryCard.js
@@ -53,6 +53,14 @@ const CardText = styled.p`
   line-height: 1.3 !important;
 `;
 
+const DraftText = styled.p`
+  color: ${colors.mediaDraftText};
+  background-color: ${colors.mediaDraftBackground};
+  position: absolute;
+  padding: 8px;
+  border-radius: ${lengths.borderRadius} 0px ${lengths.borderRadius} 0;
+`;
+
 class MediaLibraryCard extends React.Component {
   render() {
     const {
@@ -60,11 +68,13 @@ class MediaLibraryCard extends React.Component {
       displayURL,
       text,
       onClick,
+      draftText,
       width,
       margin,
       isPrivate,
       type,
       isViewableImage,
+      isDraft,
     } = this.props;
     const url = displayURL.get('url');
     return (
@@ -77,6 +87,7 @@ class MediaLibraryCard extends React.Component {
         isPrivate={isPrivate}
       >
         <CardImageWrapper>
+          {isDraft ? <DraftText>{draftText}</DraftText> : null}
           {url && isViewableImage ? <CardImage src={url} /> : <CardFileIcon>{type}</CardFileIcon>}
         </CardImageWrapper>
         <CardText>{text}</CardText>
@@ -96,12 +107,14 @@ MediaLibraryCard.propTypes = {
   displayURL: ImmutablePropTypes.map.isRequired,
   text: PropTypes.string.isRequired,
   onClick: PropTypes.func.isRequired,
+  draftText: PropTypes.string.isRequired,
   width: PropTypes.string.isRequired,
   margin: PropTypes.string.isRequired,
   isPrivate: PropTypes.bool,
   type: PropTypes.string,
   isViewableImage: PropTypes.bool.isRequired,
   loadDisplayURL: PropTypes.func.isRequired,
+  isDraft: PropTypes.bool,
 };
 
 export default MediaLibraryCard;

--- a/packages/netlify-cms-core/src/components/MediaLibrary/MediaLibraryCardGrid.js
+++ b/packages/netlify-cms-core/src/components/MediaLibrary/MediaLibraryCardGrid.js
@@ -32,6 +32,7 @@ const MediaLibraryCardGrid = ({
   onLoadMore,
   isPaginating,
   paginatingMessage,
+  cardDraftText,
   cardWidth,
   cardMargin,
   isPrivate,
@@ -46,6 +47,8 @@ const MediaLibraryCardGrid = ({
           isSelected={isSelectedFile(file)}
           text={file.name}
           onClick={() => onAssetClick(file)}
+          isDraft={file.draft}
+          draftText={cardDraftText}
           width={cardWidth}
           margin={cardMargin}
           isPrivate={isPrivate}
@@ -74,6 +77,7 @@ MediaLibraryCardGrid.propTypes = {
       type: PropTypes.string.isRequired,
       url: PropTypes.string,
       urlIsPublicPath: PropTypes.bool,
+      draft: PropTypes.bool,
     }),
   ).isRequired,
   isSelectedFile: PropTypes.func.isRequired,
@@ -82,6 +86,7 @@ MediaLibraryCardGrid.propTypes = {
   onLoadMore: PropTypes.func.isRequired,
   isPaginating: PropTypes.bool,
   paginatingMessage: PropTypes.string,
+  cardDraftText: PropTypes.string.isRequired,
   cardWidth: PropTypes.string.isRequired,
   cardMargin: PropTypes.string.isRequired,
   loadDisplayURL: PropTypes.func.isRequired,

--- a/packages/netlify-cms-core/src/components/MediaLibrary/MediaLibraryModal.js
+++ b/packages/netlify-cms-core/src/components/MediaLibrary/MediaLibraryModal.js
@@ -170,6 +170,7 @@ const MediaLibraryModal = ({
         onLoadMore={handleLoadMore}
         isPaginating={isPaginating}
         paginatingMessage={t('mediaLibrary.mediaLibraryModal.loading')}
+        cardDraftText={t('mediaLibrary.mediaLibraryCard.draft')}
         cardWidth={cardWidth}
         cardMargin={cardMargin}
         isPrivate={privateUpload}

--- a/packages/netlify-cms-core/src/constants/defaultPhrases.js
+++ b/packages/netlify-cms-core/src/constants/defaultPhrases.js
@@ -96,6 +96,9 @@ export function getPhrases() {
       },
     },
     mediaLibrary: {
+      mediaLibraryCard: {
+        draft: 'Draft',
+      },
       mediaLibrary: {
         onDelete: 'Are you sure you want to delete selected media?',
       },

--- a/packages/netlify-cms-core/src/reducers/entryDraft.js
+++ b/packages/netlify-cms-core/src/reducers/entryDraft.js
@@ -13,6 +13,7 @@ import {
   ENTRY_PERSIST_FAILURE,
   ENTRY_DELETE_SUCCESS,
   ADD_DRAFT_ENTRY_MEDIA_FILE,
+  ADD_DRAFT_ENTRY_MEDIA_FILES,
   REMOVE_DRAFT_ENTRY_MEDIA_FILE,
 } from 'Actions/entries';
 import {
@@ -117,10 +118,24 @@ const entryDraftReducer = (state = Map(), action) => {
 
     case ADD_DRAFT_ENTRY_MEDIA_FILE:
       if (state.has('mediaFiles')) {
-        const { id, public_path, draft } = action.payload;
-        return state.update('mediaFiles', list => list.push({ id, public_path, draft }));
+        return state.update('mediaFiles', list =>
+          list.filterNot(file => file.id === action.id).push({ ...action.payload }),
+        );
       }
       return state;
+
+    case ADD_DRAFT_ENTRY_MEDIA_FILES: {
+      let newState = state;
+      if (!newState.has('mediaFiles')) {
+        newState = newState.set('mediaFiles', List());
+      }
+
+      action.payload.forEach(file => {
+        newState = newState.update('mediaFiles', list => list.push({ ...file }));
+      });
+
+      return newState;
+    }
 
     case REMOVE_DRAFT_ENTRY_MEDIA_FILE:
       if (state.has('mediaFiles')) {

--- a/packages/netlify-cms-core/src/reducers/mediaLibrary.js
+++ b/packages/netlify-cms-core/src/reducers/mediaLibrary.js
@@ -143,7 +143,9 @@ const mediaLibrary = (state = Map(defaultState), action) => {
         return state;
       }
       return state.withMutations(map => {
-        const updatedFiles = map.get('files').filter(file => file.key !== key);
+        const updatedFiles = map
+          .get('files')
+          .filter(file => (key ? file.key !== key : file.id !== id));
         map.set('files', updatedFiles);
         map.deleteIn(['displayURLs', id]);
         map.set('isDeleting', false);

--- a/packages/netlify-cms-core/src/reducers/mediaLibrary.js
+++ b/packages/netlify-cms-core/src/reducers/mediaLibrary.js
@@ -1,5 +1,6 @@
 import { Map } from 'immutable';
 import uuid from 'uuid/v4';
+import { differenceBy } from 'lodash';
 import {
   MEDIA_LIBRARY_OPEN,
   MEDIA_LIBRARY_CLOSE,
@@ -18,6 +19,7 @@ import {
   MEDIA_DISPLAY_URL_REQUEST,
   MEDIA_DISPLAY_URL_SUCCESS,
   MEDIA_DISPLAY_URL_FAILURE,
+  ADD_MEDIA_FILES_TO_LIBRARY,
 } from 'Actions/mediaLibrary';
 
 const defaultState = {
@@ -126,6 +128,15 @@ const mediaLibrary = (state = Map(defaultState), action) => {
         map.set('files', updatedFiles);
         map.set('isPersisting', false);
       });
+    }
+    case ADD_MEDIA_FILES_TO_LIBRARY: {
+      const { mediaFiles } = action.payload;
+      let updatedFiles = differenceBy(state.get('files'), mediaFiles, 'path');
+      mediaFiles.forEach(file => {
+        const fileWithKey = { ...file, key: uuid() };
+        updatedFiles = [fileWithKey, ...updatedFiles];
+      });
+      return state.set('files', updatedFiles);
     }
     case MEDIA_PERSIST_FAILURE: {
       const privateUploadChanged = state.get('privateUpload') !== action.payload.privateUpload;

--- a/packages/netlify-cms-core/src/reducers/medias.js
+++ b/packages/netlify-cms-core/src/reducers/medias.js
@@ -1,10 +1,17 @@
 import { Map } from 'immutable';
 import { resolvePath } from 'netlify-cms-lib-util';
-import { ADD_ASSET, REMOVE_ASSET } from 'Actions/media';
+import { ADD_ASSETS, ADD_ASSET, REMOVE_ASSET } from 'Actions/media';
 import AssetProxy from 'ValueObjects/AssetProxy';
 
 const medias = (state = Map(), action) => {
   switch (action.type) {
+    case ADD_ASSETS: {
+      let newState = state;
+      action.payload.forEach(asset => {
+        newState = newState.set(asset.public_path, asset);
+      });
+      return newState;
+    }
     case ADD_ASSET:
       return state.set(action.payload.public_path, action.payload);
     case REMOVE_ASSET:

--- a/packages/netlify-cms-core/src/valueObjects/AssetProxy.js
+++ b/packages/netlify-cms-core/src/valueObjects/AssetProxy.js
@@ -59,7 +59,7 @@ export function createAssetProxy(value, fileObj, uploaded = false, privateUpload
         () => new AssetProxy(value, fileObj, false),
       );
   } else if (privateUpload) {
-    throw new Error('The Private Upload option is only avaible for Asset Store Integration');
+    throw new Error('The Private Upload option is only available for Asset Store Integration');
   }
 
   return Promise.resolve(new AssetProxy(value, fileObj, uploaded));

--- a/packages/netlify-cms-ui-default/src/styles.js
+++ b/packages/netlify-cms-ui-default/src/styles.js
@@ -79,6 +79,8 @@ const colors = {
   controlLabel: '#7a8291',
   checkerboardLight: '#f2f2f2',
   checkerboardDark: '#e6e6e6',
+  mediaDraftText: colorsRaw.red,
+  mediaDraftBackground: colorsRaw.redLight,
 };
 
 const lengths = {


### PR DESCRIPTION
Fixes #1344 

STILL WORK IN PROGRESS.

I just wanted to share my approach as it is different than the one here https://github.com/netlify/netlify-cms/pull/2397.

The GitHub backend already supports pushing multiple files with one commit and the draft entry has some initial support to link media files to assets.

As a result I decided to handle everything in the client until the entry is saved. It is done using the draft entry `mediaFiles` field that can be used to link the media file to its corresponding asset.

When a user opens the media gallery while creating/editing an entry in editorial workflow any new uploaded media file will not be persisted immediately, but added to the `mediaFiles` list.

Once the entry is saved everything will be pushed in a single commit.

I also needed to make sure the media files and their assets are stored in the local backup.

Items left:
- [ ] A lot of manual regression testing
- [ ] Write more tests
- [X] Add an indication in the media gallery for a draft media file
- [ ] Decide if this should be the default behaviour
- [ ] Fix test backend to work in the same way (it is the only other backend that supports editorial workflow)
- [ ] Backwards compatibility