### PR TITLE
fix(widget-markdown): don't add duplicate marks

### DIFF
--- a/packages/netlify-cms-widget-markdown/src/serializers/__tests__/__fixtures__/issue_3280.md
+++ b/packages/netlify-cms-widget-markdown/src/serializers/__tests__/__fixtures__/issue_3280.md
@@ -1,0 +1,1 @@
+Fill to_*this*_mark, and your charge is but a penny; to_*this*_a penny more; and so on to the full glass—the Cape Horn measure, which you may gulp down for a shilling.\n\nUpon entering the place I found a number of young seamen gathered about a table, examining by a dim light divers specimens of_*skrimshander*.

--- a/packages/netlify-cms-widget-markdown/src/serializers/__tests__/index.spec.js
+++ b/packages/netlify-cms-widget-markdown/src/serializers/__tests__/index.spec.js
@@ -1,0 +1,41 @@
+import path from 'path';
+import fs from 'fs';
+import { markdownToSlate } from '../';
+
+describe('markdownToSlate', () => {
+  it('should handle use case from issue 3280', () => {
+    const mdast = fs.readFileSync(path.join(__dirname, '__fixtures__', 'issue_3280.md'));
+    const slate = markdownToSlate(mdast);
+
+    expect(slate).toEqual({
+      object: 'block',
+      type: 'root',
+      nodes: [
+        {
+          object: 'block',
+          type: 'paragraph',
+          nodes: [
+            {
+              object: 'text',
+              text: 'Fill to',
+            },
+            {
+              object: 'text',
+              text:
+                'this_mark, and your charge is but a penny; tothisa penny more; and so on to the full glass—the Cape Horn measure, which you may gulp down for a shilling.\\n\\nUpon entering the place I found a number of young seamen gathered about a table, examining by a dim light divers specimens ofskrimshander',
+              marks: [
+                {
+                  type: 'italic',
+                },
+              ],
+            },
+            {
+              object: 'text',
+              text: '.',
+            },
+          ],
+        },
+      ],
+    });
+  });
+});

--- a/packages/netlify-cms-widget-markdown/src/serializers/remarkSlate.js
+++ b/packages/netlify-cms-widget-markdown/src/serializers/remarkSlate.js
@@ -230,7 +230,9 @@ export default function remarkToSlate({ voidCodeBlock } = {}) {
      * mark nodes, if any.
      */
     const markType = markMap[node.type];
-    const marks = markType ? [...parentMarks, { type: markMap[node.type] }] : parentMarks;
+    const marks = markType
+      ? [...parentMarks.filter(({ type }) => type !== markType), { type: markType }]
+      : parentMarks;
 
     const children = flatMap(node.children, child => processMarkChild(child, marks));
 


### PR DESCRIPTION
Fixes https://github.com/netlify/netlify-cms/issues/3280

The `italic` mark was added twice for the `this` text node thus preventing it from being merged here https://github.com/netlify/netlify-cms/blob/73f679480bb24ca3fbbd64b98f86a8bce99c3b25/packages/netlify-cms-widget-markdown/src/serializers/remarkSlate.js#L68