### PR TITLE
docs: fix overflow issue

### DIFF
--- a/website/src/components/sidebar-layout.js
+++ b/website/src/components/sidebar-layout.js
@@ -6,7 +6,7 @@ import { mq } from '../utils';
 import styled from '@emotion/styled';
 
 const Children = styled.div`
-  max-width: 80%;
+  overflow: auto;
 `;
 
 const SidebarLayout = ({ sidebar, children }) => (

--- a/website/src/components/sidebar-layout.js
+++ b/website/src/components/sidebar-layout.js
@@ -3,6 +3,11 @@ import { css } from '@emotion/core';
 
 import Page from './page';
 import { mq } from '../utils';
+import styled from '@emotion/styled';
+
+const Children = styled.div`
+  max-width: 80%;
+`;
 
 const SidebarLayout = ({ sidebar, children }) => (
   <Page
@@ -15,7 +20,7 @@ const SidebarLayout = ({ sidebar, children }) => (
     `}
   >
     <div>{sidebar}</div>
-    <div>{children}</div>
+    <Children>{children}</Children>
   </Page>
 );
 


### PR DESCRIPTION
There are some pages where page has horizontal scrolling due to content being overflowed

Example - https://www.netlifycms.org/docs/gatsby/

This PR fixes the above issue(s)