### PR TITLE
fix(backend-github-graphql): return empty array on non existent folder

### DIFF
--- a/packages/netlify-cms-backend-github/src/GraphQLAPI.js
+++ b/packages/netlify-cms-backend-github/src/GraphQLAPI.js
@@ -216,7 +216,7 @@ export default class GraphQLAPI extends API {
       const allFiles = this.getAllFiles(data.repository.object.entries, path);
       return allFiles;
     } else {
-      throw new APIError('Not Found', 404, 'GitHub');
+      return [];
     }
   }
 


### PR DESCRIPTION
Non existent folders usually happen on new projects. No reason to fail on that.