### PR TITLE
fix(bundle-size): don't import react-select twice

### DIFF
--- a/packages/netlify-cms-widget-relation/src/RelationControl.js
+++ b/packages/netlify-cms-widget-relation/src/RelationControl.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import ImmutablePropTypes from 'react-immutable-proptypes';
-import AsyncSelect from 'react-select/lib/Async';
+import { Async as AsyncSelect } from 'react-select';
 import { find, isEmpty, last, debounce } from 'lodash';
 import { List, Map, fromJS } from 'immutable';
 import { reactSelectStyles } from 'netlify-cms-ui-default';


### PR DESCRIPTION
While waiting for the gatsby repo to clone 😪  I analyzed the bundle size and noticed `react-select` was imported twice.
Before:
![image](https://user-images.githubusercontent.com/26760571/68776925-85728980-0639-11ea-9f87-079f3ffb53f1.png)

After:
![image](https://user-images.githubusercontent.com/26760571/68776989-a1762b00-0639-11ea-937f-464a888962b6.png)


