### PR TITLE
fix(website): missing headers anchors

### DIFF
--- a/website/src/components/sidebar-layout.js
+++ b/website/src/components/sidebar-layout.js
@@ -7,6 +7,7 @@ import styled from '@emotion/styled';
 
 const Children = styled.div`
   overflow: auto;
+  padding-left: 2rem;
 `;
 
 const SidebarLayout = ({ sidebar, children }) => (


### PR DESCRIPTION
Noticed that our headers anchors are missing from the docs site, seems like it was introduced in https://github.com/netlify/netlify-cms/pull/3191/files