### PR TITLE
fix(widget-object): allow nested widgets to overflow

### DIFF
--- a/packages/netlify-cms-widget-object/src/ObjectControl.js
+++ b/packages/netlify-cms-widget-object/src/ObjectControl.js
@@ -14,7 +14,6 @@ const styleStrings = {
   `,
   objectWidgetTopBarContainer: `
     padding: ${lengths.objectWidgetTopBarContainerPadding};
-    overflow: hidden;
   `,
 };
 


### PR DESCRIPTION
Fixes #3016 

This may break something, just can't figure out what. I did notice that, at some point, we started wrapping all object nested widgets inside of a container that was meant solely for the widget top bar, and I'm not sure if that's bad at the moment. If this breaks we'll investigate further.