### PR TITLE
fix(widget-markdown): stop double pasting in raw editor

### DIFF
--- a/packages/netlify-cms-widget-markdown/src/MarkdownControl/RawEditor.js
+++ b/packages/netlify-cms-widget-markdown/src/MarkdownControl/RawEditor.js
@@ -66,6 +66,7 @@ export default class RawEditor extends React.Component {
   };
 
   handlePaste = (event, editor, next) => {
+    event.preventDefault();
     const data = event.clipboardData;
     if (isHotkey('shift', event)) {
       return next();


### PR DESCRIPTION
Closes #3081, forgot to prevent default on custom paste.