### PR TITLE
fix(large-media): don't fail on malformed pointer files

### DIFF
--- a/packages/netlify-cms-backend-git-gateway/src/implementation.ts
+++ b/packages/netlify-cms-backend-git-gateway/src/implementation.ts
@@ -389,8 +389,11 @@ export default class GitGateway implements Implementation {
 
     return filesPromise
       .then(items =>
-        items.map(({ file: { id }, data }) => {
+        items.map(({ file: { id, path }, data }) => {
           const parsedPointerFile = parsePointerFile(data);
+          if (!parsedPointerFile.sha) {
+            console.warn(`Failed parsing pointer file ${path}`);
+          }
           return [
             {
               pointerId: id,

--- a/packages/netlify-cms-backend-git-gateway/src/netlify-lfs-client.ts
+++ b/packages/netlify-cms-backend-git-gateway/src/netlify-lfs-client.ts
@@ -16,7 +16,7 @@ export const parsePointerFile: (data: string) => PointerFile = flow([
   fromPairs,
   ({ size, oid, ...rest }) => ({
     size: parseInt(size),
-    sha: oid.split(':')[1],
+    sha: oid?.split(':')[1],
     ...rest,
   }),
 ]);


### PR DESCRIPTION
Fixes https://github.com/netlify/netlify-cms/issues/3093

For some reason the repo had one pointer file with empty content. We shouldn't fail just because one file.