### PR TITLE
docs: add a mention that test-repo backend can't access to local file…

### DIFF
--- a/website/content/docs/authentication-backends.md
+++ b/website/content/docs/authentication-backends.md
@@ -156,7 +156,7 @@ With Bitbucket's Implicit Grant, users can authenticate with Bitbucket directly 
 ## Test Repo Backend
 You can use the `test-repo` backend to try out Netlify CMS without connecting to a Git repo. With this backend, you can write and publish content normally, but any changes will disappear when you reload the page. This backend powers the Netlify CMS [demo site](https://cms-demo.netlify.com/).
 
-Note: as every backends, `test-repo` uses local browser storage, so it doesn't have access to your file system and can't interact with local git repositories. As a consequence, while using this backend you **won't see any already existing local files**.
+**Note:** The `test-repo` backend can't access your local file system, nor does it connect to a Git repo, thus you won't see any existing files while using it.
 
 To enable this backend, add the following lines to your Netlify CMS `config.yml` file:
 

--- a/website/content/docs/authentication-backends.md
+++ b/website/content/docs/authentication-backends.md
@@ -150,11 +150,13 @@ With Bitbucket's Implicit Grant, users can authenticate with Bitbucket directly 
       auth_type: implicit
       app_id: # The Key from your Bitbucket settings
     ```
-  
+
 **Warning:** With Bitbucket implicit grant, the authentication is valid for 1 hour only. After that, the user has to login again, **which can lead to data loss** if the expiration occurs while content is being edited.
 
 ## Test Repo Backend
-You can use the `test-repo` backend to try out Netlify CMS without connecting to a Git repo. With this backend, you can write and publish content normally, but any changes will disapear when you reload the page. This backend powers the Netlify CMS [demo site](https://cms-demo.netlify.com/).
+You can use the `test-repo` backend to try out Netlify CMS without connecting to a Git repo. With this backend, you can write and publish content normally, but any changes will disappear when you reload the page. This backend powers the Netlify CMS [demo site](https://cms-demo.netlify.com/).
+
+Note: as every backends, `test-repo` uses local browser storage, so it doesn't have access to your file system and can't interact with local git repositories. As a consequence, while using this backend you **won't see any already existing local files**.
 
 To enable this backend, add the following lines to your Netlify CMS `config.yml` file:
 


### PR DESCRIPTION
**Summary**

doc update: it tool me some time to figure out what wasn't working while testing Netlify CMS on my local machine: I was able to add new posts, but didn't seen any existing posts. 
I checked `folder` key of my collection a hundred times, and finally came across this [super interesting step-by-step tutorial](https://github.com/adamwatters/jekyll-tutorial-with-netlify-cms/blob/master/README.md#add-configyml) that explained what I think should be in doc: 

> Awesome, the CMS is running without errors! Great, but you might have noticed the CMS isn't displaying data from the three markdown files in the _posts/ directory. The reason is test-repo uses local browser storage and doesn't have access to your file system. In fact, none of the Netlify CMS backends can interact with local git repositories. This is a common point of confusion and bears repeating: NETLIFY CMS CANNOT INTERACT WITH LOCAL GIT REPOSITORIES.

Here's a summarized version in this PR.

**Test plan**

No tests needed for doc updates.

**A picture of a cute animal (not mandatory but encouraged)**

![](https://i.ytimg.com/vi/6TkFojsmdpw/hqdefault.jpg)