### PR TITLE
feat(proxy-server): export proxy middlewares

### DIFF
--- a/packages/netlify-cms-proxy-server/src/index.ts
+++ b/packages/netlify-cms-proxy-server/src/index.ts
@@ -1,7 +1,6 @@
 require('dotenv').config();
 import express from 'express';
-import morgan from 'morgan';
-import cors from 'cors';
+import { registerCommonMiddlewares } from './middlewares/common';
 import { registerMiddleware as registerLocalGit } from './middlewares/localGit';
 import { registerMiddleware as registerLocalFs } from './middlewares/localFs';
 
@@ -9,9 +8,7 @@ const app = express();
 const port = process.env.PORT || 8081;
 
 (async () => {
-  app.use(morgan('combined'));
-  app.use(cors());
-  app.use(express.json({ limit: '50mb' }));
+  registerCommonMiddlewares(app);
 
   try {
     const mode = process.env.MODE || 'fs';

--- a/packages/netlify-cms-proxy-server/src/middlewares.ts
+++ b/packages/netlify-cms-proxy-server/src/middlewares.ts
@@ -1,0 +1,14 @@
+import express from 'express';
+import { registerCommonMiddlewares } from './middlewares/common';
+import { registerMiddleware as localGit } from './middlewares/localGit';
+import { registerMiddleware as localFs } from './middlewares/localFs';
+
+export const registerLocalGit = async (app: express.Express) => {
+  registerCommonMiddlewares(app);
+  await localGit(app);
+};
+
+export const registerLocalFs = async (app: express.Express) => {
+  registerCommonMiddlewares(app);
+  await localFs(app);
+};

--- a/packages/netlify-cms-proxy-server/src/middlewares/common/index.ts
+++ b/packages/netlify-cms-proxy-server/src/middlewares/common/index.ts
@@ -1,0 +1,9 @@
+import express from 'express';
+import morgan from 'morgan';
+import cors from 'cors';
+
+export const registerCommonMiddlewares = (app: express.Express) => {
+  app.use(morgan('combined'));
+  app.use(cors());
+  app.use(express.json({ limit: '50mb' }));
+};

--- a/packages/netlify-cms-proxy-server/webpack.config.js
+++ b/packages/netlify-cms-proxy-server/webpack.config.js
@@ -7,13 +7,14 @@ const { NODE_ENV = 'production' } = process.env;
 const allowList = [/^netlify-cms-lib-util/];
 
 module.exports = {
-  entry: path.join('src', 'index.ts'),
+  entry: { index: path.join('src', 'index.ts'), middlewares: path.join('src', 'middlewares.ts') },
   mode: NODE_ENV,
   target: 'node',
   devtool: 'source-map',
   output: {
     path: path.resolve(__dirname, 'dist'),
-    filename: 'index.js',
+    filename: '[name].js',
+    libraryTarget: 'commonjs2',
   },
   resolve: {
     plugins: [new TsconfigPathsPlugin()],


### PR DESCRIPTION
Fixes #3348

Usage in Gatsby:

```
const { registerLocalFs } = require('netlify-cms-proxy-server/dist/middlewares');

exports.onCreateDevServer = async ({ app }) => {
  await registerLocalFs(app);
};
```

We should actually handle this in our SSGs plugins, but this is a first step towards that.