### PR TITLE
fix(widget-datetime): use default value when value is undefined

### DIFF
--- a/packages/netlify-cms-widget-datetime/src/DateTimeControl.js
+++ b/packages/netlify-cms-widget-datetime/src/DateTimeControl.js
@@ -37,14 +37,14 @@ export default class DateTimeControl extends React.Component {
     };
   }
 
-  getDefault() {    
+  getDefaultValue() {    
     const { field } = this.props;
-    const default = field.get('default');
-    return default;
+    const defaultValue = field.get('default');
+    return defaultValue;
   }
 
   formats = this.getFormats();
-  default = this.getDefault();
+  defaultValue = this.getDefaultValue();
 
   componentDidMount() {
     const { value } = this.props;
@@ -53,7 +53,7 @@ export default class DateTimeControl extends React.Component {
      * Set the current date as default value if no value is provided and default is absent. An
      * empty default string means the value is intentionally blank.
      */
-    if (!value && default === 'undefined' ) {
+    if (!value && this.defaultValue === 'undefined' ) {
       setTimeout(() => {
         this.handleChange(new Date());
       }, 0);

--- a/packages/netlify-cms-widget-datetime/src/DateTimeControl.js
+++ b/packages/netlify-cms-widget-datetime/src/DateTimeControl.js
@@ -53,9 +53,9 @@ export default class DateTimeControl extends React.Component {
      * Set the current date as default value if no value is provided and default is absent. An
      * empty default string means the value is intentionally blank.
      */
-    if (value === undefined && this.defaultValue === undefined) {
+    if (value === undefined) {
       setTimeout(() => {
-        this.handleChange(new Date());
+        this.handleChange(this.defaultValue === undefined ? new Date() : this.defaultValue);
       }, 0);
     }
   }
@@ -118,11 +118,7 @@ export default class DateTimeControl extends React.Component {
         <DateTime
           dateFormat={dateFormat}
           timeFormat={timeFormat}
-          value={
-            value === undefined && this.defaultValue !== undefined
-              ? this.defaultValue
-              : moment(value, format)
-          }
+          value={moment(value, format)}
           onChange={this.handleChange}
           onFocus={setActiveStyle}
           onBlur={this.onBlur}

--- a/packages/netlify-cms-widget-datetime/src/DateTimeControl.js
+++ b/packages/netlify-cms-widget-datetime/src/DateTimeControl.js
@@ -53,7 +53,7 @@ export default class DateTimeControl extends React.Component {
      * Set the current date as default value if no value is provided and default is absent. An
      * empty default string means the value is intentionally blank.
      */
-    if (!value && this.defaultValue === 'undefined') {
+    if (value === undefined && this.defaultValue === undefined) {
       setTimeout(() => {
         this.handleChange(new Date());
       }, 0);
@@ -108,6 +108,7 @@ export default class DateTimeControl extends React.Component {
   render() {
     const { forID, value, classNameWrapper, setActiveStyle } = this.props;
     const { format, dateFormat, timeFormat } = this.formats;
+
     return (
       <div
         css={css`
@@ -117,7 +118,11 @@ export default class DateTimeControl extends React.Component {
         <DateTime
           dateFormat={dateFormat}
           timeFormat={timeFormat}
-          value={moment(value, format)}
+          value={
+            value === undefined && this.defaultValue !== undefined
+              ? this.defaultValue
+              : moment(value, format)
+          }
           onChange={this.handleChange}
           onFocus={setActiveStyle}
           onBlur={this.onBlur}

--- a/packages/netlify-cms-widget-datetime/src/DateTimeControl.js
+++ b/packages/netlify-cms-widget-datetime/src/DateTimeControl.js
@@ -37,7 +37,14 @@ export default class DateTimeControl extends React.Component {
     };
   }
 
+  getDefault() {    
+    const { field } = this.props;
+    const default = field.get('default');
+    return default;
+  }
+
   formats = this.getFormats();
+  default = this.getDefault();
 
   componentDidMount() {
     const { value } = this.props;
@@ -46,7 +53,7 @@ export default class DateTimeControl extends React.Component {
      * Set the current date as default value if no default value is provided. An
      * empty string means the value is intentionally blank.
      */
-    if (!value && value !== '') {
+    if (!value && default === 'undefined' ) {
       setTimeout(() => {
         this.handleChange(new Date());
       }, 0);

--- a/packages/netlify-cms-widget-datetime/src/DateTimeControl.js
+++ b/packages/netlify-cms-widget-datetime/src/DateTimeControl.js
@@ -50,8 +50,8 @@ export default class DateTimeControl extends React.Component {
     const { value } = this.props;
 
     /**
-     * Set the current date as default value if no default value is provided. An
-     * empty string means the value is intentionally blank.
+     * Set the current date as default value if no value is provided and default is absent. An
+     * empty default string means the value is intentionally blank.
      */
     if (!value && default === 'undefined' ) {
       setTimeout(() => {

--- a/packages/netlify-cms-widget-datetime/src/DateTimeControl.js
+++ b/packages/netlify-cms-widget-datetime/src/DateTimeControl.js
@@ -37,7 +37,7 @@ export default class DateTimeControl extends React.Component {
     };
   }
 
-  getDefaultValue() {    
+  getDefaultValue() {
     const { field } = this.props;
     const defaultValue = field.get('default');
     return defaultValue;
@@ -53,7 +53,7 @@ export default class DateTimeControl extends React.Component {
      * Set the current date as default value if no value is provided and default is absent. An
      * empty default string means the value is intentionally blank.
      */
-    if (!value && this.defaultValue === 'undefined' ) {
+    if (!value && this.defaultValue === 'undefined') {
       setTimeout(() => {
         this.handleChange(new Date());
       }, 0);


### PR DESCRIPTION
Fixes https://github.com/netlify/netlify-cms/issues/1745

instead of checking empty value, explicitly check default from config. Checks on change for deciding entity with empty value, but also checks on render in case of new empty parent object.

<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines.

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first two fields are mandatory:
-->

**Summary**

<!--
Explain the **motivation** for making this change.
What existing problem does the pull request solve?
-->

**Test plan**

<!--
Demonstrate the code is solid.
Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.
-->

**A picture of a cute animal (not mandatory but encouraged)**
