### PR TITLE
fix(proxy-server): fix entriesByFiles implementation

### DIFF
--- a/packages/netlify-cms-proxy-server/src/middlewares/localGit/index.ts
+++ b/packages/netlify-cms-proxy-server/src/middlewares/localGit/index.ts
@@ -309,7 +309,7 @@ export const localGitMiddleware = ({ repoPath }: Options) => {
           const entries = await runOnBranch(git, branch, () =>
             entriesFromFiles(
               repoPath,
-              payload.files.map(file => path.join(repoPath, file.path)),
+              payload.files.map(file => file.path),
             ),
           );
           res.json(entries);


### PR DESCRIPTION
joining the repo path with the file path is done in `entriesFromFiles`.