### PR TITLE
fix: stringify server error message in authentication page

### DIFF
--- a/packages/netlify-cms-backend-git-gateway/src/AuthenticationPage.js
+++ b/packages/netlify-cms-backend-git-gateway/src/AuthenticationPage.js
@@ -194,7 +194,7 @@ export default class GitGatewayAuthenticationPage extends React.Component {
         renderPageContent={() => (
           <AuthForm onSubmit={this.handleLogin}>
             {!error ? null : <ErrorMessage>{error}</ErrorMessage>}
-            {!errors.server ? null : <ErrorMessage>{errors.server}</ErrorMessage>}
+            {!errors.server ? null : <ErrorMessage>{String(errors.server)}</ErrorMessage>}
             <ErrorMessage>{errors.email || null}</ErrorMessage>
             <AuthInput
               type="text"


### PR DESCRIPTION
**Summary**

Just got a `TextHttpError` in the `AuthenticationPage` -- which throws with "Objects are not valid as a React child" -- so this stringifies the error object before rendering.

**Test plan**

None