### PR TITLE
fix: cache assets using resolved path on error

### DIFF
--- a/packages/netlify-cms-core/src/actions/__tests__/media.spec.js
+++ b/packages/netlify-cms-core/src/actions/__tests__/media.spec.js
@@ -108,17 +108,18 @@ describe('media', () => {
 
     it('should return asset with original path on load error', () => {
       const path = 'static/media/image.png';
+      const resolvePath = 'resolvePath';
       const store = mockStore({
-        medias: Map({ [path]: { error: true } }),
+        medias: Map({ [resolvePath]: { error: true } }),
       });
 
-      selectMediaFilePath.mockReturnValue(path);
+      selectMediaFilePath.mockReturnValue(resolvePath);
       const payload = { path };
 
       const result = store.dispatch(getAsset(payload));
       const actions = store.getActions();
 
-      const asset = new AssetProxy({ url: path, path });
+      const asset = new AssetProxy({ url: path, path: resolvePath });
       expect(actions).toHaveLength(1);
       expect(actions[0]).toEqual({
         type: ADD_ASSET,

--- a/packages/netlify-cms-core/src/actions/media.ts
+++ b/packages/netlify-cms-core/src/actions/media.ts
@@ -114,7 +114,7 @@ export function getAsset({ collection, entry, path, field }: GetAssetArgs) {
     } else {
       if (error) {
         // on load error default back to original path
-        asset = createAssetProxy({ path, url: path });
+        asset = createAssetProxy({ path: resolvedPath, url: path });
         dispatch(addAsset(asset));
       } else {
         dispatch(loadAsset(resolvedPath));

--- a/packages/netlify-cms-core/src/components/Collection/Entries/EntryCard.js
+++ b/packages/netlify-cms-core/src/components/Collection/Entries/EntryCard.js
@@ -105,9 +105,6 @@ const EntryCard = ({
     );
   }
 
-  const asset = getAsset(image, imageField);
-  const src = asset.toString();
-
   if (viewStyle === VIEW_STYLE_GRID) {
     return (
       <GridCard>
@@ -116,7 +113,7 @@ const EntryCard = ({
             {collectionLabel ? <CollectionLabel>{collectionLabel}</CollectionLabel> : null}
             <CardHeading>{summary}</CardHeading>
           </CardBody>
-          {image ? <CardImage src={src} /> : null}
+          {image ? <CardImage src={getAsset(image, imageField).toString()} /> : null}
         </GridCardLink>
       </GridCard>
     );


### PR DESCRIPTION
Fixes https://github.com/netlify/netlify-cms/issues/3330

`getAsset` was re-triggered again an again on error in the grid view.