### PR TITLE
fix(backend-git-gateway): re-write GitHub pagination links

### DIFF
--- a/packages/netlify-cms-backend-git-gateway/src/GitHubAPI.ts
+++ b/packages/netlify-cms-backend-git-gateway/src/GitHubAPI.ts
@@ -95,4 +95,8 @@ export default class API extends GithubAPI {
       body: JSON.stringify(commitParams),
     });
   }
+
+  nextUrlProcessor() {
+    return (url: string) => url.replace(/^(?:[a-z]+:\/\/.+?\/.+?\/.+?\/)/, `${this.apiRoot}/`);
+  }
 }

--- a/packages/netlify-cms-backend-git-gateway/src/__tests__/GitHubAPI.spec.js
+++ b/packages/netlify-cms-backend-git-gateway/src/__tests__/GitHubAPI.spec.js
@@ -84,4 +84,16 @@ describe('github API', () => {
       );
     });
   });
+
+  describe('nextUrlProcessor', () => {
+    it('should re-write github url', () => {
+      const api = new API({
+        apiRoot: 'https://site.netlify.com/.netlify/git/github',
+      });
+
+      expect(api.nextUrlProcessor()('https://api.github.com/repositories/10000/pulls')).toEqual(
+        'https://site.netlify.com/.netlify/git/github/pulls',
+      );
+    });
+  });
 });

--- a/packages/netlify-cms-backend-github/src/API.ts
+++ b/packages/netlify-cms-backend-github/src/API.ts
@@ -264,10 +264,19 @@ export default class API {
       .catch(error => this.handleRequestError(error, responseStatus));
   }
 
+  nextUrlProcessor() {
+    return (url: string) => url;
+  }
+
   async requestAllPages<T>(url: string, options: Options = {}) {
     const headers = await this.requestHeaders(options.headers || {});
     const processedURL = this.urlFor(url, options);
-    const allResponses = await getAllResponses(processedURL, { ...options, headers });
+    const allResponses = await getAllResponses(
+      processedURL,
+      { ...options, headers },
+      'next',
+      this.nextUrlProcessor(),
+    );
     const pages: T[][] = await Promise.all(
       allResponses.map((res: Response) => this.parseResponse(res)),
     );

--- a/packages/netlify-cms-lib-util/src/__tests__/backendUtil.spec.js
+++ b/packages/netlify-cms-lib-util/src/__tests__/backendUtil.spec.js
@@ -66,7 +66,7 @@ describe('getAllResponses', () => {
 
   it('should return all paged response', async () => {
     interceptCall({ repeat: 3, data: generatePulls(70) });
-    const res = await getAllResponses('https://api.github.com/pulls');
+    const res = await getAllResponses('https://api.github.com/pulls', {}, 'next', url => url);
     const pages = await Promise.all(res.map(res => res.json()));
 
     expect(pages[0]).toHaveLength(30);

--- a/packages/netlify-cms-lib-util/src/backendUtil.ts
+++ b/packages/netlify-cms-lib-util/src/backendUtil.ts
@@ -80,7 +80,8 @@ export const parseLinkHeader = flow([
 export const getAllResponses = async (
   url: string,
   options: { headers?: {} } = {},
-  linkHeaderRelName = 'next',
+  linkHeaderRelName: string,
+  nextUrlProcessor: (url: string) => string,
 ) => {
   const maxResponses = 30;
   let responseCount = 1;
@@ -95,7 +96,7 @@ export const getAllResponses = async (
     const nextURL = linkHeader && parseLinkHeader(linkHeader)[linkHeaderRelName];
 
     const { headers = {} } = options;
-    req = nextURL && unsentRequest.fromFetchArguments(nextURL, { headers });
+    req = nextURL && unsentRequest.fromFetchArguments(nextUrlProcessor(nextURL), { headers });
     pageResponses.push(pageResponse);
     responseCount++;
   }


### PR DESCRIPTION
Fixes https://github.com/netlify/netlify-cms/issues/3129 which will happen on any git-gateway+GitHub setup with more than 30 pull requests.

See my comment here https://github.com/netlify/netlify-cms/issues/3129#issuecomment-577722439.

We currently follow GitHub pagination link headers as is which breaks with `git-gateway`. 
Tested with pull requests as this is the only place we follow paginations links.

Another option is to do it in the `git-gateway` project itself.

@erquhart Thoughts?