### PR TITLE
docs(list-widget): add `collapsed` option to list widget docs (#3090)

### DIFF
--- a/website/content/docs/widgets/list.md
+++ b/website/content/docs/widgets/list.md
@@ -11,6 +11,7 @@ The list widget allows you to create a repeatable item in the UI which saves as 
 - **Options:**
   - `default`: if `fields` is specified, declare defaults on the child widgets; if not, you may specify a list of strings to populate the text field
   - `allow_add`: if added and labeled `false`, button to add additional widgets disappears
+  - `collapsed`: if added and labeled `false`, the list widget's content does not collapse by default
   - `field`: a single widget field to be repeated
   - `fields`: a nested list of multiple widget fields to be included in each repeatable iteration
 - **Example** (`field`/`fields` not specified):
@@ -48,4 +49,14 @@ The list widget allows you to create a repeatable item in the UI which saves as 
           fields:
             - {label: Name, name: name, widget: string, default: "Emmet"}
             - {label: Avatar, name: avatar, widget: image, default: "/img/emmet.jpg"}
+    ```
+- **Example** (`collapsed` marked `false`):
+    ```yaml
+    - label: "Testimonials"
+      name: "testimonials"
+      collapsed: false
+      widget: "list"
+      fields:
+        - {label: Quote, name: quote, widget: string, default: "Everything is awesome!"}
+        - {label: Author, name: author, widget: string }
     ```


### PR DESCRIPTION
Add the missing `collapsed` option with example to list widget docs.

Fixes #3090 

![Screen Shot 2020-01-29 at 12 52 58](https://user-images.githubusercontent.com/1159931/73354576-53ff7680-4296-11ea-9226-f30af57b7d11.png)

![Screen Shot 2020-01-29 at 12 52 20](https://user-images.githubusercontent.com/1159931/73354578-5661d080-4296-11ea-8a10-3aa702dde0fd.png)


**A picture of a cute animal**

(Not my dog, just found this picture).

![tacsi copy](https://user-images.githubusercontent.com/1159931/73354701-a2ad1080-4296-11ea-8d09-8692cb77d2df.jpg)
