### PR TITLE
Docs(nuxt): Do not slice the first two chars of the file name

### DIFF
--- a/website/content/docs/nuxt.md
+++ b/website/content/docs/nuxt.md
@@ -247,9 +247,10 @@ export default {
   generate: {
     routes: function() {
       const fs = require('fs');
+      const path = require('path');
       return fs.readdirSync('./assets/content/blog').map(file => {
         return {
-          route: `/blog/${file.slice(2, -5)}`, // Remove the .json from the end of the filename
+          route: `/blog/${path.parse(file).name}`, // Return the slug
           payload: require(`./assets/content/blog/${file}`),
         };
       });


### PR DESCRIPTION
**Summary**
While following the tutorial I've noticed that the tutorial code had a bug in which the first two chars of a file were stripped before creating the route file. So the generated route files were named `20-01-27-slug` instead of `2020-01-27-slug`. I've corrected the mistake in the documentation

**Test plan**
Not applicable (?)

**A picture of a cute animal (not mandatory but encouraged)**
![2abb38b2d3fb5504229a87f8ce567b56](https://user-images.githubusercontent.com/781476/73200840-e4737500-4137-11ea-8b3d-ac1e528f77c8.png)
