### PR TITLE
fix!: ignore metadata when setting entry unsaved flag

### DIFF
--- a/packages/netlify-cms-core/src/reducers/__tests__/entryDraft.spec.js
+++ b/packages/netlify-cms-core/src/reducers/__tests__/entryDraft.spec.js
@@ -18,7 +18,9 @@ const entry = {
   path: 'content/blog/art-and-wine-festival.md',
   partial: false,
   raw: '',
-  data: {},
+  data: {
+    dataField: 'dataFieldInitialValue',
+  },
   metaData: null,
 };
 
@@ -62,6 +64,47 @@ describe('entryDraft reducer', () => {
   describe('DRAFT_DISCARD', () => {
     it('should discard the draft and return initial state', () => {
       expect(reducer(initialState, actions.discardDraft())).toEqual(initialState);
+    });
+  });
+
+  describe('DRAFT_CHANGE_FIELD', () => {
+    it('should update the draft field', () => {
+      const initialEntry = reducer(initialState, actions.createDraftFromEntry(fromJS(entry)));
+
+      const actualState = reducer(
+        initialEntry,
+        actions.changeDraftField('dataField', 'update', {}),
+      );
+
+      expect(actualState.toJS()).toEqual({
+        ...initialEntry.toJS(),
+        entry: {
+          ...initialEntry.toJS().entry,
+          data: {
+            dataField: 'update',
+          },
+        },
+        hasChanged: true,
+      });
+    });
+
+    it('should metadata update the draft field without marking hasChanged', () => {
+      const initialEntry = reducer(initialState, actions.createDraftFromEntry(fromJS(entry)));
+
+      const actualState = reducer(
+        initialEntry,
+        actions.changeDraftField('dataField', 'dataFieldInitialValue', {
+          metaField: 'metaFieldValue',
+        }),
+      );
+
+      expect(actualState.toJS()).toEqual({
+        ...initialEntry.toJS(),
+        fieldsMetaData: {
+          metaField: 'metaFieldValue',
+        },
+        hasChanged: false,
+      });
     });
   });
 

--- a/packages/netlify-cms-core/src/reducers/entryDraft.js
+++ b/packages/netlify-cms-core/src/reducers/entryDraft.js
@@ -1,4 +1,4 @@
-import { Map, List, fromJS } from 'immutable';
+import { Map, List, fromJS, is } from 'immutable';
 import uuid from 'uuid/v4';
 import {
   DRAFT_CREATE_FROM_ENTRY,
@@ -90,9 +90,12 @@ const entryDraftReducer = (state = Map(), action) => {
     }
     case DRAFT_CHANGE_FIELD:
       return state.withMutations(state => {
-        state.setIn(['entry', 'data', action.payload.field], action.payload.value);
         state.mergeDeepIn(['fieldsMetaData'], fromJS(action.payload.metadata));
-        state.set('hasChanged', true);
+        const prev = state.getIn(['entry', 'data', action.payload.field]);
+        if (!is(action.payload.value, prev)) {
+          state.setIn(['entry', 'data', action.payload.field], action.payload.value);
+          state.set('hasChanged', true);
+        }
       });
 
     case DRAFT_VALIDATION_ERRORS:


### PR DESCRIPTION
**Summary**

Relation widget updates metadata when first loading the relationship mapping.
These metadata updates cause any collections using the relation widget to always
get marked as having usaved changes whenever they are opened.

Note: This is obviously a pretty serious change to the underlying data model
semantics. It might not make sense, but there didn't seem to be a better way of handling
the relation widget without adding an extra field to the DRAFT_CHANGE_FIELD action
to flag that this is a metadata only change and to leave the `hasChanged` field alone.

This is the 'metadata fix' from #2377. Some of the issues reported in #725 will be resolved (#725 is only for new entries and default values, but many of the relation widget complaints for existing entries are being funneled to that issue - see #2743)

fixes #2211

**Test plan**

I've testing this fixed the relation widget for myself. I wasn't able to run the e2e test package on this machine when trying the `tests:all` script. The new test spec sets the `hasChanged` semantic.

**A picture of a cute animal (not mandatory but encouraged)**

![image](https://user-images.githubusercontent.com/119958/75103135-987df800-5631-11ea-9c4b-a665bd6bba34.png)

