### PR TITLE
Fix signature for CMS.registerWidget

### DIFF
--- a/packages/netlify-cms-core/index.d.ts
+++ b/packages/netlify-cms-core/index.d.ts
@@ -207,7 +207,7 @@ declare module 'netlify-cms-core' {
     registerPreviewTemplate: (name: string, component: ComponentType) => void;
     registerWidget: (
       widget: string | CmsWidgetParam,
-      control: ComponentType,
+      control?: ComponentType,
       preview?: ComponentType,
     ) => void;
     registerWidgetValueSerializer: (


### PR DESCRIPTION
`registerWidget` can be called with a single argument `CmsWidgetParam`

