### PR TITLE
feat: populate new entry from URL params

### DIFF
--- a/packages/netlify-cms-core/src/actions/__tests__/entries.spec.js
+++ b/packages/netlify-cms-core/src/actions/__tests__/entries.spec.js
@@ -1,5 +1,6 @@
 import { fromJS, Map } from 'immutable';
 import {
+  createEmptyDraft,
   createEmptyDraftData,
   retrieveLocalBackup,
   persistLocalBackup,
@@ -23,6 +24,99 @@ const middlewares = [thunk];
 const mockStore = configureMockStore(middlewares);
 
 describe('entries', () => {
+  describe('createEmptyDraft', () => {
+    beforeEach(() => {
+      jest.clearAllMocks();
+    });
+    it('should dispatch draft created action', () => {
+      const store = mockStore({ mediaLibrary: fromJS({ files: [] }) });
+
+      const collection = fromJS({
+        fields: [{ name: 'title' }],
+      });
+
+      return store.dispatch(createEmptyDraft(collection, '')).then(() => {
+        const actions = store.getActions();
+        expect(actions).toHaveLength(1);
+
+        expect(actions[0]).toEqual({
+          payload: {
+            collection: undefined,
+            data: {},
+            isModification: null,
+            label: null,
+            mediaFiles: fromJS([]),
+            metaData: null,
+            partial: false,
+            path: '',
+            raw: '',
+            slug: '',
+          },
+          type: 'DRAFT_CREATE_EMPTY',
+        });
+      });
+    });
+
+    it('should populate draft entry from URL param', () => {
+      const store = mockStore({ mediaLibrary: fromJS({ files: [] }) });
+
+      const collection = fromJS({
+        fields: [{ name: 'title' }],
+      });
+
+      return store.dispatch(createEmptyDraft(collection, '?title=title')).then(() => {
+        const actions = store.getActions();
+        expect(actions).toHaveLength(1);
+
+        expect(actions[0]).toEqual({
+          payload: {
+            collection: undefined,
+            data: { title: 'title' },
+            isModification: null,
+            label: null,
+            mediaFiles: fromJS([]),
+            metaData: null,
+            partial: false,
+            path: '',
+            raw: '',
+            slug: '',
+          },
+          type: 'DRAFT_CREATE_EMPTY',
+        });
+      });
+    });
+
+    it('should html escape URL params', () => {
+      const store = mockStore({ mediaLibrary: fromJS({ files: [] }) });
+
+      const collection = fromJS({
+        fields: [{ name: 'title' }],
+      });
+
+      return store
+        .dispatch(createEmptyDraft(collection, "?title=<script>alert('hello')</script>"))
+        .then(() => {
+          const actions = store.getActions();
+          expect(actions).toHaveLength(1);
+
+          expect(actions[0]).toEqual({
+            payload: {
+              collection: undefined,
+              data: { title: '&lt;script&gt;alert(&#039;hello&#039;)&lt;/script&gt;' },
+              isModification: null,
+              label: null,
+              mediaFiles: fromJS([]),
+              metaData: null,
+              partial: false,
+              path: '',
+              raw: '',
+              slug: '',
+            },
+            type: 'DRAFT_CREATE_EMPTY',
+          });
+        });
+    });
+  });
   describe('createEmptyDraftData', () => {
     it('should set default value for list field widget', () => {
       const fields = fromJS([

--- a/packages/netlify-cms-core/src/actions/__tests__/entries.spec.js
+++ b/packages/netlify-cms-core/src/actions/__tests__/entries.spec.js
@@ -61,17 +61,17 @@ describe('entries', () => {
       const store = mockStore({ mediaLibrary: fromJS({ files: [] }) });
 
       const collection = fromJS({
-        fields: [{ name: 'title' }],
+        fields: [{ name: 'title' }, { name: 'boolean' }],
       });
 
-      return store.dispatch(createEmptyDraft(collection, '?title=title')).then(() => {
+      return store.dispatch(createEmptyDraft(collection, '?title=title&boolean=True')).then(() => {
         const actions = store.getActions();
         expect(actions).toHaveLength(1);
 
         expect(actions[0]).toEqual({
           payload: {
             collection: undefined,
-            data: { title: 'title' },
+            data: { title: 'title', boolean: true },
             isModification: null,
             label: null,
             mediaFiles: fromJS([]),

--- a/packages/netlify-cms-core/src/components/Editor/Editor.js
+++ b/packages/netlify-cms-core/src/components/Editor/Editor.js
@@ -78,6 +78,7 @@ export class Editor extends React.Component {
     user: ImmutablePropTypes.map.isRequired,
     location: PropTypes.shape({
       pathname: PropTypes.string,
+      search: PropTypes.string,
     }),
     hasChanged: PropTypes.bool,
     t: PropTypes.func.isRequired,
@@ -104,7 +105,7 @@ export class Editor extends React.Component {
     retrieveLocalBackup(collection, slug);
 
     if (newEntry) {
-      createEmptyDraft(collection);
+      createEmptyDraft(collection, this.props.location.search);
     } else {
       loadEntry(collection, slug);
     }
@@ -209,7 +210,7 @@ export class Editor extends React.Component {
       const fieldsMetaData = this.props.entryDraft && this.props.entryDraft.get('fieldsMetaData');
       this.createDraft(deserializedEntry, fieldsMetaData);
     } else if (newEntry) {
-      prevProps.createEmptyDraft(collection);
+      prevProps.createEmptyDraft(collection, this.props.location.search);
     }
   }
 

--- a/packages/netlify-cms-core/src/components/Editor/__tests__/Editor.spec.js
+++ b/packages/netlify-cms-core/src/components/Editor/__tests__/Editor.spec.js
@@ -50,6 +50,7 @@ describe('Editor', () => {
     localBackup: fromJS({}),
     retrieveLocalBackup: jest.fn(),
     persistLocalBackup: jest.fn(),
+    location: { search: '?title=title' },
   };
 
   beforeEach(() => {
@@ -114,7 +115,7 @@ describe('Editor', () => {
     );
 
     expect(props.createEmptyDraft).toHaveBeenCalledTimes(1);
-    expect(props.createEmptyDraft).toHaveBeenCalledWith(props.collection);
+    expect(props.createEmptyDraft).toHaveBeenCalledWith(props.collection, '?title=title');
     expect(props.loadEntry).toHaveBeenCalledTimes(0);
   });
 

--- a/packages/netlify-cms-core/src/reducers/__tests__/collections.spec.js
+++ b/packages/netlify-cms-core/src/reducers/__tests__/collections.spec.js
@@ -8,6 +8,7 @@ import collections, {
   selectMediaFolders,
   getFieldsNames,
   selectField,
+  updateFieldByKey,
 } from '../collections';
 import { FILES, FOLDER } from 'Constants/collectionTypes';
 
@@ -378,6 +379,90 @@ describe('collections', () => {
           .get(0)
           .get('types')
           .get(0),
+      );
+    });
+  });
+
+  describe('updateFieldByKey', () => {
+    it('should update field by key', () => {
+      const collection = fromJS({
+        fields: [
+          { name: 'title' },
+          { name: 'image' },
+          {
+            name: 'object',
+            fields: [{ name: 'title' }, { name: 'gallery', fields: [{ name: 'image' }] }],
+          },
+          { name: 'list', field: { name: 'image' } },
+          { name: 'body' },
+        ],
+      });
+
+      const updater = field => field.set('default', 'default');
+
+      expect(updateFieldByKey(collection, 'non-existent', updater)).toBe(collection);
+      expect(updateFieldByKey(collection, 'title', updater)).toEqual(
+        fromJS({
+          fields: [
+            { name: 'title', default: 'default' },
+            { name: 'image' },
+            {
+              name: 'object',
+              fields: [{ name: 'title' }, { name: 'gallery', fields: [{ name: 'image' }] }],
+            },
+            { name: 'list', field: { name: 'image' } },
+            { name: 'body' },
+          ],
+        }),
+      );
+      expect(updateFieldByKey(collection, 'object.title', updater)).toEqual(
+        fromJS({
+          fields: [
+            { name: 'title' },
+            { name: 'image' },
+            {
+              name: 'object',
+              fields: [
+                { name: 'title', default: 'default' },
+                { name: 'gallery', fields: [{ name: 'image' }] },
+              ],
+            },
+            { name: 'list', field: { name: 'image' } },
+            { name: 'body' },
+          ],
+        }),
+      );
+
+      expect(updateFieldByKey(collection, 'object.gallery.image', updater)).toEqual(
+        fromJS({
+          fields: [
+            { name: 'title' },
+            { name: 'image' },
+            {
+              name: 'object',
+              fields: [
+                { name: 'title' },
+                { name: 'gallery', fields: [{ name: 'image', default: 'default' }] },
+              ],
+            },
+            { name: 'list', field: { name: 'image' } },
+            { name: 'body' },
+          ],
+        }),
+      );
+      expect(updateFieldByKey(collection, 'list.image', updater)).toEqual(
+        fromJS({
+          fields: [
+            { name: 'title' },
+            { name: 'image' },
+            {
+              name: 'object',
+              fields: [{ name: 'title' }, { name: 'gallery', fields: [{ name: 'image' }] }],
+            },
+            { name: 'list', field: { name: 'image', default: 'default' } },
+            { name: 'body' },
+          ],
+        }),
       );
     });
   });

--- a/packages/netlify-cms-core/src/reducers/__tests__/collections.spec.js
+++ b/packages/netlify-cms-core/src/reducers/__tests__/collections.spec.js
@@ -395,6 +395,7 @@ describe('collections', () => {
           },
           { name: 'list', field: { name: 'image' } },
           { name: 'body' },
+          { name: 'widgetList', types: [{ name: 'widget' }] },
         ],
       });
 
@@ -412,6 +413,7 @@ describe('collections', () => {
             },
             { name: 'list', field: { name: 'image' } },
             { name: 'body' },
+            { name: 'widgetList', types: [{ name: 'widget' }] },
           ],
         }),
       );
@@ -429,6 +431,7 @@ describe('collections', () => {
             },
             { name: 'list', field: { name: 'image' } },
             { name: 'body' },
+            { name: 'widgetList', types: [{ name: 'widget' }] },
           ],
         }),
       );
@@ -447,6 +450,7 @@ describe('collections', () => {
             },
             { name: 'list', field: { name: 'image' } },
             { name: 'body' },
+            { name: 'widgetList', types: [{ name: 'widget' }] },
           ],
         }),
       );
@@ -461,6 +465,23 @@ describe('collections', () => {
             },
             { name: 'list', field: { name: 'image', default: 'default' } },
             { name: 'body' },
+            { name: 'widgetList', types: [{ name: 'widget' }] },
+          ],
+        }),
+      );
+
+      expect(updateFieldByKey(collection, 'widgetList.widget', updater)).toEqual(
+        fromJS({
+          fields: [
+            { name: 'title' },
+            { name: 'image' },
+            {
+              name: 'object',
+              fields: [{ name: 'title' }, { name: 'gallery', fields: [{ name: 'image' }] }],
+            },
+            { name: 'list', field: { name: 'image' } },
+            { name: 'body' },
+            { name: 'widgetList', types: [{ name: 'widget', default: 'default' }] },
           ],
         }),
       );

--- a/packages/netlify-cms-core/src/reducers/collections.ts
+++ b/packages/netlify-cms-core/src/reducers/collections.ts
@@ -261,6 +261,8 @@ export const updateFieldByKey = (
           return field.set('fields', traverseFields(field.get('fields')!));
         } else if (field.has('field')) {
           return field.set('field', traverseFields(List([field.get('field')!])).get(0));
+        } else if (field.has('types')) {
+          return field.set('types', traverseFields(field.get('types')!));
         } else {
           return field;
         }

--- a/packages/netlify-cms-core/src/reducers/collections.ts
+++ b/packages/netlify-cms-core/src/reducers/collections.ts
@@ -233,6 +233,51 @@ export const selectField = (collection: Collection, key: string) => {
   return field;
 };
 
+export const updateFieldByKey = (
+  collection: Collection,
+  key: string,
+  updater: (field: EntryField) => EntryField,
+) => {
+  const selected = selectField(collection, key);
+  if (!selected) {
+    return collection;
+  }
+
+  let updated = false;
+
+  const traverseFields = (fields: List<EntryField>) => {
+    if (updated) {
+      // we can stop once the field is found
+      return fields;
+    }
+
+    fields = fields
+      .map(f => {
+        const field = f as EntryField;
+        if (field === selected) {
+          updated = true;
+          return updater(field);
+        } else if (field.has('fields')) {
+          return field.set('fields', traverseFields(field.get('fields')!));
+        } else if (field.has('field')) {
+          return field.set('field', traverseFields(List([field.get('field')!])).get(0));
+        } else {
+          return field;
+        }
+      })
+      .toList() as List<EntryField>;
+
+    return fields;
+  };
+
+  collection = collection.set(
+    'fields',
+    traverseFields(collection.get('fields', List<EntryField>())),
+  );
+
+  return collection;
+};
+
 export const selectIdentifier = (collection: Collection) => {
   const identifier = collection.get('identifier_field');
   const identifierFields = identifier ? [identifier, ...IDENTIFIER_FIELDS] : IDENTIFIER_FIELDS;

--- a/packages/netlify-cms-core/src/types/redux.ts
+++ b/packages/netlify-cms-core/src/types/redux.ts
@@ -95,7 +95,7 @@ export type EntryField = StaticallyTypedRecord<{
   types?: List<EntryField>;
   widget: string;
   name: string;
-  default: string | null;
+  default: string | null | boolean;
   media_folder?: string;
   public_folder?: string;
 }>;

--- a/website/content/docs/beta-features.md
+++ b/website/content/docs/beta-features.md
@@ -142,10 +142,10 @@ And for the image field being populated with a value of `image.png`.
 
 Supports all of the [`slug` templates](/docs/configuration-options#slug) and:
 
-* `{{filename}}` The file name without the extension part.
-* `{{extension}}` The file extension.
-* `{{media_folder}}` The global `media_folder`.
-* `{{public_folder}}` The global `public_folder`.
+- `{{filename}}` The file name without the extension part.
+- `{{extension}}` The file extension.
+- `{{media_folder}}` The global `media_folder`.
+- `{{public_folder}}` The global `public_folder`.
 
 ## List Widget: Variable Types
 
@@ -156,9 +156,9 @@ pane.**
 
 To use variable types in the list widget, update your field configuration as follows:
 
-1. Instead of defining your list fields under `fields` or `field`, define them under `types`.  Similar to `fields`, `types` must be an array of field definition objects.
+1. Instead of defining your list fields under `fields` or `field`, define them under `types`. Similar to `fields`, `types` must be an array of field definition objects.
 2. Each field definition under `types` must use the `object` widget (this is the default value for
-`widget`).
+   `widget`).
 
 ### Additional list widget options
 
@@ -171,27 +171,27 @@ The example configuration below imagines a scenario where the editor can add two
 either a "carousel" or a "spotlight". Each type has a unique name and set of fields.
 
 ```yaml
-- label: "Home Section"
-  name: "sections"
-  widget: "list"
+- label: 'Home Section'
+  name: 'sections'
+  widget: 'list'
   types:
-    - label: "Carousel"
-      name: "carousel"
+    - label: 'Carousel'
+      name: 'carousel'
       widget: object
       fields:
-        - {label: Header, name: header, widget: string, default: "Image Gallery"}
-        - {label: Template, name: template, widget: string, default: "carousel.html"}
+        - { label: Header, name: header, widget: string, default: 'Image Gallery' }
+        - { label: Template, name: template, widget: string, default: 'carousel.html' }
         - label: Images
           name: images
           widget: list
-          field: {label: Image, name: image, widget: image}
-    - label: "Spotlight"
-      name: "spotlight"
+          field: { label: Image, name: image, widget: image }
+    - label: 'Spotlight'
+      name: 'spotlight'
       widget: object
       fields:
-        - {label: Header, name: header, widget: string, default: "Spotlight"}
-        - {label: Template, name: template, widget: string, default: "spotlight.html"}
-        - {label: Text, name: text, widget: text, default: "Hello World"}
+        - { label: Header, name: header, widget: string, default: 'Spotlight' }
+        - { label: Template, name: template, widget: string, default: 'spotlight.html' }
+        - { label: Text, name: text, widget: text, default: 'Hello World' }
 ```
 
 ### Example Output
@@ -310,8 +310,8 @@ CMS.registerPreviewTemplate(...);
  * Takes advantage of the `toString` method in the return value of `css-loader`.
  */
 import CMS from 'netlify-cms';
-import styles from '!css-loader!sass-loader!../main.scss'
-CMS.registerPreviewStyle(styles.toString(), { raw: true })
+import styles from '!css-loader!sass-loader!../main.scss';
+CMS.registerPreviewStyle(styles.toString(), { raw: true });
 ```
 
 ## Squash merge GitHub pull requests
@@ -348,14 +348,14 @@ backend:
 
 Netlify CMS generates the following commit types:
 
-Commit type   | When is it triggered?        | Available template tags
---------------|------------------------------|-----------------------------
-`create`      | A new entry is created       | `slug`, `path`, `collection`
-`update`      | An existing entry is changed | `slug`, `path`, `collection`
-`delete`      | An exising entry is deleted  | `slug`, `path`, `collection`
-`uploadMedia` | A media file is uploaded     | `path`
-`deleteMedia` | A media file is deleted      | `path`
-`openAuthoring` | A commit is made via a forked repository | `message`, `author-login`, `author-name`
+| Commit type     | When is it triggered?                    | Available template tags                  |
+| --------------- | ---------------------------------------- | ---------------------------------------- |
+| `create`        | A new entry is created                   | `slug`, `path`, `collection`             |
+| `update`        | An existing entry is changed             | `slug`, `path`, `collection`             |
+| `delete`        | An exising entry is deleted              | `slug`, `path`, `collection`             |
+| `uploadMedia`   | A media file is uploaded                 | `path`                                   |
+| `deleteMedia`   | A media file is deleted                  | `path`                                   |
+| `openAuthoring` | A commit is made via a forked repository | `message`, `author-login`, `author-name` |
 
 Template tags produce the following output:
 
@@ -378,10 +378,10 @@ You can set a limit to as what the maximum file size of a file is that users can
 Example config:
 
 ```yaml
-- label: "Featured Image"
-  name: "thumbnail"
-  widget: "image"
-  default: "/uploads/chocolate-dogecoin.jpg"
+- label: 'Featured Image'
+  name: 'thumbnail'
+  widget: 'image'
+  default: '/uploads/chocolate-dogecoin.jpg'
   media_library:
     config:
       max_file_size: 512000 # in bytes, only for default media library
@@ -415,7 +415,7 @@ CMS.registerEventListener({
 });
 ```
 
-> Supported events are `prePublish`, `postPublish`, `preUnpublish` and `postUnpublish`
+**Note:** Supported events are `prePublish`, `postPublish`, `preUnpublish` and `postUnpublish`.
 
 ## Dynamic Default Values
 
@@ -440,9 +440,14 @@ collections:
           - label: Title
             name: title
             widget: string
+      - label: body
+        name: body
+        widget: markdown
 ```
 
-clicking the following link: `/#/collections/posts/new?title=first&object.title=second`
+clicking the following link: `/#/collections/posts/new?title=first&object.title=second&body=%23%20content`
 
-will open the editor for a new post with the `title` field populated with `first` and the nested `object.title` field
-with `second`.
+will open the editor for a new post with the `title` field populated with `first`, the nested `object.title` field
+with `second` and the markdown `body` field with `# content`.
+
+**Note:** URL Encoding might be required for certain values (e.g. in the previous example the value for `body` is URL encoded).

--- a/website/content/docs/beta-features.md
+++ b/website/content/docs/beta-features.md
@@ -416,3 +416,33 @@ CMS.registerEventListener({
 ```
 
 > Supported events are `prePublish`, `postPublish`, `preUnpublish` and `postUnpublish`
+
+## Dynamic Default Values
+
+When linking to `/admin/#/collections/posts/new` you can pass URL parameters to pre-populate an entry.
+
+For example given the configuration:
+
+```yaml
+collections:
+  - name: posts
+    label: Posts
+    folder: content/posts
+    create: true
+    fields:
+      - label: Title
+        name: title
+        widget: string
+      - label: Object
+        name: object
+        widget: object
+        fields:
+          - label: Title
+            name: title
+            widget: string
+```
+
+clicking the following link: `/#/collections/posts/new?title=first&object.title=second`
+
+will open the editor for a new post with the `title` field populated with `first` and the nested `object.title` field
+with `second`.


### PR DESCRIPTION
Fixes #3322

![populate_from_url](https://user-images.githubusercontent.com/26760571/75560916-619b4e00-5a46-11ea-86a0-0a719432828a.gif)

Didn't want to leave it to the widgets to verify that the URL params values are safe to use, so added html escaping.