### PR TITLE
fix: avoid nested select widget z-index conflicts

### DIFF
--- a/packages/netlify-cms-ui-default/src/styles.js
+++ b/packages/netlify-cms-ui-default/src/styles.js
@@ -352,7 +352,7 @@ const reactSelectStyles = {
       : 'transparent',
     paddingLeft: '22px',
   }),
-  menu: styles => ({ ...styles, right: 0, zIndex: 2 }),
+  menu: styles => ({ ...styles, right: 0, zIndex: 300 }),
   container: styles => ({ ...styles, padding: '0 !important' }),
   indicatorSeparator: (styles, state) =>
     state.hasValue && state.selectProps.isClearable

--- a/packages/netlify-cms-widget-markdown/src/MarkdownControl/VisualEditor.js
+++ b/packages/netlify-cms-widget-markdown/src/MarkdownControl/VisualEditor.js
@@ -28,6 +28,7 @@ const visualEditorStyles = `
   padding: 0;
   display: flex;
   flex-direction: column;
+  z-index: 100;
 `;
 
 const InsertionPoint = styled.div`


### PR DESCRIPTION
Allows dropdown lists within the markdown editor to stay on top of sibling markdown editors that are also nested, but keeps them inside the parent editor.