### PR TITLE
doc: beta netlify-cms-proxy-server - add missing "backend" property i…

### DIFF
--- a/website/content/docs/beta-features.md
+++ b/website/content/docs/beta-features.md
@@ -16,19 +16,18 @@ You can connect Netlify CMS to a local Git repository, instead of working with a
 
 1. Navigate to a local Git repository configured with the CMS.
 2. Run `npx netlify-cms-proxy-server` from the root directory of the above repository.
-3. Add the `local_backend` configuration to your `config.yml`:
+3. Add the top-level property `local_backend` configuration to your `config.yml`:
 
 ```yaml
+backend:
+  name: git-gateway
+
 # when using the default proxy server port
 local_backend: true
 
 # when using a custom proxy server port
 local_backend:
   url: http://localhost:8082/api/v1
-
-# you can keep your existing backend configuration, e.g.
-backend:
-  name: git-gateway
 ```
 
 4. Start your local development server (e.g. run `gatsby develop`).

--- a/website/content/docs/beta-features.md
+++ b/website/content/docs/beta-features.md
@@ -25,6 +25,10 @@ local_backend: true
 # when using a custom proxy server port
 local_backend:
   url: http://localhost:8082/api/v1
+
+# in all cases the backend property must be kept
+backend:
+  name: whatever
 ```
 
 4. Start your local development server (e.g. run `gatsby develop`).

--- a/website/content/docs/beta-features.md
+++ b/website/content/docs/beta-features.md
@@ -26,9 +26,9 @@ local_backend: true
 local_backend:
   url: http://localhost:8082/api/v1
 
-# in all cases the backend property must be kept
+# you can keep your existing backend configuration, e.g.
 backend:
-  name: whatever
+  name: git-gateway
 ```
 
 4. Start your local development server (e.g. run `gatsby develop`).


### PR DESCRIPTION
Hi again, 

Following https://github.com/netlify/netlify-cms/pull/3230 I managed to use `netlify-cms-proxy-server` (thanks @erezrokah ! :tada:). But it took me some time to get a working config file, it's a detail but this really can help beginners like me !

I first thought that `local_backend: true` should be a sub-property of `backend`, then I understand that it has to be at top-level !

(maybe this should be qualified as a "bug": when defining `local_backend` config option, I don't see why `backend` stays mandatory)

**A picture of a cute animal (not mandatory but encouraged)**

![](http://3.bp.blogspot.com/-oSP-o4AaGPE/TtQEA_dm57I/AAAAAAAAAio/cPEpL4QmaoU/s1600/cute_mouse-8551.jpg)