### PR TITLE
nuxtServerInit requires mode: universal

### DIFF
--- a/website/content/docs/nuxt.md
+++ b/website/content/docs/nuxt.md
@@ -137,7 +137,7 @@ Once you've reached this point, you should be able to access the CMS in your bro
 
 ## Integrating content in Nuxt with Vuex
 
-Next, you'll set up the integrated Vuex store to collect blog posts. Create a file `index.js` in the `store/` directory, and add **state**, **mutations**, and **actions** for your blog posts:
+In order to use nuxtServerInit your mode must be 'universal' in your nuxt.config.js.  Next, you'll set up the integrated Vuex store to collect blog posts. Create a file `index.js` in the `store/` directory, and add **state**, **mutations**, and **actions** for your blog posts:
 
 ```js
 export const state = () => ({

--- a/website/content/docs/nuxt.md
+++ b/website/content/docs/nuxt.md
@@ -137,7 +137,9 @@ Once you've reached this point, you should be able to access the CMS in your bro
 
 ## Integrating content in Nuxt with Vuex
 
-In order to use nuxtServerInit your mode must be 'universal' in your nuxt.config.js.  Next, you'll set up the integrated Vuex store to collect blog posts. Create a file `index.js` in the `store/` directory, and add **state**, **mutations**, and **actions** for your blog posts:
+**Note:** In order to use `nuxtServerInit` your mode must be `universal` in your `nuxt.config.js`.
+
+Next, you'll set up the integrated Vuex store to collect blog posts. Create a file `index.js` in the `store/` directory, and add **state**, **mutations**, and **actions** for your blog posts:
 
 ```js
 export const state = () => ({


### PR DESCRIPTION
I've updated the description for this guide.  It seems you can't use mode: 'spa' if you plan on using nuxtServerInit, even though you are just doing a 'generate'.  So, you have to use 'universal'

@Atinux
