### PR TITLE
fix: report config error when external media lib is missing

### DIFF
--- a/packages/netlify-cms-core/src/reducers/config.ts
+++ b/packages/netlify-cms-core/src/reducers/config.ts
@@ -3,7 +3,9 @@ import { CONFIG_REQUEST, CONFIG_SUCCESS, CONFIG_FAILURE, CONFIG_MERGE } from '..
 import { Config, ConfigAction } from '../types/redux';
 import { EDITORIAL_WORKFLOW } from '../constants/publishModes';
 
-const config = (state = Map({ isFetching: true }), action: ConfigAction) => {
+const defaultState: Map<string, boolean | string> = Map({ isFetching: true });
+
+const config = (state = defaultState, action: ConfigAction) => {
   switch (action.type) {
     case CONFIG_MERGE:
       return state.mergeDeep(action.payload);
@@ -17,7 +19,10 @@ const config = (state = Map({ isFetching: true }), action: ConfigAction) => {
        */
       return action.payload.delete('isFetching');
     case CONFIG_FAILURE:
-      return Map({ error: action.payload.toString() });
+      return state.withMutations(s => {
+        s.delete('isFetching');
+        s.set('error', action.payload.toString());
+      });
     default:
       return state;
   }

--- a/packages/netlify-cms-core/src/types/redux.ts
+++ b/packages/netlify-cms-core/src/types/redux.ts
@@ -41,6 +41,7 @@ export type Config = StaticallyTypedRecord<{
   site_id?: string;
   site_url?: string;
   show_preview_links?: boolean;
+  isFetching?: boolean;
 }>;
 
 type PagesObject = {


### PR DESCRIPTION
Fixes https://github.com/netlify/netlify-cms/issues/3248

At the moment the CMS will fail silently and revert to internal media library.