### PR TITLE
Feat: add GitHub folder collections pagination

### DIFF
--- a/packages/netlify-cms-backend-git-gateway/src/implementation.ts
+++ b/packages/netlify-cms-backend-git-gateway/src/implementation.ts
@@ -258,6 +258,9 @@ export default class GitGateway implements Implementation {
   entriesByFolder(folder: string, extension: string, depth: number) {
     return this.backend!.entriesByFolder(folder, extension, depth);
   }
+  allEntriesByFolder(folder: string, extension: string, depth: number) {
+    return this.backend!.allEntriesByFolder(folder, extension, depth);
+  }
   entriesByFiles(files: ImplementationFile[]) {
     return this.backend!.entriesByFiles(files);
   }
@@ -511,6 +514,6 @@ export default class GitGateway implements Implementation {
     return this.backend!.publishUnpublishedEntry(collection, slug);
   }
   traverseCursor(cursor: Cursor, action: string) {
-    return (this.backend as GitLabBackend | BitbucketBackend).traverseCursor!(cursor, action);
+    return this.backend!.traverseCursor!(cursor, action);
   }
 }

--- a/packages/netlify-cms-lib-util/src/Cursor.ts
+++ b/packages/netlify-cms-lib-util/src/Cursor.ts
@@ -40,6 +40,7 @@ const jsToMap = (obj: {}) => {
 
 const knownMetaKeys = Set([
   'index',
+  'page',
   'count',
   'pageSize',
   'pageCount',
@@ -85,8 +86,10 @@ const getActionHandlers = (store: CursorStore, handler: ActionHandler) =>
 export default class Cursor {
   store?: CursorStore;
   actions?: Set<string>;
-  data?: Map<string, unknown>;
-  meta?: Map<string, unknown>;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  data?: Map<string, any>;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  meta?: Map<string, any>;
 
   static create(...args: {}[]) {
     return new Cursor(...args);


### PR DESCRIPTION
Fixes: https://github.com/netlify/netlify-cms/issues/50
Related: https://github.com/netlify/netlify-cms/issues/68

Paginate the results returning from GitHub tree API.

### Todo:
- [x] Test with GraphQL
- [x] Test with `git-gateway`
- [x] Test search

P.S. tested with https://github.com/erezrokah/netlify-cms-reproductions/tree/netlify_cms/pagination