### PR TITLE
fix(git-gateway): unpublished entries not loaded for git-gateway(GitHub)

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -7,6 +7,7 @@ module.exports = {
     'netlify-cms-lib-auth': '<rootDir>/packages/netlify-cms-lib-auth/src/index.js',
     'netlify-cms-lib-util': '<rootDir>/packages/netlify-cms-lib-util/src/index.js',
     'netlify-cms-ui-default': '<rootDir>/packages/netlify-cms-ui-default/src/index.js',
+    'netlify-cms-backend-github': '<rootDir>/packages/netlify-cms-backend-github/src/index.js',
   },
   testURL: 'http://localhost:8080',
 };

--- a/packages/netlify-cms-backend-git-gateway/src/GitHubAPI.js
+++ b/packages/netlify-cms-backend-git-gateway/src/GitHubAPI.js
@@ -41,7 +41,7 @@ export default class API extends GithubAPI {
       });
   }
 
-  getRequestHeaders(headers = {}) {
+  requestHeaders(headers = {}) {
     return this.tokenPromise().then(jwtToken => {
       const baseHeader = {
         Authorization: `Bearer ${jwtToken}`,
@@ -53,36 +53,12 @@ export default class API extends GithubAPI {
     });
   }
 
-  urlFor(path, options) {
-    const cacheBuster = new Date().getTime();
-    const params = [`ts=${cacheBuster}`];
-    if (options.params) {
-      for (const key in options.params) {
-        params.push(`${key}=${encodeURIComponent(options.params[key])}`);
-      }
-    }
-    if (params.length) {
-      path += `?${params.join('&')}`;
-    }
-    return this.api_root + path;
+  handleRequestError(error, responseStatus) {
+    throw new APIError(error.message || error.msg, responseStatus, 'Git Gateway');
   }
 
   user() {
     return Promise.resolve(this.commitAuthor);
-  }
-
-  request(path, options = {}, parseResponse = response => this.parseResponse(response)) {
-    const url = this.urlFor(path, options);
-    let responseStatus;
-    return this.getRequestHeaders(options.headers || {})
-      .then(headers => fetch(url, { ...options, headers }))
-      .then(response => {
-        responseStatus = response.status;
-        return parseResponse(response);
-      })
-      .catch(error => {
-        throw new APIError(error.message || error.msg, responseStatus, 'Git Gateway');
-      });
   }
 
   commit(message, changeTree) {

--- a/packages/netlify-cms-backend-git-gateway/src/__tests__/GitHubAPI.spec.js
+++ b/packages/netlify-cms-backend-git-gateway/src/__tests__/GitHubAPI.spec.js
@@ -1,0 +1,84 @@
+import API from '../GitHubAPI';
+
+describe('github API', () => {
+  describe('request', () => {
+    beforeEach(() => {
+      const fetch = jest.fn();
+      global.fetch = fetch;
+      global.Date = jest.fn(() => ({ getTime: () => 1000 }));
+    });
+
+    afterEach(() => {
+      jest.resetAllMocks();
+    });
+
+    it('should fetch url with authorization header', async () => {
+      const api = new API({
+        api_root: 'https://site.netlify.com/.netlify/git/github',
+        tokenPromise: () => Promise.resolve('token'),
+      });
+
+      fetch.mockResolvedValue({
+        text: jest.fn().mockResolvedValue('some response'),
+        ok: true,
+        status: 200,
+        headers: { get: () => '' },
+      });
+      const result = await api.request('/some-path');
+      expect(result).toEqual('some response');
+      expect(fetch).toHaveBeenCalledTimes(1);
+      expect(fetch).toHaveBeenCalledWith(
+        'https://site.netlify.com/.netlify/git/github/some-path?ts=1000',
+        {
+          headers: { Authorization: 'Bearer token', 'Content-Type': 'application/json' },
+        },
+      );
+    });
+
+    it('should throw error on not ok response with message property', async () => {
+      const api = new API({
+        api_root: 'https://site.netlify.com/.netlify/git/github',
+        tokenPromise: () => Promise.resolve('token'),
+      });
+
+      fetch.mockResolvedValue({
+        text: jest.fn().mockResolvedValue({ message: 'some error' }),
+        ok: false,
+        status: 404,
+        headers: { get: () => '' },
+      });
+
+      await expect(api.request('some-path')).rejects.toThrow(
+        expect.objectContaining({
+          message: 'some error',
+          name: 'API_ERROR',
+          status: 404,
+          api: 'Git Gateway',
+        }),
+      );
+    });
+
+    it('should throw error on not ok response with msg property', async () => {
+      const api = new API({
+        api_root: 'https://site.netlify.com/.netlify/git/github',
+        tokenPromise: () => Promise.resolve('token'),
+      });
+
+      fetch.mockResolvedValue({
+        text: jest.fn().mockResolvedValue({ msg: 'some error' }),
+        ok: false,
+        status: 404,
+        headers: { get: () => '' },
+      });
+
+      await expect(api.request('some-path')).rejects.toThrow(
+        expect.objectContaining({
+          message: 'some error',
+          name: 'API_ERROR',
+          status: 404,
+          api: 'Git Gateway',
+        }),
+      );
+    });
+  });
+});


### PR DESCRIPTION
The authorization header was not sent for paginated requests when using `git-gateway` with a GitHub repo.

Introduced here: https://github.com/netlify/netlify-cms/commit/34e1f0910544d38b5142b0e45c178441faecb7a3#diff-b4ba42c688a23ed9cec5139daec2c157R115 and only partially fixed (for the GitHub backend) here: https://github.com/netlify/netlify-cms/commit/ece136c92e87500c0bda945ba4669e7a9366cda6#diff-b4ba42c688a23ed9cec5139daec2c157R120

To reproduce:

1. Deploy a site to Netlify with a `git-gateway` setup and editorial workflow.
2. Create a new POST and change to workflow tab to list the unpublished entries - you should get an error:

![image](https://user-images.githubusercontent.com/26760571/68543674-1ee43600-03c3-11ea-8c6e-650a4229300a.png)

The `pulls` API call is sent without an authorization header:

![image](https://user-images.githubusercontent.com/26760571/68543691-56eb7900-03c3-11ea-8b83-8b7c76c7003c.png)
  
![image](https://user-images.githubusercontent.com/26760571/68543700-68cd1c00-03c3-11ea-8325-1fc994be89c4.png)
