### PR TITLE
fix(core): force multiline flag for editor component patterns

### DIFF
--- a/packages/netlify-cms-core/src/valueObjects/EditorComponent.js
+++ b/packages/netlify-cms-core/src/valueObjects/EditorComponent.js
@@ -25,7 +25,8 @@ export default function createEditorComponent(config) {
     type,
     icon,
     widget,
-    pattern,
+    // enforce multiline flag, exclude others
+    pattern: new RegExp(pattern, 'm'),
     fromBlock: bind(fromBlock) || (() => ({})),
     toBlock: bind(toBlock) || (() => 'Plugin'),
     toPreview: bind(toPreview) || (!widget && (bind(toBlock) || (() => 'Plugin'))),


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines.

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first two fields are mandatory:
-->

**Summary**

<!--
Explain the **motivation** for making this change.
What existing problem does the pull request solve?
-->
Replacement fix for bug outlined in #3077.

Adds multiline flag (and excludes others) for all editor component patterns - this allows the beginning and end anchors to match lines instead of the entire remaining value.

**Test plan**
Unit test added.
<!--
Demonstrate the code is solid.
Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.
-->

