### PR TITLE
Docs update list widget

### DIFF
--- a/website/content/docs/widgets/list.md
+++ b/website/content/docs/widgets/list.md
@@ -1,11 +1,11 @@
 ---
-label: 'List'
+label: "List"
 title: list
 ---
 
 The list widget allows you to create a repeatable item in the UI which saves as a list of widget values. map a user-provided string with a comma delimiter into a list. You can choose any widget as a child of a list widget—even other lists.
 
-- **Name:** `list`
+- **Name:** "list"
 - **UI:** if `fields` is specified, field containing a repeatable child widget, with controls for adding, deleting, and re-ordering the repeated widgets; if unspecified, a text input for entering comma-separated values
 - **Data type:** list of widget values
 - **Options:**
@@ -15,24 +15,24 @@ The list widget allows you to create a repeatable item in the UI which saves as 
   - `fields`: a nested list of multiple widget fields to be included in each repeatable iteration
 - **Example** (`field`/`fields` not specified):
   ```yaml
-  - label: 'Tags'
-    name: 'tags'
-    widget: 'list'
-    default: ['news']
+  - label: "Tags"
+    name: "tags"
+    widget: "list"
+    default: ["news"]
   ```
 - **Example** (`allow_add` marked `false`):
   ```yaml
-  - label: 'Tags'
-    name: 'tags'
-    widget: 'list'
+  - label: "Tags"
+    name: "tags"
+    widget: "list"
     allow_add: false
-    default: ['news']
+    default: ["news"]
   ```
 - **Example** (with `field`):
   ```yaml
-  - label: 'Gallery'
-    name: 'galleryImages'
-    widget: 'list'
+  - label: "Gallery"
+    name: "galleryImages"
+    widget: "list"
     field: { label: Image, name: image, widget: image }
   ```
 - **Example** (with `fields`):

--- a/website/content/docs/widgets/list.md
+++ b/website/content/docs/widgets/list.md
@@ -53,5 +53,4 @@ The list widget allows you to create a repeatable item in the UI which saves as 
             ]
         }
       ]
-      }
   ```

--- a/website/content/docs/widgets/list.md
+++ b/website/content/docs/widgets/list.md
@@ -5,7 +5,7 @@ title: list
 
 The list widget allows you to create a repeatable item in the UI which saves as a list of widget values. map a user-provided string with a comma delimiter into a list. You can choose any widget as a child of a list widget—even other lists.
 
-- **Name:** "list"
+- **Name:** 'list'
 - **UI:** if `fields` is specified, field containing a repeatable child widget, with controls for adding, deleting, and re-ordering the repeated widgets; if unspecified, a text input for entering comma-separated values
 - **Data type:** list of widget values
 - **Options:**

--- a/website/content/docs/widgets/list.md
+++ b/website/content/docs/widgets/list.md
@@ -1,5 +1,5 @@
 ---
-label: "List"
+label: 'List'
 title: list
 ---
 
@@ -14,38 +14,44 @@ The list widget allows you to create a repeatable item in the UI which saves as 
   - `field`: a single widget field to be repeated
   - `fields`: a nested list of multiple widget fields to be included in each repeatable iteration
 - **Example** (`field`/`fields` not specified):
-    ```yaml
-    - label: "Tags"
-      name: "tags"
-      widget: "list"
-      default: ["news"]
-    ```
+  ```yaml
+  - label: 'Tags'
+    name: 'tags'
+    widget: 'list'
+    default: ['news']
+  ```
 - **Example** (`allow_add` marked `false`):
-    ```yaml
-    - label: "Tags"
-      name: "tags"
-      widget: "list"
-      allow_add: false
-      default: ["news"]
-    ```
+  ```yaml
+  - label: 'Tags'
+    name: 'tags'
+    widget: 'list'
+    allow_add: false
+    default: ['news']
+  ```
 - **Example** (with `field`):
-    ```yaml
-    - label: "Gallery"
-      name: "galleryImages"
-      widget: "list"
-      field: {label: Image, name: image, widget: image}
-    ```
+  ```yaml
+  - label: 'Gallery'
+    name: 'galleryImages'
+    widget: 'list'
+    field: { label: Image, name: image, widget: image }
+  ```
 - **Example** (with `fields`):
-    ```yaml
-    - label: "Testimonials"
-      name: "testimonials"
-      widget: "list"
-      fields:
-        - {label: Quote, name: quote, widget: string, default: "Everything is awesome!"}
-        - label: Author
-          name: author
-          widget: object
+  ```yaml
+  - label: "Testimonials"
+    name: "testimonials"
+    widget: "list"
+    fields:
+      [
+        {label: Quote, name: quote, widget: string, default: "Everything is awesome!"},
+        {label: Author,
+          name: author,
+          widget: object,
           fields:
-            - {label: Name, name: name, widget: string, default: "Emmet"}
-            - {label: Avatar, name: avatar, widget: image, default: "/img/emmet.jpg"}
-    ```
+            [
+              {label: Name, name: name, widget: string, default: "Emmet"},
+              {label: Avatar, name: avatar, widget: image, default: "/img/emmet.jpg"}
+            ]
+        }
+      ]
+      }
+  ```

--- a/website/content/docs/widgets/list.md
+++ b/website/content/docs/widgets/list.md
@@ -43,7 +43,8 @@ The list widget allows you to create a repeatable item in the UI which saves as 
     fields:
       [
         {label: Quote, name: quote, widget: string, default: "Everything is awesome!"},
-        {label: Author,
+        {
+          label: Author,
           name: author,
           widget: object,
           fields:


### PR DESCRIPTION
**Summary**

When setting up Gatsbyjs with netlify cms I was having errors with the `config.yml` because I was following the documentation for the "list" widget. Specifically the documentation lists that when the `fields` option is used it should be delineated:
```
fields:
    - {...}
    - {...}
```
However the boilerplate code actually is set up:
```
fields:
    [
      {...},
      {...}
    ]
```

So this is a tweak to the documentation reflecting this change.

**Test plan**

This is just updating an .md file so no testing should be necessary

**A picture of a cute animal (not mandatory but encouraged)**
Our pup, Ember with her favorite chew toy.
![ember](https://user-images.githubusercontent.com/18124644/73141490-7ef98880-4052-11ea-9ba4-536ea02198a1.jpg)
