### PR TITLE
fix(core): strip closing separators in yaml files

### DIFF
--- a/packages/netlify-cms-core/src/formats/__tests__/yaml.spec.js
+++ b/packages/netlify-cms-core/src/formats/__tests__/yaml.spec.js
@@ -1,0 +1,17 @@
+import yaml from '../yaml';
+
+describe('yaml', () => {
+  describe('fromFile', () => {
+    test('loads valid yaml', () => {
+      expect(yaml.fromFile('[]')).toEqual([]);
+    });
+    test('does not fail on closing separator', () => {
+      expect(yaml.fromFile('---\n[]\n---')).toEqual([]);
+    });
+  });
+  describe('toFile', () => {
+    test('outputs valid yaml', () => {
+      expect(yaml.toFile([])).toEqual('[]\n');
+    });
+  });
+});

--- a/packages/netlify-cms-core/src/formats/yaml.js
+++ b/packages/netlify-cms-core/src/formats/yaml.js
@@ -37,6 +37,9 @@ const OutputSchema = new yaml.Schema({
 
 export default {
   fromFile(content) {
+    if (content && content.trim().endsWith('---')) {
+      content = content.trim().slice(0, -3);
+    }
     return yaml.safeLoad(content);
   },
 


### PR DESCRIPTION
**js-yaml** fails on closing separators for standalone yaml files, interpreting them as indicating a separate document. Since separators are stripped out on output anyway, and the js-yaml repo doesn't seem responsive to issues/PR's, this fix removes them if present.