### PR TITLE
fix: allow to set initial draft value & metadata w/o toggling hasChanged

### DIFF
--- a/packages/netlify-cms-core/src/actions/entries.ts
+++ b/packages/netlify-cms-core/src/actions/entries.ts
@@ -219,10 +219,15 @@ export function discardDraft() {
   return { type: DRAFT_DISCARD };
 }
 
-export function changeDraftField(field: string, value: string, metadata: Record<string, unknown>) {
+export function changeDraftField(
+  field: string,
+  value: string,
+  metadata: Record<string, unknown>,
+  hasChanged = true,
+) {
   return {
     type: DRAFT_CHANGE_FIELD,
-    payload: { field, value, metadata },
+    payload: { field, value, metadata, hasChanged },
   };
 }
 

--- a/packages/netlify-cms-core/src/components/Editor/EditorControlPane/EditorControl.js
+++ b/packages/netlify-cms-core/src/components/Editor/EditorControlPane/EditorControl.js
@@ -222,7 +222,9 @@ class EditorControl extends React.Component {
               value={value}
               mediaPaths={mediaPaths}
               metadata={metadata}
-              onChange={(newValue, newMetadata) => onChange(fieldName, newValue, newMetadata)}
+              onChange={(newValue, newMetadata, hasChanged) =>
+                onChange(fieldName, newValue, newMetadata, hasChanged)
+              }
               onValidate={onValidate && partial(onValidate, this.uniqueFieldId)}
               onOpenMediaLibrary={openMediaLibrary}
               onClearMediaControl={clearMediaControl}

--- a/packages/netlify-cms-core/src/components/Editor/EditorControlPane/Widget.js
+++ b/packages/netlify-cms-core/src/components/Editor/EditorControlPane/Widget.js
@@ -208,11 +208,12 @@ export default class Widget extends Component {
   /**
    * Change handler for fields that are nested within another field.
    */
-  onChangeObject = (fieldName, newValue, newMetadata) => {
+  onChangeObject = (fieldName, newValue, newMetadata, hasChanged) => {
     const newObjectValue = this.getObjectValue().set(fieldName, newValue);
     return this.props.onChange(
       newObjectValue,
       newMetadata && { [this.props.field.get('name')]: newMetadata },
+      hasChanged,
     );
   };
 

--- a/packages/netlify-cms-core/src/reducers/entryDraft.js
+++ b/packages/netlify-cms-core/src/reducers/entryDraft.js
@@ -92,7 +92,7 @@ const entryDraftReducer = (state = Map(), action) => {
       return state.withMutations(state => {
         state.setIn(['entry', 'data', action.payload.field], action.payload.value);
         state.mergeDeepIn(['fieldsMetaData'], fromJS(action.payload.metadata));
-        state.set('hasChanged', true);
+        state.set('hasChanged', state.get('hasChanged') || action.payload.hasChanged);
       });
 
     case DRAFT_VALIDATION_ERRORS:

--- a/packages/netlify-cms-widget-date/src/DateControl.js
+++ b/packages/netlify-cms-widget-date/src/DateControl.js
@@ -62,7 +62,7 @@ export default class DateControl extends React.Component {
      */
     if (!value && value !== '') {
       setTimeout(() => {
-        this.handleChange(new Date());
+        this.handleChange(new Date(), false);
       }, 0);
     }
   }
@@ -72,7 +72,7 @@ export default class DateControl extends React.Component {
   isValidDate = datetime =>
     moment.isMoment(datetime) || datetime instanceof Date || datetime === '';
 
-  handleChange = datetime => {
+  handleChange = (datetime, hasChanged) => {
     /**
      * Set the date only if it is valid.
      */
@@ -89,10 +89,10 @@ export default class DateControl extends React.Component {
      */
     if (format) {
       const formattedValue = datetime ? moment(datetime).format(format) : '';
-      onChange(formattedValue);
+      onChange(formattedValue, undefined, hasChanged);
     } else {
       const value = moment.isMoment(datetime) ? datetime.toDate() : datetime;
-      onChange(value);
+      onChange(value, undefined, hasChanged);
     }
   };
 

--- a/packages/netlify-cms-widget-datetime/src/DateTimeControl.js
+++ b/packages/netlify-cms-widget-datetime/src/DateTimeControl.js
@@ -48,7 +48,7 @@ export default class DateTimeControl extends React.Component {
      */
     if (!value && value !== '') {
       setTimeout(() => {
-        this.handleChange(new Date());
+        this.handleChange(new Date(), false);
       }, 0);
     }
   }
@@ -58,7 +58,7 @@ export default class DateTimeControl extends React.Component {
   isValidDate = datetime =>
     moment.isMoment(datetime) || datetime instanceof Date || datetime === '';
 
-  handleChange = datetime => {
+  handleChange = (datetime, hasChanged) => {
     /**
      * Set the date only if it is valid.
      */
@@ -75,10 +75,10 @@ export default class DateTimeControl extends React.Component {
      */
     if (format) {
       const formattedValue = datetime ? moment(datetime).format(format) : '';
-      onChange(formattedValue);
+      onChange(formattedValue, undefined, hasChanged);
     } else {
       const value = moment.isMoment(datetime) ? datetime.toDate() : datetime;
-      onChange(value);
+      onChange(value, undefined, hasChanged);
     }
   };
 

--- a/packages/netlify-cms-widget-list/src/ListControl.js
+++ b/packages/netlify-cms-widget-list/src/ListControl.js
@@ -248,7 +248,7 @@ export default class ListControl extends React.Component {
   getObjectValue = idx => this.props.value.get(idx) || Map();
 
   handleChangeFor(index) {
-    return (fieldName, newValue, newMetadata) => {
+    return (fieldName, newValue, newMetadata, hasChanged) => {
       const { value, metadata, onChange, field } = this.props;
       const collectionName = field.get('name');
       const listFieldObjectWidget = field.getIn(['field', 'widget']) === 'object';
@@ -261,7 +261,7 @@ export default class ListControl extends React.Component {
       const parsedMetadata = {
         [collectionName]: Object.assign(metadata ? metadata.toJS() : {}, newMetadata || {}),
       };
-      onChange(value.set(index, newObjectValue), parsedMetadata);
+      onChange(value.set(index, newObjectValue), parsedMetadata, hasChanged);
     };
   }
 

--- a/packages/netlify-cms-widget-relation/src/RelationControl.js
+++ b/packages/netlify-cms-widget-relation/src/RelationControl.js
@@ -74,11 +74,15 @@ export default class RelationControl extends React.Component {
         listValue.forEach(val => {
           const hit = hits.find(i => this.parseNestedFields(i.data, valueField) === val);
           if (hit) {
-            onChange(value, {
-              [field.get('name')]: {
-                [field.get('collection')]: { [val]: hit.data },
+            onChange(
+              value,
+              {
+                [field.get('name')]: {
+                  [field.get('collection')]: { [val]: hit.data },
+                },
               },
-            });
+              false,
+            );
           }
         });
       }


### PR DESCRIPTION
**Summary**

Currently, the `datetime` and `relation` widgets can inadvertently set `hasChanged` on initial load. Either because of setting a field's default value (datetime), or when updating a field's metadata (relation).

This PR allows updating a draft field's value/metadata without changing the `hasChanged` flag. It adds a third parameter to `onChange`.

**Alternative approach**

alternative would be to introduce dedicated actions for updating initial draft field value and metadata

**Test plan**

If you think this makes sense I'll add some tests. I checked this with the kitchen sink test which works correctly -- as long as the initial state of the slate editor is set to md (not rich text), which looks like it's an unrelated bug (#3280).
