### PR TITLE
fix: .d.ts definitions for core and app

### DIFF
--- a/packages/netlify-cms-app/index.d.ts
+++ b/packages/netlify-cms-app/index.d.ts
@@ -1,0 +1,7 @@
+declare module 'netlify-cms-app' {
+  import { CMS } from 'netlify-cms-core';
+
+  export const NetlifyCmsApp: CMS;
+
+  export default NetlifyCmsApp;
+}

--- a/packages/netlify-cms-app/package.json
+++ b/packages/netlify-cms-app/package.json
@@ -6,6 +6,12 @@
   "repository": "https://github.com/netlify/netlify-cms/tree/master/packages/netlify-cms-app",
   "bugs": "https://github.com/netlify/netlify-cms/issues",
   "main": "dist/netlify-cms-app.js",
+  "files": [
+    "src/",
+    "dist/",
+    "index.d.ts"
+  ],
+  "types": "index.d.ts",
   "scripts": {
     "develop": "yarn build:esm --watch",
     "build": "cross-env NODE_ENV=production webpack",

--- a/packages/netlify-cms-core/index.d.ts
+++ b/packages/netlify-cms-core/index.d.ts
@@ -1,0 +1,255 @@
+declare module 'netlify-cms-core' {
+  import React, { ComponentType } from 'react';
+  import { Map } from 'immutable';
+
+  export type CmsBackendType
+    = 'git-gateway'
+    | 'github'
+    | 'gitlab'
+    | 'bitbucket'
+    | 'test-repo';
+
+  export type CmsMapWidgetType
+    = 'Point'
+    | 'LineString'
+    | 'Polygon';
+
+  export type CmsMarkdownWidgetButton
+    = 'bold'
+    | 'italic'
+    | 'code'
+    | 'link'
+    | 'heading-one'
+    | 'heading-two'
+    | 'heading-three'
+    | 'heading-four'
+    | 'heading-five'
+    | 'heading-six'
+    | 'quote'
+    | 'code-block'
+    | 'bulleted-list'
+    | 'numbered-list';
+
+  export type CmsFilesExtension
+    = 'yml'
+    | 'yaml'
+    | 'toml'
+    | 'json'
+    | 'md'
+    | 'markdown'
+    | 'html';
+
+  export type CmsCollectionFormatType
+    = 'yml'
+    | 'yaml'
+    | 'toml'
+    | 'json'
+    | 'frontmatter'
+    | 'yaml-frontmatter'
+    | 'toml-frontmatter'
+    | 'json-frontmatter';
+
+  export interface CmsField {
+    label: string;
+    name: string;
+    widget: string;
+    pattern?: string[];
+    default?: boolean | string | string[] | number | null;
+    format?: string;
+    dateFormat?: boolean | string;
+    timeFormat?: boolean | string;
+    media_library?: {
+      allow_multiple?: boolean;
+      config?: {
+        multiple?: boolean;
+      };
+    };
+    allow_add?: boolean;
+    field?: CmsField;
+    fields?: CmsField[];
+    decimals?: number;
+    type?: CmsMapWidgetType;
+    buttons?: CmsMarkdownWidgetButton[];
+    valueType?: number;
+    min?: number;
+    max?: number;
+    step?: number;
+    collection?: string;
+    displayFields?: string[];
+    valueField?: string;
+    multiple?: boolean;
+    optionsLength?: number;
+    options?: string[] | {
+      label: string;
+      value: string;
+    }[];
+  }
+
+  export interface CmsCollectionFile {
+    label: string;
+    name: string;
+    file: string;
+    fields: CmsField[];
+  }
+
+  export interface CmsCollection {
+    name: string;
+    fields: CmsField[];
+    label?: string;
+    label_singular?: string;
+    description?: string;
+    files?: CmsCollectionFile[];
+    folder?: string;
+    create?: boolean;
+    delete?: boolean;
+    filter?: {
+      field: string;
+      value: string;
+    };
+    identifier_field?: string;
+    extension?: CmsFilesExtension;
+    format?: CmsCollectionFormatType;
+    frontmatter_delimiter?: string[];
+    slug?: string;
+    preview_path?: string;
+    preview_path_date_field?: string;
+    editor?: {
+      preview: boolean;
+    };
+    summary?: string;
+  }
+
+  export interface CmsBackendParam {
+    name: CmsBackendType;
+    accept_roles?: string[];
+    repo?: string;
+    preview_context?: string;
+    auth_type?: string;
+    app_id?: string;
+    api_root?: string;
+    base_url?: string;
+    auth_endpoint?: string;
+  }
+
+  export interface CmsConfig {
+    backend?: CmsBackendType | CmsBackendParam;
+    load_config_file?: boolean;
+    media_folder?: string;
+    public_folder?: string;
+    collections: CmsCollection[];
+  }
+
+  export interface InitOptions {
+    config: CmsConfig;
+  }
+
+  export interface EditorComponentField {
+    name: string;
+    label: string;
+    widget: string;
+  }
+
+  export interface EditorComponentData {
+    id: number;
+  }
+
+  export interface EditorComponentOptions {
+    id: string;
+    label: string;
+    fields: EditorComponentField[];
+    pattern: RegExp;
+    fromBlock: (match: RegExpMatchArray) => EditorComponentData;
+    toBlock: (data: EditorComponentData) => string;
+    toPreview: (data: EditorComponentData) => string;
+  }
+
+  export interface PreviewStyleOptions {
+    raw: boolean;
+  }
+
+  export interface PreviewStyle extends PreviewStyleOptions {
+    value: string;
+  }
+
+  export type CmsBackendClass = any; // TODO: type properly
+
+  export interface CmsRegistryBackend {
+    init: (args: any) => CmsBackendClass;
+  }
+
+  export interface CmsWidgetParam {
+    name: string;
+    controlComponent: ComponentType;
+    previewComponent?: ComponentType;
+    globalStyles: any;
+  }
+
+  export interface CmsWidget {
+    control: ComponentType;
+    preview?: ComponentType;
+    globalStyles?: any;
+  }
+
+  export type CmsWidgetValueSerializer = any; // TODO: type properly
+
+  export interface CmsMediaLibraryParam {
+    name: string;
+    config?: {
+      publicKey?: string;
+    };
+  }
+
+  export type CmsMediaLibraryOptions = any; // TODO: type properly
+
+  export interface CmsMediaLibrary extends CmsMediaLibraryOptions {
+    options: CmsMediaLibraryOptions;
+  }
+
+  export type CmsLocalePhrases = any; // TODO: type properly
+
+  export interface CmsRegistry {
+    backends: {
+      [name: string]: CmsRegistryBackend;
+    };
+    templates: {
+      [name: string]: ComponentType;
+    };
+    previewStyles: PreviewStyle[];
+    widgets: {
+      [name: string]: CmsWidget;
+    };
+    editorComponents: Map<string, ComponentType>;
+    widgetValueSerializers: {
+      [name: string]: CmsWidgetValueSerializer;
+    };
+    mediaLibraries: CmsMediaLibrary[];
+    locales: {
+      [name: string]: CmsLocalePhrases;
+    };
+  }
+
+  export interface CMS {
+    getBackend: (name: string) => CmsRegistryBackend | undefined;
+    getEditorComponents: () => Map<string, ComponentType>;
+    getLocale: (locale: string) => CmsLocalePhrases | undefined;
+    getMediaLibrary: (name: string) => CmsMediaLibrary | undefined;
+    getPreviewStyles: () => PreviewStyle[];
+    getPreviewTemplate: (name: string) => ComponentType | undefined;
+    getWidget: (name: string) => CmsWidget | undefined;
+    getWidgetValueSerializer: (widgetName: string) => CmsWidgetValueSerializer | undefined;
+    init: (options?: InitOptions) => void;
+    registerBackend: (name: string, backendClass: CmsBackendClass) => void;
+    registerEditorComponent: (options: EditorComponentOptions) => void;
+    registerLocale: (locale: string, phrases: CmsLocalePhrases) => void;
+    registerMediaLibrary: (mediaLibrary: CmsMediaLibraryParam, options?: CmsMediaLibraryOptions) => void;
+    registerPreviewStyle: (filePath: string, options?: PreviewStyleOptions) => void;
+    registerPreviewTemplate: (name: string, component: ComponentType) => void;
+    registerWidget: (widget: string | CmsWidgetParam, control: ComponentType, preview?: ComponentType) => void;
+    registerWidgetValueSerializer: (widgetName: string, serializer: CmsWidgetValueSerializer) => void;
+    resolveWidget: (name: string) => CmsWidget | undefined;
+  }
+
+  export const NetlifyCmsCore: CMS;
+
+  export default NetlifyCmsCore;
+}

--- a/packages/netlify-cms-core/index.d.ts
+++ b/packages/netlify-cms-core/index.d.ts
@@ -49,94 +49,75 @@ declare module 'netlify-cms-core' {
     | 'toml-frontmatter'
     | 'json-frontmatter';
 
+  export type CmsAuthScope = 'repo' | 'public_repo';
+
+  export type CmsPublishMode = 'simple' | 'editorial_workflow';
+
+  export type CmsSlugEncoding = 'unicode' | 'ascii';
+
   export interface CmsField {
-    label: string;
     name: string;
-    widget: string;
-    pattern?: string[];
-    default?: boolean | string | string[] | number | null;
-    format?: string;
-    dateFormat?: boolean | string;
-    timeFormat?: boolean | string;
-    media_library?: {
-      allow_multiple?: boolean;
-      config?: {
-        multiple?: boolean;
-      };
-    };
-    allow_add?: boolean;
-    field?: CmsField;
-    fields?: CmsField[];
-    decimals?: number;
-    type?: CmsMapWidgetType;
-    buttons?: CmsMarkdownWidgetButton[];
-    valueType?: number;
-    min?: number;
-    max?: number;
-    step?: number;
-    collection?: string;
-    displayFields?: string[];
-    valueField?: string;
-    multiple?: boolean;
-    optionsLength?: number;
-    options?: string[] | {
-      label: string;
-      value: string;
-    }[];
+    label?: string;
+    widget?: string;
+    required?: boolean;
   }
 
   export interface CmsCollectionFile {
-    label: string;
     name: string;
+    label: string;
     file: string;
     fields: CmsField[];
+    label_singular?: string;
+    description?: string;
   }
 
   export interface CmsCollection {
     name: string;
-    fields: CmsField[];
-    label?: string;
+    label: string;
     label_singular?: string;
     description?: string;
-    files?: CmsCollectionFile[];
     folder?: string;
-    create?: boolean;
-    delete?: boolean;
-    filter?: {
-      field: string;
-      value: string;
-    };
+    files?: CmsCollectionFile[];
     identifier_field?: string;
-    extension?: CmsFilesExtension;
-    format?: CmsCollectionFormatType;
-    frontmatter_delimiter?: string[];
+    summary?: string;
     slug?: string;
     preview_path?: string;
     preview_path_date_field?: string;
+    create?: boolean;
     editor?: {
-      preview: boolean;
+      preview?: boolean;
     };
-    summary?: string;
+    format?: CmsCollectionFormatType;
+    extension?: CmsFilesExtension;
+    frontmatter_delimiter?: string[] | string;
+    fields?: CmsField[];
   }
 
-  export interface CmsBackendParam {
+  export interface CmsBackend {
     name: CmsBackendType;
-    accept_roles?: string[];
-    repo?: string;
-    preview_context?: string;
-    auth_type?: string;
-    app_id?: string;
-    api_root?: string;
-    base_url?: string;
-    auth_endpoint?: string;
+    auth_scope?: CmsAuthScope;
+    open_authoring?: boolean;
+  }
+
+  export interface CmsSlug {
+    encoding?: CmsSlugEncoding;
+    clean_accents?: boolean;
   }
 
   export interface CmsConfig {
-    backend?: CmsBackendType | CmsBackendParam;
-    load_config_file?: boolean;
+    backend: CmsBackend;
+    collections: CmsCollection[];
+    locale?: string;
+    site_url?: string;
+    display_url?: string;
+    logo_url?: string;
+    show_preview_links?: boolean;
     media_folder?: string;
     public_folder?: string;
-    collections: CmsCollection[];
+    media_folder_relative?: boolean;
+    media_library?: CmsMediaLibrary;
+    publish_mode?: CmsPublishMode;
+    slug?: CmsSlug;
   }
 
   export interface InitOptions {
@@ -192,17 +173,11 @@ declare module 'netlify-cms-core' {
 
   export type CmsWidgetValueSerializer = any; // TODO: type properly
 
-  export interface CmsMediaLibraryParam {
-    name: string;
-    config?: {
-      publicKey?: string;
-    };
-  }
-
   export type CmsMediaLibraryOptions = any; // TODO: type properly
 
-  export interface CmsMediaLibrary extends CmsMediaLibraryOptions {
-    options: CmsMediaLibraryOptions;
+  export interface CmsMediaLibrary {
+    name: string;
+    config?: CmsMediaLibraryOptions;
   }
 
   export type CmsLocalePhrases = any; // TODO: type properly
@@ -241,7 +216,7 @@ declare module 'netlify-cms-core' {
     registerBackend: (name: string, backendClass: CmsBackendClass) => void;
     registerEditorComponent: (options: EditorComponentOptions) => void;
     registerLocale: (locale: string, phrases: CmsLocalePhrases) => void;
-    registerMediaLibrary: (mediaLibrary: CmsMediaLibraryParam, options?: CmsMediaLibraryOptions) => void;
+    registerMediaLibrary: (mediaLibrary: CmsMediaLibrary, options?: CmsMediaLibraryOptions) => void;
     registerPreviewStyle: (filePath: string, options?: PreviewStyleOptions) => void;
     registerPreviewTemplate: (name: string, component: ComponentType) => void;
     registerWidget: (widget: string | CmsWidgetParam, control: ComponentType, preview?: ComponentType) => void;

--- a/packages/netlify-cms-core/package.json
+++ b/packages/netlify-cms-core/package.json
@@ -8,8 +8,10 @@
   "main": "dist/netlify-cms-core.js",
   "files": [
     "src/",
-    "dist/"
+    "dist/",
+    "index.d.ts"
   ],
+  "types": "index.d.ts",
   "scripts": {
     "develop": "yarn build:esm --watch",
     "build": "cross-env NODE_ENV=production webpack",


### PR DESCRIPTION
Hello! It's a partial fix for #2926 including TypeScript type definitions for `netlify-cms-core` and `netlify-cms-app`. 

**Summary**
I'm using Netlify CMS in TS project, so I needed types for it. I first wrote them in my project, so these types are partially tested in my project. However, there is still room for improvement since some types are defined as `any` which is not good. If I'll get more details about those types I'll open a separate PR with the fix. Also, please take a look and maybe you can tell me straight away what kind of values we can expect there, so I could change it right away before merging this PR.
Also, I've updated `package.json` files for these two packages so the types will be automatically added to the next NPM release.

**Test plan**
Well, who is testing before going to production?! Let's have some fun of unpredictability :)
Joking aside, It should work as expected. I did tests in my project with updates of the `node_modules` folder.

**A picture of a cute animal (not mandatory but encouraged)**
Why not... Sharing with you the pic of my lovely cat (her usual posture).
![IMG_20191110_125433](https://user-images.githubusercontent.com/10692413/69866563-c35fe680-12a4-11ea-9a7e-a85dae08e1fd.jpg)
(it's me on Friday night 😄)