### PR TITLE
style: now HTML tags are allowed in collection-specific card titles

### DIFF
--- a/packages/netlify-cms-core/src/components/Collection/Entries/EntryCard.js
+++ b/packages/netlify-cms-core/src/components/Collection/Entries/EntryCard.js
@@ -113,7 +113,7 @@ const EntryCard = ({
       <ListCard>
         <ListCardLink to={path}>
           {collectionLabel ? <CollectionLabel>{collectionLabel}</CollectionLabel> : null}
-          <ListCardTitle>{title}</ListCardTitle>
+          <ListCardTitle dangerouslySetInnerHTML={{ __html: title }} />
         </ListCardLink>
       </ListCard>
     );
@@ -125,7 +125,7 @@ const EntryCard = ({
         <GridCardLink to={path}>
           <CardBody hasImage={image}>
             {collectionLabel ? <CollectionLabel>{collectionLabel}</CollectionLabel> : null}
-            <CardHeading>{title}</CardHeading>
+            <CardHeading dangerouslySetInnerHTML={{ __html: title }} />
           </CardBody>
           {image ? <CardImage url={image} /> : null}
         </GridCardLink>


### PR DESCRIPTION
**Summary**

Given the flexibility of the collection system, it's highly incongruous to strictly limit the visible summary on list and grid cards to a single line of un-formatted text. At some point, this may warrant a customization system parallel to what's now available for previews, where modules are created for each collection type that define their list and grid cards.

In the meantime, the same result can be achieved by simply allowing the configured collection summary (what in the EntryCard.js is assigned to the "title" constant) to include HTML tags. That, paired with currently-permitted CSS overriding, gives developers a lot of freedom in designing list and grid cards.

This can be achieved simply by rendering EntryCard titles using dangerouslySetInnerHTML. I've done this.

Now, cards can easily be configured on a collection-specific basis.

**Test plan**

In config.yml, I've defined a collection with the following summary:

    summary: "<img src='{{portraitimage}}' /> <span class='fullName'>{{fullName}}</span><span class='impact'>{{impact}}</span>"

I also added this CSS to static/admin/cms.css:

    h2[class*=ListCardTitle] img {
        max-width: 100px;
        float: left;
        margin: 0 20px 20px 0;
    }

    h2[class*=ListCardTitle] .fullName {
        font-size: 1.2em;
        font-weight: bold;
    }

    h2[class*=ListCardTitle] .impact {
        display: block;
        font-size: 0.95em;
        margin-top: 10px;
    }

This results in an EntryCard that looks like this:

![image](https://www.dropbox.com/s/5dwdnhkmyiqrvl7/netlify-cms-html-tags-in-title.jpg?dl=0&raw=1)
