### PR TITLE
Docs: Added Google Cloud Function to External OAuth Clients List

### DIFF
--- a/website/content/docs/authentication-backends.md
+++ b/website/content/docs/authentication-backends.md
@@ -177,6 +177,7 @@ If you would like to facilitate your own OAuth authentication rather than use Ne
 | [@marcelkornblum](https://github.com/marcelkornblum) | GitHub, GitHub Enterprise | Google AppEngine with Python                  | [Repo](https://github.com/signal-noise/netlify-cms-oauth-provider-python-appengine)                                                                  |
 | [@marksteele](https://github.com/marksteele)   | GitHub, GitHub Enterprise | Serverless              | [Repo](https://github.com/marksteele/netlify-serverless-oauth2-backend), [Blog](https://www.control-alt-del.org/blog/serverless-blog-howto/) |
 | [@Herohtar](https://github.com/Herohtar)       | GitHub, GitHub Enterprise | Firebase Cloud Function | [Repo](https://github.com/Herohtar/netlify-cms-oauth-firebase)                                                                               |
+| [@abcalderon3](https://github.com/abcalderon3) | GitHub, GitHub Enterprise | Google Cloud Function with Python | [Repo](https://github.com/abcalderon3/netlify-cms-oauth-client-cloud-function)                                                     |
 
 Check each project's documentation for instructions on how to configure it.
 


### PR DESCRIPTION
**Summary**
Adding a link to a new Google Cloud Function with Python  External OAuth Client to the Documentation

I created a new External OAuth Client running on Google Cloud Functions with Python for use in a lightweight open-source, community-driven project and would like to add it to the list in the Netlify CMS Documentation. Another user found it useful, so figured others may as well!

**Test plan**
Updated Website markdown only. Confirmed via running local website only.
