### PR TITLE
fix: update image component pattern to match line break

### DIFF
--- a/packages/netlify-cms-editor-component-image/src/index.js
+++ b/packages/netlify-cms-editor-component-image/src/index.js
@@ -16,7 +16,7 @@ const image = {
     const src = await getAsset(image);
     return <img src={src || ''} alt={alt || ''} title={title || ''} />;
   },
-  pattern: /^!\[(.*)\]\((.*?)(\s"(.*)")?\)$/,
+  pattern: /^!\[(.*)\]\((.*?)(\s"(.*)")?\)\n?$/,
   fields: [
     {
       label: 'Image',


### PR DESCRIPTION
While working on https://github.com/netlify/netlify-cms/issues/2211 I had an issue where the image editor component was broken on initial load:

![image](https://user-images.githubusercontent.com/26760571/72251352-6dea5980-3606-11ea-8224-2c4246bf8507.png)

After some debugging I realized that reverting this https://github.com/netlify/netlify-cms/pull/3066/files fixes the issue.

Eventually fixed the image component pattern to match `![](/media/netlify.png)\n` of this file https://raw.githubusercontent.com/erezrokah/gatsby-netlify-cms-aws-test/cdcebc3b3b499df1f0b35d108b8ab9a6917fdf53/content/posts/2020-01-12-test.md