### PR TITLE
fix: show better error for missing widgets

### DIFF
--- a/packages/netlify-cms-core/src/lib/__tests__/registry.spec.js
+++ b/packages/netlify-cms-core/src/lib/__tests__/registry.spec.js
@@ -147,4 +147,26 @@ describe('registry', () => {
       });
     });
   });
+
+  describe('getWidget', () => {
+    it('should throw on missing widget', () => {
+      const { getWidget } = require('../registry');
+
+      expect(() => getWidget('Unknown')).toThrow(
+        new Error(
+          `Could not find widget 'Unknown'. Please make sure the widget name is configured correctly or register it via 'registerwidget'.`,
+        ),
+      );
+    });
+
+    it('should throw on missing widget and suggest lowercase name', () => {
+      const { getWidget, registerWidget } = require('../registry');
+
+      registerWidget('string', {});
+
+      expect(() => getWidget('String')).toThrow(
+        new Error(`Could not find widget 'String'. Did you mean 'string'?`),
+      );
+    });
+  });
 });

--- a/packages/netlify-cms-core/src/lib/registry.js
+++ b/packages/netlify-cms-core/src/lib/registry.js
@@ -113,7 +113,16 @@ export function registerWidget(name, control, preview) {
   }
 }
 export function getWidget(name) {
-  return registry.widgets[name];
+  const widget = registry.widgets[name];
+  if (!widget) {
+    const nameLowerCase = name.toLowerCase();
+    const hasLowercase = !!registry.widgets[nameLowerCase];
+    const message = hasLowercase
+      ? `Could not find widget '${name}'. Did you mean '${nameLowerCase}'?`
+      : `Could not find widget '${name}'. Please make sure the widget name is configured correctly or register it via 'registerwidget'.`;
+    throw new Error(message);
+  }
+  return widget;
 }
 export function getWidgets() {
   return produce(Object.entries(registry.widgets), draft => {

--- a/packages/netlify-cms-core/src/lib/registry.js
+++ b/packages/netlify-cms-core/src/lib/registry.js
@@ -116,8 +116,8 @@ export function getWidget(name) {
   const widget = registry.widgets[name];
   if (!widget) {
     const nameLowerCase = name.toLowerCase();
-    const hasLowercase = !!registry.widgets[nameLowerCase];
-    const message = hasLowercase
+    const hasLowerCase = !!registry.widgets[nameLowerCase];
+    const message = hasLowerCase
       ? `Could not find widget '${name}'. Did you mean '${nameLowerCase}'?`
       : `Could not find widget '${name}'. Please make sure the widget name is configured correctly or register it via 'registerwidget'.`;
     throw new Error(message);


### PR DESCRIPTION
Fixes https://github.com/netlify/netlify-cms/issues/3283

Handles most of the expected behaviour in that issue.

We could also validate widget names during configuration load, but that might request some thought as widgets can be registered dynamically after the config was loaded (odd case to support).

Furthermore, we could extend that validation to any required dynamically registered resource (e.g. backends, locales, media library).