### PR TITLE
chore: add hack to manually bump main packages

### DIFF
--- a/packages/netlify-cms-app/package.json
+++ b/packages/netlify-cms-app/package.json
@@ -64,5 +64,6 @@
   "peerDependencies": {
     "react": "^16.8.4",
     "react-dom": "^16.8.4"
-  }
+  },
+  "incrementToForceBump": 0
 }

--- a/packages/netlify-cms/package.json
+++ b/packages/netlify-cms/package.json
@@ -26,5 +26,6 @@
     "netlify-cms-media-library-uploadcare": "^0.5.5",
     "react": "^16.8.4",
     "react-dom": "^16.8.4"
-  }
+  },
+  "incrementToForceBump": 0
 }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines.

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first two fields are mandatory:
-->

**Summary**
We need to manually force minor/major bumps on the primary packages when a release will feel like a minor or major release to users - there's isn't a great way to determine programatically when this is the case. The simplest way is to add an arbitrary code change to these packages in commits that should trigger a bump for them. For example, a `feat:` prefixed commit will produce a minor bump for all packages that are changed in that commit.

This PR facilitates this temporarily by adding an `incrementToForceBump` key in the `package.json` files of the `netlify-cms` and `netlify-cms-app` packages, each set to `0` initially. The number can be incremented to provide a somewhat self documenting way of including these packages in Lerna's semantic versioning calculations.

