### PR TITLE
Fixes carriage return issue with markdown widget #1437

### DIFF
--- a/packages/netlify-cms-widget-markdown/src/serializers/index.js
+++ b/packages/netlify-cms-widget-markdown/src/serializers/index.js
@@ -135,7 +135,8 @@ export const remarkToMarkdown = obj => {
     .use(remarkToMarkdownPlugin, remarkToMarkdownPluginOpts)
     .use(remarkAllowAllText)
     .use(createRemarkShortcodeStringifier({ plugins: getEditorComponents() }))
-    .stringify(processedMdast);
+    .stringify(processedMdast)
+    .replace(/\r?/g, '');
 
   /**
    * Return markdown with trailing whitespace removed.


### PR DESCRIPTION
Updates the markdown widget serializer to remove \r characters from text.

Fixes issue #1437 with the patch proposed by the issue creator - @papandreou

**Summary**

Recently, carriage returns (\r) have been added to git commits for our static sites through using netlifycms. Due to these characters being added, when doing a fresh clone of a website repo there were unstaged changes in the working git tree due to our [.gitattributes file](https://github.com/Linaro/website/blob/develop/.gitattributes) setting `text=auto`. This PR will strip any \r characters from the markdown widget text. I've built a custom version of netlify-cms with this patch applied and tested by creating a duplicate PR.

Before Patch: [https://github.com/Linaro/website/pull/928/commits/89bb049f85fb64f3bbbd9a9778c25b94d5ffea12](https://github.com/Linaro/website/pull/928/commits/89bb049f85fb64f3bbbd9a9778c25b94d5ffea12)
After Patch: [https://github.com/Linaro/website/pull/933/commits/0e2c3046ecf2b2d40032cceabba00c28e28d1966](https://github.com/Linaro/website/pull/933/commits/0e2c3046ecf2b2d40032cceabba00c28e28d1966)

Thanks to @morancj for helping diagnose this issue.

![71qX7Vf79hL _SX466_](https://user-images.githubusercontent.com/4564433/69244834-9ec98780-0b9d-11ea-8dd3-861832c8dddb.jpg)


Many thanks,

Kyle 
