### PR TITLE
docs: create proxy-server docs

### DIFF
--- a/packages/netlify-cms-proxy-server/.env.example
+++ b/packages/netlify-cms-proxy-server/.env.example
@@ -1,0 +1,4 @@
+# optional, defaults to current directory
+GIT_REPO_DIRECTORY=FULL_PATH_TO_LOCAL_GIT_REPO
+# optional, defaults to 8081
+PORT=CUSTOM_PORT

--- a/packages/netlify-cms-proxy-server/README.md
+++ b/packages/netlify-cms-proxy-server/README.md
@@ -1,11 +1,30 @@
-# Docs coming soon!
+# Netlify CMS Proxy Server
 
-Netlify CMS was recently converted from a single npm package to a "monorepo" of over 20 packages.
-That's over 20 Readme's! We haven't created one for this package yet, but we will soon.
+Netlify CMS Proxy Server is an express server created to facilitate local development.
 
-In the meantime, you can:
+## How It Works
 
-1. Check out the [main readme](https://github.com/netlify/netlify-cms/#readme) or the [documentation
-   site](https://www.netlifycms.org) for more info.
-2. Reach out to the [community chat](https://netlifycms.org/chat/) if you need help.
-3. Help out and [write the readme yourself](https://github.com/netlify/netlify-cms/edit/master/packages/netlify-cms-proxy-server/README.md)!
+1. Navigate to a local Git repository configured with the CMS.
+2. Run `npx netlify-cms-proxy-server` from the root directory of the above repository.
+3. Update your `config.yml` to connect to the server:
+
+```yaml
+backend:
+  name: proxy
+  proxy_url: http://localhost:8081/api/v1
+  branch: master # optional, defaults to master
+```
+
+4. Start you local development server (e.g. run `gatsby develop`).
+
+## Custom Configuration
+
+1. Create a `.env` file in the root directory of your local Git repository.
+2. Update the file as follows:
+
+```bash
+# optional, defaults to current directory
+GIT_REPO_DIRECTORY=FULL_PATH_TO_LOCAL_GIT_REPO
+# optional, defaults to 8081
+PORT=CUSTOM_PORT
+```

--- a/website/content/docs/beta-features.md
+++ b/website/content/docs/beta-features.md
@@ -8,6 +8,25 @@ We run new functionality in an open beta format from time to time. That means th
 
 **Use these features at your own risk.**
 
+## Working with a Local Git Repository
+
+You can connect Netlify CMS to a local Git repository, instead of working with a live repo.
+
+1. Navigate to a local Git repository configured with the CMS.
+2. Run `npx netlify-cms-proxy-server` from the root directory of the above repository.
+3. Update your `config.yml` to connect to the server:
+
+```yaml
+backend:
+  name: proxy
+  proxy_url: http://localhost:8081/api/v1
+  branch: master # optional, defaults to master
+```
+
+4. Start you local development server (e.g. run `gatsby develop`).
+
+> `netlify-cms-proxy-server` runs an unauthenticated express server. As any client can send requests to the server, it should only be used for local development.
+
 ## GitLab and BitBucket editorial workflow support
 
 You can enable the Editorial Workflow with the following line in your Netlify CMS `config.yml` file:


### PR DESCRIPTION
Fixes https://github.com/netlify/netlify-cms/issues/3136

Adds the missing documentation related to the proxy server.