### PR TITLE
fixed webpack loader error

### DIFF
--- a/website/content/docs/nextjs.md
+++ b/website/content/docs/nextjs.md
@@ -80,7 +80,7 @@ module.exports = {
         cfg.module.rules.push(
             {
                 test: /\.md$/,
-                use: 'frontmatter-markdown-loader',
+                loader: 'frontmatter-markdown-loader',
                 options: { mode: ['react-component'] }
             }
         )


### PR DESCRIPTION
A simple fix that allows webpack to build.

<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines.

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first two fields are mandatory:
-->

**Summary**
Webpack failed to build with previous setting use. With the following Error: options/query provided without loader (use loader + options)
 
<!--
Explain the **motivation** for making this change.
What existing problem does the pull request solve?
-->


**Test plan**
Changing 'use' to 'loader' solves the error, and allows the dev to build.

<!--
Demonstrate the code is solid.
Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.
-->

**A picture of a cute animal (not mandatory but encouraged)**
