### PR TITLE
fix(core): use UTC date methods for slug formatting

### DIFF
--- a/packages/netlify-cms-core/src/lib/stringTemplate.js
+++ b/packages/netlify-cms-core/src/lib/stringTemplate.js
@@ -7,12 +7,12 @@ function formatDate(date) {
 }
 
 export const dateParsers = {
-  year: date => date.getFullYear(),
-  month: date => formatDate(date.getMonth() + 1),
-  day: date => formatDate(date.getDate()),
-  hour: date => formatDate(date.getHours()),
-  minute: date => formatDate(date.getMinutes()),
-  second: date => formatDate(date.getSeconds()),
+  year: date => date.getUTCFullYear(),
+  month: date => formatDate(date.getUTCMonth() + 1),
+  day: date => formatDate(date.getUTCDate()),
+  hour: date => formatDate(date.getUTCHours()),
+  minute: date => formatDate(date.getUTCMinutes()),
+  second: date => formatDate(date.getUTCSeconds()),
 };
 
 export const SLUG_MISSING_REQUIRED_DATE = 'SLUG_MISSING_REQUIRED_DATE';


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines.

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first two fields are mandatory:
-->

**Summary**

<!--
Explain the **motivation** for making this change.
What existing problem does the pull request solve?
-->
Tests fail when run in a UTC negative timezone, Eg., from the east coast, `2020-01-01` becomes `Tue Dec 31 2019 19:00:00 GMT-0500 (EST)` - falling back five hours and therefore referencing the previous calendar date.

**Test plan**

<!--
Demonstrate the code is solid.
Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.
-->
Existing tests that fail without this change now passes by providing the expected dates.
