### PR TITLE
fix: fs proxy info action

### DIFF
--- a/packages/netlify-cms-proxy-server/src/middlewares/localFs/index.ts
+++ b/packages/netlify-cms-proxy-server/src/middlewares/localFs/index.ts
@@ -25,7 +25,7 @@ export const localFsMiddleware = ({ repoPath }: Options) => {
       const { body } = req;
 
       switch (body.action) {
-        case 'action': {
+        case 'info': {
           res.json({
             repo: path.basename(repoPath),
             // eslint-disable-next-line @typescript-eslint/camelcase


### PR DESCRIPTION
Not sure how this passed our tests (bug introduced in a [code cleanup](https://github.com/netlify/netlify-cms/pull/3217/commits/3bffffc89c1900edecbff288dea09b19960aa22f) commit I did).

Cypress reported a success GitHub status for this run: https://github.com/netlify/netlify-cms/actions/runs/36998894

But on the dashboard it failed: https://dashboard.cypress.io/projects/dzqjxb/runs/4420/specs

Also, the logs for the run are missing from the GitHub action logs