### PR TITLE
Add 'hero' as inferable image field

### DIFF
--- a/packages/netlify-cms-core/src/constants/fieldInference.js
+++ b/packages/netlify-cms-core/src/constants/fieldInference.js
@@ -58,7 +58,7 @@ export const INFERABLE_FIELDS = {
   image: {
     type: 'image',
     secondaryTypes: [],
-    synonyms: ['image', 'thumbnail', 'thumb', 'picture', 'avatar', 'photo', 'cover'],
+    synonyms: ['image', 'thumbnail', 'thumb', 'picture', 'avatar', 'photo', 'cover', 'hero'],
     defaultPreview: value => value,
     fallbackToFirstField: false,
     showError: false,


### PR DESCRIPTION
**Summary**

'hero' is used as the cover image field in the popular theme - https://github.com/narative/gatsby-theme-novela

**Test plan**

Tested locally using content grid view in the editor.
