### PR TITLE
Fix broken "start with a template" link

### DIFF
--- a/website/content/docs/configuration-options.md
+++ b/website/content/docs/configuration-options.md
@@ -12,7 +12,7 @@ Alternatively, you can specify a custom config file using a link tag:
 <link href="path/to/config.yml" type="text/yaml" rel="cms-config-url">
 ```
 
-To see working configuration examples, you can [start from a template](../start-with-a-template) or check out the [CMS demo site](https://cms-demo.netlify.com). (No login required: click the login button and the CMS will open.) You can refer to the demo [configuration code](https://github.com/netlify/netlify-cms/blob/master/dev-test/config.yml) to see how each option was configured.
+To see working configuration examples, you can [start from a template](./start-with-a-template) or check out the [CMS demo site](https://cms-demo.netlify.com). (No login required: click the login button and the CMS will open.) You can refer to the demo [configuration code](https://github.com/netlify/netlify-cms/blob/master/dev-test/config.yml) to see how each option was configured.
 
 You can find details about all configuration options below. Note that [YAML syntax](https://en.wikipedia.org/wiki/YAML#Basic_components) allows lists and objects to be written in block or inline style, and the code samples below include a mix of both.
 


### PR DESCRIPTION
References the correct "start-with-a-template" file found in the correct directory:
"https://github.com/netlify/netlify-cms/tree/master/website/content/docs"

**Summary**

This minor amendment solves the incorrectly referenced "start from a template" link found in the documentation.

**Test plan**

The link in the docs would link to a non existent URL: 
"https://github.com/netlify/netlify-cms/tree/master/website/content/"
rather than the file in the same directory
"https://github.com/netlify/netlify-cms/tree/master/website/content/docs/"