### PR TITLE
fix: make forkExists name matching case-insensitive

### DIFF
--- a/packages/netlify-cms-backend-github/src/__tests__/implementation.spec.js
+++ b/packages/netlify-cms-backend-github/src/__tests__/implementation.spec.js
@@ -1,0 +1,75 @@
+import GitHubImplementation from '../implementation';
+
+jest.spyOn(console, 'error').mockImplementation(() => {});
+
+describe('github backend implementation', () => {
+  const config = {
+    getIn: jest.fn().mockImplementation(array => {
+      if (array[0] === 'backend' && array[1] === 'repo') {
+        return 'owner/repo';
+      }
+      if (array[0] === 'backend' && array[1] === 'open_authoring') {
+        return false;
+      }
+      if (array[0] === 'backend' && array[1] === 'branch') {
+        return 'master';
+      }
+      if (array[0] === 'backend' && array[1] === 'api_root') {
+        return 'https://api.github.com';
+      }
+    }),
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('forkExists', () => {
+    it('should return true when repo is fork and parent matches originRepo', async () => {
+      const gitHubImplementation = new GitHubImplementation(config);
+      gitHubImplementation.currentUser = jest.fn().mockResolvedValue({ login: 'login' });
+
+      global.fetch = jest.fn().mockResolvedValue({
+        // matching should be case-insensitive
+        json: () => ({ fork: true, parent: { full_name: 'OWNER/REPO' } }),
+      });
+
+      await expect(gitHubImplementation.forkExists({ token: 'token' })).resolves.toBe(true);
+
+      expect(gitHubImplementation.currentUser).toHaveBeenCalledTimes(1);
+      expect(gitHubImplementation.currentUser).toHaveBeenCalledWith({ token: 'token' });
+      expect(global.fetch).toHaveBeenCalledTimes(1);
+      expect(global.fetch).toHaveBeenCalledWith('https://api.github.com/repos/login/repo', {
+        method: 'GET',
+        headers: {
+          Authorization: 'token token',
+        },
+      });
+    });
+
+    it('should return false when repo is not a fork', async () => {
+      const gitHubImplementation = new GitHubImplementation(config);
+      gitHubImplementation.currentUser = jest.fn().mockResolvedValue({ login: 'login' });
+
+      global.fetch = jest.fn().mockResolvedValue({
+        // matching should be case-insensitive
+        json: () => ({ fork: false }),
+      });
+
+      expect.assertions(1);
+      await expect(gitHubImplementation.forkExists({ token: 'token' })).resolves.toBe(false);
+    });
+
+    it("should return false when parent doesn't match originRepo", async () => {
+      const gitHubImplementation = new GitHubImplementation(config);
+      gitHubImplementation.currentUser = jest.fn().mockResolvedValue({ login: 'login' });
+
+      global.fetch = jest.fn().mockResolvedValue({
+        json: () => ({ fork: true, parent: { full_name: 'owner/other_repo' } }),
+      });
+
+      expect.assertions(1);
+      await expect(gitHubImplementation.forkExists({ token: 'token' })).resolves.toBe(false);
+    });
+  });
+});

--- a/packages/netlify-cms-backend-github/src/implementation.js
+++ b/packages/netlify-cms-backend-github/src/implementation.js
@@ -167,7 +167,9 @@ export default class GitHub {
       // The parent and source objects are present when the repository is a fork.
       // parent is the repository this repository was forked from, source is the ultimate source for the network.
       const forkExists =
-        repo.fork === true && repo.parent && repo.parent.full_name === this.originRepo;
+        repo.fork === true &&
+        repo.parent &&
+        repo.parent.full_name.toLowerCase() === this.originRepo.toLowerCase();
       return forkExists;
     } catch {
       return false;


### PR DESCRIPTION
I noticed the fix [here](https://github.com/netlify/netlify-cms/pull/2802) doesn't work for https://github.com/CSS-Tricks/serverless.

The GitHub API returns the parent name as `CSS-Tricks/serverless` while the config repo is `css-tricks/serverless` so I changed the comparison to be case-insensitive.