### PR TITLE
feat: sanitize media filenames according to global slug setting

### DIFF
--- a/website/content/docs/configuration-options.md
+++ b/website/content/docs/configuration-options.md
@@ -156,7 +156,9 @@ show_preview_links: false
 
 ## Slug Type
 
-The `slug` option allows you to change how filenames for entries are created and sanitized. For modifying the actual data in a slug, see the per-collection option below.
+The `slug` option allows you to change how filenames for entries are created and sanitized.
+It also applies to filenames of media inserted via the default media library.  
+For modifying the actual data in a slug, see the per-collection option below.
 
 `slug` accepts multiple options:
 


### PR DESCRIPTION
Currently, users are allowed to upload images whose filename contains accents, spaces or special characters. This may cause several problems downstream (https://github.com/netlify/netlify-cms/issues/857). 

It seems that at some point, the work done in #1135 should have fixed that issue (see https://github.com/netlify/netlify-cms/issues/857#issuecomment-369054206) but I can't find any trace of that behaviour in the current codebase.

This PR adds/restores that feature by applying the policy defined in the global `slug` setting to media inserted via the default media library. 