### PR TITLE
[documentation] improve NextJS docs by adding Identity Widget to homepage

### DIFF
--- a/website/content/docs/add-to-your-site.md
+++ b/website/content/docs/add-to-your-site.md
@@ -15,7 +15,8 @@ A static `admin` folder contains all Netlify CMS files, stored at the root of yo
 | These generators ...               | store static files in |
 | ---------------------------------- | --------------------- |
 | Jekyll, GitBook                    | `/` (project root)    |
-| Hugo, Gatsby, Nuxt, Next, Gridsome, Zola | `/static`             |
+| Hugo, Gatsby, Nuxt, Gridsome, Zola | `/static`             |
+| Next                               | `/public`             |
 | Hexo, Middleman, Jigsaw            | `/source`             |
 | Spike                              | `/views`              |
 | Wyam                               | `/input`              |

--- a/website/content/docs/nextjs.md
+++ b/website/content/docs/nextjs.md
@@ -32,7 +32,7 @@ mkdir content
 touch content/home.md
 
 #Create a folder for static assets
-mkdir static
+mkdir -p public/static
 
 ```
 
@@ -62,7 +62,7 @@ cats:
     name: Maru (まる)
   - description: Lil Bub is an American celebrity cat known for her unique appearance.
     name: Lil Bub
-  - description: 'Grumpy cat is an American celebrity cat known for her grumpy appearance. '
+  - description: 'Grumpy cat is an American celebrity cat known for her grumpy appearance.'
     name: Grumpy cat (Tardar Sauce)
 ---
 Welcome to my awesome page about cats of the internet. 
@@ -128,19 +128,19 @@ npm run dev
 
 ## Adding Netlify CMS
 
-There are many different ways to add Netlify CMS to your project. The easiest is probably just to embed it from a CDN, and that's exactly what we're gonna do. To avoid making this guide too complicated, we're just going to add Netlify into a subfolder inside the ```/static``` directory (which is just served as static files by Next):
+There are many different ways to add Netlify CMS to your project. The easiest is probably just to embed it from a CDN, and that's exactly what we're gonna do. To avoid making this guide too complicated, we're just going to add Netlify into a subfolder inside the ```/public/static``` directory (which is just served as static files by Next):
 
 ```bash
 # Create and navigate into static/admin folder
-mkdir static/admin
-cd static/admin
+mkdir public/static/admin
+cd public/static/admin
 
 # Create index.html and config.yml file
 touch index.html
 touch config.yml
 ```
 
-Paste HTML for Netlify CMS into your ``static/admin/index.html`` file (check out the [Add Netlify To Your Site](https://www.netlifycms.org/docs/add-to-your-site/) section for more information)
+Paste HTML for Netlify CMS into your ``public/static/admin/index.html`` file (check out the [Add Netlify To Your Site](https://www.netlifycms.org/docs/add-to-your-site/) section for more information)
 
 ```html
 <!doctype html>
@@ -159,13 +159,14 @@ Paste HTML for Netlify CMS into your ``static/admin/index.html`` file (check out
 ```
 Notice that we also added the identity widget. This allows sign up when the project is hosted at Netlify.
 
-Paste the following configuration into your```static/admin/config.yml``` file:
+Paste the following configuration into your ```public/static/admin/config.yml``` file:
 
 ```yaml
 backend:
   name: git-gateway
   branch: master
-media_folder: static/img
+media_folder: public/static/img
+public_folder: static/img
 collections:
   - name: "pages"
     label: "Pages"

--- a/website/content/docs/nextjs.md
+++ b/website/content/docs/nextjs.md
@@ -31,8 +31,8 @@ touch pages/index.js
 mkdir content
 touch content/home.md
 
-#Create a folder for static assets
-mkdir -p public/static
+# Create a folder for static assets
+mkdir public
 
 ```
 
@@ -128,19 +128,19 @@ npm run dev
 
 ## Adding Netlify CMS
 
-There are many different ways to add Netlify CMS to your project. The easiest is probably just to embed it from a CDN, and that's exactly what we're gonna do. To avoid making this guide too complicated, we're just going to add Netlify into a subfolder inside the ```/public/static``` directory (which is just served as static files by Next):
+There are many different ways to add Netlify CMS to your project. The easiest is probably just to embed it from a CDN, and that's exactly what we're gonna do. To avoid making this guide too complicated, we're just going to add Netlify into a subfolder inside the ```/public``` directory (which is just served as static files by Next):
 
 ```bash
 # Create and navigate into static/admin folder
-mkdir public/static/admin
-cd public/static/admin
+mkdir public/admin
+cd public/admin
 
 # Create index.html and config.yml file
 touch index.html
 touch config.yml
 ```
 
-Paste HTML for Netlify CMS into your ``public/static/admin/index.html`` file (check out the [Add Netlify To Your Site](https://www.netlifycms.org/docs/add-to-your-site/) section for more information)
+Paste HTML for Netlify CMS into your ``public/admin/index.html`` file (check out the [Add Netlify To Your Site](https://www.netlifycms.org/docs/add-to-your-site/) section for more information)
 
 ```html
 <!doctype html>
@@ -159,14 +159,14 @@ Paste HTML for Netlify CMS into your ``public/static/admin/index.html`` file (ch
 ```
 Notice that we also added the identity widget. This allows sign up when the project is hosted at Netlify.
 
-Paste the following configuration into your ```public/static/admin/config.yml``` file:
+Paste the following configuration into your ```public/admin/config.yml``` file:
 
 ```yaml
 backend:
   name: git-gateway
   branch: master
-media_folder: public/static/img
-public_folder: static/img
+media_folder: public/img
+public_folder: img
 collections:
   - name: "pages"
     label: "Pages"
@@ -186,10 +186,10 @@ collections:
             - { label: "Description", name: "description", widget: "text"}
 ```
 
-Awesome! Netlify CMS should now be available at ```localhost:3000/static/admin/index.html```.
+Awesome! Netlify CMS should now be available at ```localhost:3000/admin/index.html```.
 Unfortunately we can't edit our content just yet. First we need to move our code into a git repository, and create a new Netlify site.
 
-**Tip:** If you want to test changes made to your config.yml file locally, swap out "git-gateway" with "test-repo" and navigate to ```localhost:3000/static/admin/index.html``` to view Netlify CMS locally (you can't make changes or read actual content from Git this way, but it's great to verify how things will look).
+**Tip:** If you want to test changes made to your config.yml file locally, swap out "git-gateway" with "test-repo" and navigate to ```localhost:3000/admin/index.html``` to view Netlify CMS locally (you can't make changes or read actual content from Git this way, but it's great to verify how things will look).
 
 ## Publishing to GitHub and Netlify
 
@@ -228,7 +228,7 @@ Netlify's Identity and Git Gateway services allow you to manage CMS admin users 
 
 ### Celebrate!
 Great job - you did it! 
-Open your new page via the new Netlify URL, and navigate to ```/static/admin```. If you did everything correct in the previous step, you should now be able to sign up for an account, and log in. 
+Open your new page via the new Netlify URL, and navigate to ```/admin```. If you did everything correct in the previous step, you should now be able to sign up for an account, and log in. 
 
 **Tip:** Signing up with an external provider is the easiest. If you want to sign up by email, you'll have to set up a redirect in your index.js page (which we won't be covering in this guide). For more information, have a look at the [Add To Your Site](https://www.netlifycms.org/docs/add-to-your-site) section.
 

--- a/website/content/docs/nextjs.md
+++ b/website/content/docs/nextjs.md
@@ -90,6 +90,7 @@ module.exports = {
 Almost there! The last thing we need to do is to add some content our ```pages/index.js``` file. With a little help of our webpack loader, we can now easilly import Markdown files:
 
 ```js
+import Head from "next/head"
 import React, { Component } from 'react'
 import content from '../content/home.md';
 
@@ -97,18 +98,23 @@ export default class Home extends Component {
   render() {
     let { html , attributes:{ title, cats } } = content;
     return (
-      <article>
+      <>
+        <Head>
+          <script src="https://identity.netlify.com/v1/netlify-identity-widget.js"></script>
+        </Head>
+        <article>
           <h1>{title}</h1>
-          <div dangerouslySetInnerHTML={{ __html: html }}/>
+          <div dangerouslySetInnerHTML={{ __html: html }} />
           <ul>
-              { cats.map((cat, k) => (
-                  <li key={k}>
-                    <h2>{cat.name}</h2>
-                    <p>{cat.description}</p>
-                  </li>
-              ))}
+            {cats.map((cat, k) => (
+              <li key={k}>
+                <h2>{cat.name}</h2>
+                <p>{cat.description}</p>
+              </li>
+            ))}
           </ul>
-      </article>
+        </article>
+      </>
     )
   }
 }
@@ -147,7 +153,7 @@ Paste HTML for Netlify CMS into your ``static/admin/index.html`` file (check out
 </head>
 <body>
   <!-- Include the script that builds the page and powers Netlify CMS -->
-  <script src="https://unpkg.com/netlify-cms@^2.0.0/dist/netlify-cms.js"></script>
+  <script src="https://unpkg.com/netlify-cms@2.9.7/dist/netlify-cms.js"></script>
 </body>
 </html>
 ```

--- a/website/content/docs/nextjs.md
+++ b/website/content/docs/nextjs.md
@@ -91,7 +91,7 @@ Almost there! The last thing we need to do is to add some content our ```pages/i
 
 ```js
 import Head from "next/head"
-import React, { Component } from 'react'
+import { Component } from 'react'
 import content from '../content/home.md';
 
 export default class Home extends Component {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines.

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first two fields are mandatory:
-->

**Summary**

1. Missing Netlify Identity Widget

This is a PR for the NextJS guide in the docs: https://www.netlifycms.org/docs/nextjs. I had a tough time getting up and running—these changes would have solved the problem.

It is frustrating how your own docs mention the need to add the Netlify Identity Widget in **two places** (https://www.netlifycms.org/docs/add-to-your-site/#add-the-netlify-identity-widget), but the NextJS guide only includes it in **one place**. This results in frustrated users who can't figure why they are gettting "Email not confirmed" errors on their admin page:

Frustrated users with the same problem:
- https://github.com/netlify/netlify-identity-widget/issues/125
- https://github.com/netlify/netlify-identity-widget/issues/116
- https://community.netlify.com/t/problem-with-email-verification/4847
- https://community.netlify.com/t/common-issue-netlify-cms-isn-t-working-how-i-d-expect-how-do-i-debug/176
- https://community.netlify.com/t/logging-in-to-netify-cms-email-not-confirmed-on-admin-page/3153

On the one hand it is great that there are so many answers available, but on the other hand shouldn't the guides do a better job of steering clear of this problem in the first place? 

2. /public directory

In order to future-proof this example, I switched all instances of `/static` to `/public/static` as per Next.js best practices.

The `/static` directory has been deprecated since the 9.1 release. Next will continue to support it, but their recommendation is to use `/public/static` instead: https://nextjs.org/blog/next-9-1#public-directory-support

![image](https://user-images.githubusercontent.com/462836/69594414-1db12c80-0fb1-11ea-8084-11df98fda82d.png)
