### PR TITLE
revert: don't force multiline flag for editor component patterns

### DIFF
--- a/packages/netlify-cms-core/src/valueObjects/EditorComponent.js
+++ b/packages/netlify-cms-core/src/valueObjects/EditorComponent.js
@@ -26,7 +26,7 @@ export default function createEditorComponent(config) {
     icon,
     widget,
     // enforce multiline flag, exclude others
-    pattern: new RegExp(pattern, 'm'),
+    pattern,
     fromBlock: bind(fromBlock) || (() => ({})),
     toBlock: bind(toBlock) || (() => 'Plugin'),
     toPreview: bind(toPreview) || (!widget && (bind(toBlock) || (() => 'Plugin'))),

--- a/packages/netlify-cms-widget-markdown/src/serializers/remarkShortcodes.js
+++ b/packages/netlify-cms-widget-markdown/src/serializers/remarkShortcodes.js
@@ -11,8 +11,14 @@ export function remarkParseShortcodes({ plugins }) {
 function createShortcodeTokenizer({ plugins }) {
   return function tokenizeShortcode(eat, value, silent) {
     let match;
+    const potentialMatchValue = value.split('\n\n')[0].trim();
     const plugin = plugins.find(plugin => {
       match = value.match(plugin.pattern);
+
+      if (!match) {
+        match = potentialMatchValue.match(plugin.pattern);
+      }
+
       return !!match;
     });
 

--- a/packages/netlify-cms-widget-markdown/src/serializers/remarkShortcodes.js
+++ b/packages/netlify-cms-widget-markdown/src/serializers/remarkShortcodes.js
@@ -11,7 +11,7 @@ export function remarkParseShortcodes({ plugins }) {
 function createShortcodeTokenizer({ plugins }) {
   return function tokenizeShortcode(eat, value, silent) {
     let match;
-    const potentialMatchValue = value.split('\n\n')[0].trim();
+    const potentialMatchValue = value.split('\n\n')[0].trimEnd();
     const plugin = plugins.find(plugin => {
       match = value.match(plugin.pattern);
 
@@ -29,10 +29,19 @@ function createShortcodeTokenizer({ plugins }) {
 
       const shortcodeData = plugin.fromBlock(match);
 
-      return eat(match[0])({
-        type: 'shortcode',
-        data: { shortcode: plugin.id, shortcodeData },
-      });
+      try {
+        return eat(match[0])({
+          type: 'shortcode',
+          data: { shortcode: plugin.id, shortcodeData },
+        });
+      } catch (e) {
+        console.log(
+          `Sent invalid data to remark. Plugin: ${plugin.id}. Value: ${
+            match[0]
+          }. Data: ${JSON.stringify(shortcodeData)}`,
+        );
+        return false;
+      }
     }
   };
 }

--- a/packages/netlify-cms-widget-markdown/src/serializers/remarkShortcodes.js
+++ b/packages/netlify-cms-widget-markdown/src/serializers/remarkShortcodes.js
@@ -35,7 +35,7 @@ function createShortcodeTokenizer({ plugins }) {
           data: { shortcode: plugin.id, shortcodeData },
         });
       } catch (e) {
-        console.log(
+        console.warn(
           `Sent invalid data to remark. Plugin: ${plugin.id}. Value: ${
             match[0]
           }. Data: ${JSON.stringify(shortcodeData)}`,


### PR DESCRIPTION
Fixes https://github.com/netlify/netlify-cms/issues/3088
Probably fixes https://github.com/netlify/netlify-cms/issues/3086

Reverted https://github.com/netlify/netlify-cms/pull/3082 as a fix (the multiline flag had it matching when it shouldn't I think) and implemented a workaround for https://github.com/netlify/netlify-cms/pull/3077 as I'm not sure what is the correct way to handle multi lines.

Update: the second commit fixes https://github.com/netlify/netlify-cms/issues/3037 ([forked](https://github.com/erezrokah/marie-hogan-singer) the repo, [restored](https://github.com/erezrokah/marie-hogan-singer/blob/0e567eb2989b425f765b3ba843ab54079590fcb9/src/pages/posts/basic-rules-for-walking-in-the-mountains.md) the relevant file to reproduce the issue).
The error comes from here: https://github.com/remarkjs/remark/blob/4e020e8de31583666192602a63dc81790007285b/packages/remark-parse/lib/tokenizer.js#L144
as remark does prefix validation on the value and sub value. The fix was just to trim the end.
Also, wrapped the `eat` function in a try/catch. I think we shouldn't fail completely in this case.

