### PR TITLE
Feat: multi content authoring

### DIFF
--- a/packages/netlify-cms-core/src/actions/__tests__/config.spec.js
+++ b/packages/netlify-cms-core/src/actions/__tests__/config.spec.js
@@ -101,5 +101,33 @@ describe('config', () => {
         ]),
       ).toEqual('_');
     });
+
+    it('should add langauge fields', () => {
+      const inputFields = [
+        { label: 'Title', name: 'title', widget: 'string', translate: true },
+        { label: 'Slug', name: 'slug', widget: 'string' },
+      ];
+      const outputFields = [
+        {
+          label: 'Title',
+          name: 'title',
+          widget: 'object',
+          fields: [
+            { label: 'EN', name: 'en', widget: 'string' },
+            { label: 'FR', name: 'fr', widget: 'string' },
+          ],
+        },
+        { label: 'Slug', name: 'slug', widget: 'string' },
+      ];
+
+      expect(
+        applyDefaults(
+          fromJS({
+            languages: ['en', 'fr'],
+            collections: [{ folder: '_posts', fields: inputFields }],
+          }),
+        ).get('collections'),
+      ).toEqual(fromJS([{ folder: '_posts', fields: outputFields }]));
+    });
   });
 });


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines.

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first two fields are mandatory:
-->

**Summary**
Closes #716 

Based on the issue and comments, introduced new config options, a top-level `languages ` option
```
languages
 - en
 - fr
```
and `translate: true` widget option. The fix here is to wrap the field inside an `object` widget, generating fields for each of the supported languages. For example, a  folder collection fields like so:
```
- {label: 'Slug', name: 'slug', widget: 'string', translate: true}
```
would be transformed to:
```
 - label: 'Slug'
   name: 'slug'
   widget: 'object'
   fields:
      - {label: 'EN', name: 'en', widget: 'string'}
      - {label: 'FR', name: 'fr', widget: 'string'}
```
Editor UI:
![multi-slug](https://user-images.githubusercontent.com/8580864/71283695-39fe7a00-2361-11ea-8e62-f8f4136f75a1.png)

Data should be saved like so:
```
slug:
  en: a-night-not-like-the-others
  fr: une-nuit-pas-comme-les-autres
```
Note that the `identifier field` and the markdown `body` widget are excluded from the translation.
<!--
Explain the **motivation** for making this change.
What existing problem does the pull request solve?
-->

<!--
Demonstrate the code is solid.
Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.
-->
