### PR TITLE
fix: don't show progress when loading preview URL status

### DIFF
--- a/packages/netlify-cms-core/src/reducers/__tests__/globalUI.js
+++ b/packages/netlify-cms-core/src/reducers/__tests__/globalUI.js
@@ -1,0 +1,50 @@
+import { Map } from 'immutable';
+import { USE_OPEN_AUTHORING } from 'Actions/auth';
+import {
+  DEPLOY_PREVIEW_REQUEST,
+  DEPLOY_PREVIEW_SUCCESS,
+  DEPLOY_PREVIEW_FAILURE,
+} from 'Actions/deploys';
+import { ENTRY_REQUEST, ENTRY_SUCCESS, ENTRY_FAILURE } from 'Actions/entries';
+import reducer from '../globalUI';
+
+describe('globalUI', () => {
+  it('should set isFetching to true on entry request', () => {
+    expect(reducer(Map({ isFetching: false }), { type: ENTRY_REQUEST })).toEqual(
+      Map({ isFetching: true }),
+    );
+  });
+
+  it('should set isFetching to false on entry success', () => {
+    expect(reducer(Map({ isFetching: true }), { type: ENTRY_SUCCESS })).toEqual(
+      Map({ isFetching: false }),
+    );
+  });
+
+  it('should set isFetching to false on entry failure', () => {
+    expect(reducer(Map({ isFetching: true }), { type: ENTRY_FAILURE })).toEqual(
+      Map({ isFetching: false }),
+    );
+  });
+
+  it('should not change state on deploy preview request', () => {
+    const state = Map({ isFetching: false });
+    expect(reducer(state, { type: DEPLOY_PREVIEW_REQUEST })).toBe(state);
+  });
+
+  it('should not change state on deploy preview success', () => {
+    const state = Map({ isFetching: true });
+    expect(reducer(state, { type: DEPLOY_PREVIEW_SUCCESS })).toBe(state);
+  });
+
+  it('should not change state on deploy preview failure', () => {
+    const state = Map({ isFetching: true });
+    expect(reducer(state, { type: DEPLOY_PREVIEW_FAILURE })).toBe(state);
+  });
+
+  it('should set useOpenAuthoring to true on USE_OPEN_AUTHORING', () => {
+    expect(reducer(Map({ useOpenAuthoring: false }), { type: USE_OPEN_AUTHORING })).toEqual(
+      Map({ useOpenAuthoring: true }),
+    );
+  });
+});

--- a/packages/netlify-cms-core/src/reducers/globalUI.js
+++ b/packages/netlify-cms-core/src/reducers/globalUI.js
@@ -1,13 +1,21 @@
 import { Map } from 'immutable';
 import { USE_OPEN_AUTHORING } from 'Actions/auth';
+
+const LOADING_IGNORE_LIST = ['DEPLOY_PREVIEW'];
+
+const ignoreWhenLoading = action => LOADING_IGNORE_LIST.some(type => action.type.includes(type));
+
 /*
  * Reducer for some global UI state that we want to share between components
  * */
 const globalUI = (state = Map({ isFetching: false, useOpenAuthoring: false }), action) => {
   // Generic, global loading indicator
-  if (action.type.indexOf('REQUEST') > -1) {
+  if (!ignoreWhenLoading(action) && action.type.includes('REQUEST')) {
     return state.set('isFetching', true);
-  } else if (action.type.indexOf('SUCCESS') > -1 || action.type.indexOf('FAILURE') > -1) {
+  } else if (
+    !ignoreWhenLoading(action) &&
+    (action.type.includes('SUCCESS') || action.type.includes('FAILURE'))
+  ) {
     return state.set('isFetching', false);
   } else if (action.type === USE_OPEN_AUTHORING) {
     return state.set('useOpenAuthoring', true);


### PR DESCRIPTION
Small usability fix, but one that has been bugging me for a while.
When you open an unpublished entry it will load the entry, then show the progress bar for an additional 15 seconds due to the loading of the deploy preview URL (3 attempts of 5 seconds intervals).

It is not very clear that the progress bar is related to deploy preview URL loading (only visible when opening the network traffic).

I think we might want to add a specific loading indication just for the deploy preview URL in the future.