### PR TITLE
fix: pass auth type in implicit auth URL to be used in identity widget

### DIFF
--- a/packages/netlify-cms-lib-auth/src/implicit-oauth.js
+++ b/packages/netlify-cms-lib-auth/src/implicit-oauth.js
@@ -41,7 +41,9 @@ export default class ImplicitAuthenticator {
     authURL.searchParams.set('redirect_uri', document.location.origin + document.location.pathname);
     authURL.searchParams.set('response_type', 'token');
     authURL.searchParams.set('scope', options.scope);
-    authURL.searchParams.set('state', createNonce());
+
+    const state = JSON.stringify({ auth_type: 'implicit', nonce: createNonce() });
+    authURL.searchParams.set('state', state);
 
     document.location.assign(authURL.href);
   }
@@ -59,7 +61,8 @@ export default class ImplicitAuthenticator {
 
     const params = Map(hashParams.entries());
 
-    const validNonce = validateNonce(params.get('state'));
+    const { nonce } = JSON.parse(params.get('state'));
+    const validNonce = validateNonce(nonce);
     if (!validNonce) {
       return cb(new Error('Invalid nonce'));
     }


### PR DESCRIPTION
Fixes https://github.com/netlify/netlify-cms/issues/1824

See comment here https://github.com/netlify/netlify-cms/issues/1824#issuecomment-559064466

Dependant on https://github.com/netlify/netlify-identity-widget/pull/223 to work