### PR TITLE
fix(widget-image): hide image overflow in widget control

### DIFF
--- a/packages/netlify-cms-widget-file/src/withFileControl.js
+++ b/packages/netlify-cms-widget-file/src/withFileControl.js
@@ -26,6 +26,7 @@ const ImageWrapper = styled.div`
   margin-bottom: 20px;
   border: ${borders.textField};
   border-radius: ${lengths.borderRadius};
+  overflow: hidden;
   ${effects.checkerboard};
   ${shadows.inset};
 `;


### PR DESCRIPTION
Fixes #3130.