### PR TITLE
fix: dispatch QUERY_FAILURE on query failure

### DIFF
--- a/packages/netlify-cms-core/src/actions/search.js
+++ b/packages/netlify-cms-core/src/actions/search.js
@@ -74,7 +74,7 @@ export function querySuccess(namespace, collection, searchFields, searchTerm, re
 
 export function queryFailure(namespace, collection, searchFields, searchTerm, error) {
   return {
-    type: QUERY_SUCCESS,
+    type: QUERY_FAILURE,
     payload: {
       namespace,
       collection,

--- a/packages/netlify-cms-widget-relation/src/RelationControl.js
+++ b/packages/netlify-cms-widget-relation/src/RelationControl.js
@@ -157,7 +157,10 @@ export default class RelationControl extends React.Component {
     const searchFieldsArray = List.isList(searchFields) ? searchFields.toJS() : [searchFields];
 
     query(forID, collection, searchFieldsArray, term).then(({ payload }) => {
-      let options = this.parseHitOptions(payload.response.hits);
+      let options =
+        payload.response && payload.response.hits
+          ? this.parseHitOptions(payload.response.hits)
+          : [];
 
       if (!this.allOptions && !term) {
         this.allOptions = options;


### PR DESCRIPTION
**Summary**

currently, the `queryFailure` action creator produces a `QUERY_SUCCESSS` action, which seems wrong??

(can't find where the error case is handled though)

**Test plan**

None
