### PR TITLE
chore: enable renovate for website

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,3 @@
 {
-  "extends": ["github>netlify/renovate-config:default"],
-  "ignorePaths": ["website/"]
+  "extends": ["github>netlify/renovate-config:default"]
 }


### PR DESCRIPTION
The website was initially excluded from Renovate updates because it was way behind on major releases, this was fixed in #2068.