### PR TITLE
fix: unpublish published entry

### DIFF
--- a/packages/netlify-cms-core/src/actions/editorialWorkflow.js
+++ b/packages/netlify-cms-core/src/actions/editorialWorkflow.js
@@ -541,10 +541,12 @@ export function unpublishPublishedEntry(collection, slug) {
     const entryDraft = Map().set('entry', entry);
     dispatch(unpublishedEntryPersisting(collection, entry, transactionID));
     return backend
-      .persistEntry(state.config, collection, entryDraft, [], state.integrations, [], {
-        status: status.get('PENDING_PUBLISH'),
-      })
-      .then(() => backend.deleteEntry(state.config, collection, slug))
+      .deleteEntry(state.config, collection, slug)
+      .then(() =>
+        backend.persistEntry(state.config, collection, entryDraft, [], state.integrations, [], {
+          status: status.get('PENDING_PUBLISH'),
+        }),
+      )
       .then(() => {
         dispatch(unpublishedEntryPersisted(collection, entryDraft, transactionID, slug));
         dispatch(entryDeleted(collection, slug));


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines.

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first two fields are mandatory:
-->

**Summary**
A fix for the issue described by Mateusz on slack:

> New beta feature publish/unpublish, with editorial workflow on (not sure if this is related, just letting you know) ->
When you unpublish, new branch is being created to store the file you unpublished. Good.
Then the file gets displayed under Workflow tab in CMS. Perfect.
I check in repo, and the file exists on this new branch which is cool.
Then you click to publish inside CMS to get file back again, and you randomly get error in cms, on repo branch storing unpublished file gets merged to the main branch, but it says branch has no changes, so its like empty merege, and the “store” branch gets deleted. (so you basically lose your “unpublished”  file)
-> I basically lost that way few files, but I also managed randomly to get things merged from “store” branch as it should wthout error and losing file.

<!--
Explain the **motivation** for making this change.
What existing problem does the pull request solve?
-->


<!--
Demonstrate the code is solid.
Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.
-->
