### PR TITLE
fix: ensure remarkToSlate result matches slate schema

### DIFF
--- a/packages/netlify-cms-widget-markdown/src/MarkdownControl/__tests__/__snapshots__/parser.spec.js.snap
+++ b/packages/netlify-cms-widget-markdown/src/MarkdownControl/__tests__/__snapshots__/parser.spec.js.snap
@@ -477,6 +477,10 @@ more important, there there are only so many sizes that you can use.",
             Object {
               "nodes": Array [
                 Object {
+                  "object": "text",
+                  "text": "",
+                },
+                Object {
                   "data": Object {
                     "title": null,
                     "url": "http://www.markitdown.net/",
@@ -506,6 +510,10 @@ more important, there there are only so many sizes that you can use.",
           "nodes": Array [
             Object {
               "nodes": Array [
+                Object {
+                  "object": "text",
+                  "text": "",
+                },
                 Object {
                   "data": Object {
                     "title": null,
@@ -557,6 +565,12 @@ more important, there there are only so many sizes that you can use.",
       "type": "paragraph",
     },
     Object {
+      "nodes": Array [
+        Object {
+          "object": "text",
+          "text": "",
+        },
+      ],
       "object": "block",
       "type": "thematic-break",
     },

--- a/packages/netlify-cms-widget-markdown/src/MarkdownControl/__tests__/parser.spec.js
+++ b/packages/netlify-cms-widget-markdown/src/MarkdownControl/__tests__/parser.spec.js
@@ -279,6 +279,12 @@ Object {
       "type": "heading-one",
     },
     Object {
+      "nodes": Array [
+        Object {
+          "object": "text",
+          "text": "",
+        },
+      ],
       "object": "block",
       "type": "thematic-break",
     },
@@ -321,6 +327,12 @@ Object {
       "type": "heading-one",
     },
     Object {
+      "nodes": Array [
+        Object {
+          "object": "text",
+          "text": "",
+        },
+      ],
       "object": "block",
       "type": "thematic-break",
     },
@@ -357,6 +369,12 @@ Object {
         },
         Object {
           "data": undefined,
+          "nodes": Array [
+            Object {
+              "object": "text",
+              "text": "",
+            },
+          ],
           "object": "inline",
           "type": "break",
         },
@@ -385,13 +403,27 @@ Object {
     Object {
       "nodes": Array [
         Object {
+          "object": "text",
+          "text": "",
+        },
+        Object {
           "data": Object {
             "alt": "super",
             "title": null,
             "url": "duper.jpg",
           },
+          "nodes": Array [
+            Object {
+              "object": "text",
+              "text": "",
+            },
+          ],
           "object": "inline",
           "type": "image",
+        },
+        Object {
+          "object": "text",
+          "text": "",
         },
       ],
       "object": "block",
@@ -639,13 +671,27 @@ Object {
     Object {
       "nodes": Array [
         Object {
+          "object": "text",
+          "text": "",
+        },
+        Object {
           "data": Object {
             "alt": "test",
             "title": null,
             "url": "test.png",
           },
+          "nodes": Array [
+            Object {
+              "object": "text",
+              "text": "",
+            },
+          ],
           "object": "inline",
           "type": "image",
+        },
+        Object {
+          "object": "text",
+          "text": "",
         },
       ],
       "object": "block",

--- a/packages/netlify-cms-widget-markdown/src/serializers/__tests__/remarkSlate.spec.js
+++ b/packages/netlify-cms-widget-markdown/src/serializers/__tests__/remarkSlate.spec.js
@@ -1,0 +1,77 @@
+import { wrapInlinesWithTexts } from '../remarkSlate';
+describe('remarkSlate', () => {
+  describe('wrapInlinesWithTexts', () => {
+    it('should handle empty array', () => {
+      const children = [];
+      expect(wrapInlinesWithTexts(children)).toBe(children);
+    });
+
+    it('should wrap single inline node with texts', () => {
+      expect(wrapInlinesWithTexts([{ object: 'inline' }])).toEqual([
+        { object: 'text', text: '' },
+        { object: 'inline' },
+        { object: 'text', text: '' },
+      ]);
+    });
+
+    it('should insert text before inline', () => {
+      expect(wrapInlinesWithTexts([{ object: 'inline' }, { object: 'text', text: '' }])).toEqual([
+        { object: 'text', text: '' },
+        { object: 'inline' },
+        { object: 'text', text: '' },
+      ]);
+    });
+
+    it('should insert text after inline', () => {
+      expect(wrapInlinesWithTexts([{ object: 'text', text: '' }, { object: 'inline' }])).toEqual([
+        { object: 'text', text: '' },
+        { object: 'inline' },
+        { object: 'text', text: '' },
+      ]);
+    });
+
+    it('should not modify valid children array', () => {
+      const children = [
+        { object: 'text', text: '' },
+        { object: 'inline' },
+        { object: 'text', text: '' },
+      ];
+      expect(wrapInlinesWithTexts(children)).toBe(children);
+    });
+
+    it('should wrap inlines with text nodes', () => {
+      expect(
+        wrapInlinesWithTexts([
+          { object: 'inline' },
+          { object: 'other' },
+          { object: 'inline' },
+          { object: 'inline' },
+          { object: 'other' },
+          { object: 'text', text: 'hello' },
+          { object: 'inline' },
+          { object: 'inline' },
+          { object: 'text', text: 'world' },
+          { object: 'inline' },
+        ]),
+      ).toEqual([
+        { object: 'text', text: '' },
+        { object: 'inline' },
+        { object: 'text', text: '' },
+        { object: 'other' },
+        { object: 'text', text: '' },
+        { object: 'inline' },
+        { object: 'text', text: '' },
+        { object: 'inline' },
+        { object: 'text', text: '' },
+        { object: 'other' },
+        { object: 'text', text: 'hello' },
+        { object: 'inline' },
+        { object: 'text', text: '' },
+        { object: 'inline' },
+        { object: 'text', text: 'world' },
+        { object: 'inline' },
+        { object: 'text', text: '' },
+      ]);
+    });
+  });
+});


### PR DESCRIPTION
Fixes https://github.com/netlify/netlify-cms/issues/3039
Couldn't reproduce the original issue https://github.com/netlify/netlify-cms/issues/2211

Makes sure to conform to slate schema as set here: https://github.com/ianstormtaylor/slate/blob/a0b7976cb9a2812d8d96361e9993fe8853a2cc64/packages/slate/src/plugins/core.js#L96

Not sure this is the most elegant way to solve it...
See my comment here https://github.com/netlify/netlify-cms/issues/2211#issuecomment-574141780

Also see principal number 2 here https://github.com/ianstormtaylor/slate#principles