### PR TITLE
feat(lang): add 'uk' locale

### DIFF
--- a/packages/netlify-cms-locales/src/index.js
+++ b/packages/netlify-cms-locales/src/index.js
@@ -2,3 +2,4 @@ export { default as en } from './en';
 export { default as de } from './de';
 export { default as fr } from './fr';
 export { default as es } from './es';
+export { default as uk } from './uk';

--- a/packages/netlify-cms-locales/src/uk/index.js
+++ b/packages/netlify-cms-locales/src/uk/index.js
@@ -1,0 +1,181 @@
+const uk = {
+  app: {
+    header: {
+      content: 'Зміст',
+      workflow: 'Робочий процес',
+      media: 'Медіа',
+      quickAdd: 'Додати',
+    },
+    app: {
+      errorHeader: 'Помилка завантаження конфігурації',
+      configErrors: 'Помилка конфігурації',
+      checkConfigYml: 'Перевірте config.yml файл.',
+      loadingConfig: 'Завантаження конфігурації...',
+      waitingBackend: 'Очікування серверу...',
+    },
+    notFoundPage: {
+      header: 'Сторінку не знайдено ',
+    },
+  },
+  collection: {
+    sidebar: {
+      collections: 'Колекції',
+      searchAll: 'Пошук',
+    },
+    collectionTop: {
+      viewAs: 'Змінити вигляд',
+      newButton: 'Створити %{collectionLabel}',
+    },
+    entries: {
+      loadingEntries: 'Завантаження записів',
+      cachingEntries: 'Кешування записів',
+      longerLoading: 'Це може зайняти декілька хвилинок',
+    },
+  },
+  editor: {
+    editorControlPane: {
+      widget: {
+        required: "%{fieldLabel} є обов'язковим.",
+        regexPattern: '%{fieldLabel} не задовільняє умові: %{pattern}.',
+        processing: 'обробляється %{fieldLabel}.',
+        range: 'значення %{fieldLabel} повинне бути від %{minValue} до %{maxValue}.',
+        min: 'значення %{fieldLabel} має бути від %{minValue}.',
+        max: 'значення %{fieldLabel} має бути %{maxValue} та менше.',
+      },
+    },
+    editor: {
+      onLeavePage: 'Ви дійсно бажаєте залишити сторінку?',
+      onUpdatingWithUnsavedChanges:
+        'Присутні незбережені зміни, будь ласка збережіть перед зміною статусу.',
+      onPublishingNotReady: 'Будь ласка, встановіть статус "Готово" перед публікацією.',
+      onPublishingWithUnsavedChanges:
+        'Присутні незбережені зміни, будь ласка збережіть їх перед публікацією.',
+      onPublishing: 'Ви дійсно бажаєте опублікувати запис?',
+      onDeleteWithUnsavedChanges:
+        'Ви дійсно бажаєте видалити опублікований запис, як і всі незбережені зміни під час поточної сесії?',
+      onDeletePublishedEntry: 'Ви дійсно бажаєте видалити опублікований запис?',
+      onDeleteUnpublishedChangesWithUnsavedChanges:
+        'Видаляться всі неопубліковані зміни до цього запису, а також всі незбережені зміни під час поточної сесії. Бажаєте продовжити?',
+      onDeleteUnpublishedChanges:
+        'Всі незбережені зміни до цього запису буде видалено. Бажаєте продовжити?',
+      loadingEntry: 'Завантаження...',
+      confirmLoadBackup: 'Відновлено резервну копію, бажаєте її використати?',
+    },
+    editorToolbar: {
+      publishing: 'Публікація...',
+      publish: 'Опублікувати',
+      published: 'Опубліковано',
+      publishAndCreateNew: 'Опублікувати і створити нову',
+      deleteUnpublishedChanges: 'Видалити неопубліковані зміни',
+      deleteUnpublishedEntry: 'Видалити неопубліковану сторінку',
+      deletePublishedEntry: 'Видалити опубліковану сторінку',
+      deleteEntry: 'Видалити',
+      saving: 'Збереження...',
+      save: 'Зберегти',
+      deleting: 'Видалення...',
+      updating: 'Оновлення...',
+      setStatus: 'Змінити стан',
+      backCollection: ' Робота над %{collectionLabel} колекцією',
+      unsavedChanges: 'Незбережені зміни',
+      changesSaved: 'Зміни збережено',
+      draft: 'В роботі',
+      inReview: 'На розгляді',
+      ready: 'Готово',
+      publishNow: 'Опублікувати',
+      deployPreviewPendingButtonLabel: 'Перевірити оновлення',
+      deployPreviewButtonLabel: 'Попередній перегляд',
+      deployButtonLabel: 'Переглянути наживо',
+    },
+    editorWidgets: {
+      unknownControl: {
+        noControl: "Відсутній модуль для '%{widget}'.",
+      },
+      unknownPreview: {
+        noPreview: "Відсутній перегляд для '%{widget}'.",
+      },
+    },
+  },
+  mediaLibrary: {
+    mediaLibraryCard: {
+      draft: 'В роботі',
+    },
+    mediaLibrary: {
+      onDelete: 'Ви дійсно бажаєте видалити обрані матеріали?',
+    },
+    mediaLibraryModal: {
+      loading: 'Завантаження...',
+      noResults: 'Результати відсутні.',
+      noAssetsFound: 'Матеріали відсутні.',
+      noImagesFound: 'Зображення відсутні.',
+      private: 'Private ',
+      images: 'Зображення',
+      mediaAssets: 'Медіа матеріали',
+      search: 'Пошук...',
+      uploading: 'Завантаження...',
+      uploadNew: 'Завантажити',
+      deleting: 'Видалення...',
+      deleteSelected: 'Видалити обране',
+      chooseSelected: 'Додати обране',
+    },
+  },
+  ui: {
+    errorBoundary: {
+      title: 'Помилка',
+      details: 'Відбулась помилка - будь ласка ',
+      reportIt: 'надішліть нам деталі.',
+      detailsHeading: 'Деталі',
+      recoveredEntry: {
+        heading: 'Відновлено документ',
+        warning: 'Будь ласка, збережіть це десь перед тим як піти!',
+        copyButtonLabel: 'Скопіювати в буфер',
+      },
+    },
+    settingsDropdown: {
+      logOut: 'Вихід',
+    },
+    toast: {
+      onFailToLoadEntries: 'Помилка завантаження: %{details}',
+      onFailToLoadDeployPreview: 'Помилка завантаження перегляду: %{details}',
+      onFailToPersist: 'Помилка перезапису: %{details}',
+      onFailToDelete: 'Помилка видалення: %{details}',
+      onFailToUpdateStatus: 'Помилка оновлення статусу: %{details}',
+      missingRequiredField:
+        "Йой, здається пропущено обов'язкове поле. Будь ласка, заповніть перед збереженням.",
+      entrySaved: 'Збережено',
+      entryPublished: 'Опубліковано',
+      onFailToPublishEntry: 'Помилка публікації: %{details}',
+      entryUpdated: 'Статус оновлено',
+      onDeleteUnpublishedChanges: 'Видалено неопубліковані зміни',
+      onFailToAuth: '%{details}',
+    },
+  },
+  workflow: {
+    workflow: {
+      loading: 'Завантаження редакційних матеріалів',
+      workflowHeading: 'Редакція',
+      newPost: 'Новий запис',
+      description: '%{smart_count} записів очікують розгляду, %{readyCount} готові до публікації. ',
+    },
+    workflowCard: {
+      lastChange: '%{date} від %{author}',
+      lastChangeNoAuthor: '%{date}',
+      lastChangeNoDate: 'від %{author}',
+      deleteChanges: 'Видалити зміни',
+      deleteNewEntry: 'Видалити новий запис',
+      publishChanges: 'Опублікувати всі зміни',
+      publishNewEntry: 'Опублікувати новий запис',
+    },
+    workflowList: {
+      onDeleteEntry: 'Ви дійсно бажаєте видалити запис?',
+      onPublishingNotReadyEntry:
+        'Тільки елементи з статусом "Готово" можуть бути опубліковані. Будь ласка перемістіть картку в колонку "Готово" для публікації.',
+      onPublishEntry: 'Дійсно бажаєте опублікувати запис?',
+      draftHeader: 'В роботі',
+      inReviewHeader: 'На розгляді',
+      readyHeader: 'Готово',
+      currentEntries: '%{smart_count} запис |||| %{smart_count} записів',
+    },
+  },
+};
+
+export default uk;


### PR DESCRIPTION
**Summary**

- Changes: Add ukrainian (uk) locale to the list of locales

- Motivation: I'm a native ukrainian speaker and I want my editors to have a CMS in a language they can fully understand

**Test plan**
 - Content:
<img width="1411" alt="main" src="https://user-images.githubusercontent.com/11396724/69256519-40fb6680-0bc2-11ea-84b6-caec7cf2cc3f.png">
 - Editorial Workflow:  

<img width="1406" alt="workflow" src="https://user-images.githubusercontent.com/11396724/69256523-435dc080-0bc2-11ea-8fda-91dcea695d9c.png">
 - Media:  

<img width="1290" alt="media" src="https://user-images.githubusercontent.com/11396724/69256531-45c01a80-0bc2-11ea-9a80-1ecf5d696784.png">

**A picture of a cute animal (not mandatory but encouraged)**
![70075ea91c8a099a3a13cc98ef2d502c](https://user-images.githubusercontent.com/11396724/69256779-a8b1b180-0bc2-11ea-9fea-86f072a9471e.jpg)