### PR TITLE
Update datetime widget description

### DIFF
--- a/website/content/docs/widgets/datetime.md
+++ b/website/content/docs/widgets/datetime.md
@@ -10,14 +10,16 @@ The datetime widget translates a datetime picker to a datetime string. For savin
 - **Data type:** Moment.js-formatted datetime string
 - **Options:**
   - `default`: accepts a datetime string, or an empty string to accept blank input; otherwise defaults to current datetime
-  - `format`: optional; accepts Moment.js [tokens](https://momentjs.com/docs/#/parsing/string-format/); defaults to raw Date object (if supported by output format)
-  - `dateFormat`: optional; boolean or Moment.js [tokens](https://momentjs.com/docs/#/parsing/string-format/). If `true` use default locale format.
-  - `timeFormat`: optional; boolean or Moment.js [tokens](https://momentjs.com/docs/#/parsing/string-format/). If `true` use default locale format, `false` hides time-picker.
+  - `format`: sets storage format; accepts Moment.js [tokens](https://momentjs.com/docs/#/parsing/string-format/); defaults to raw Date object (if supported by output format)
+  - `dateFormat`: sets date display format in UI; boolean or Moment.js [tokens](https://momentjs.com/docs/#/parsing/string-format/). If `true` use default locale format.
+  - `timeFormat`: sets time display format in UI; boolean or Moment.js [tokens](https://momentjs.com/docs/#/parsing/string-format/). If `true` use default locale format, `false` hides time-picker.
 - **Example:**
     ```yaml
     - label: "Start time"
       name: "start"
       widget: "datetime"
       default: ""
+      dateFormat: "DD.MM.YYYY" # e.g. 24.12.2021
+      timeFormat: "HH:mm" # e.g. 21:07
       format: "LLL"
     ```


### PR DESCRIPTION
This should clarify what the format options do. The example is updated to show a plausible non-default case. The "optional" hint is not used in the other widgets' docs, so I removed it. If you want to keep it (edit my commit), the `default` parameter should have it too for consistency.