### PR TITLE
AppBar background is missing when scroll to the right on mobile

### DIFF
--- a/packages/netlify-cms-core/src/components/App/Header.js
+++ b/packages/netlify-cms-core/src/components/App/Header.js
@@ -30,7 +30,6 @@ const AppHeader = props => (
       position: sticky;
       width: 100%;
       min-width: 800px;
-      max-width: 1440px;
       top: 0;
       background-color: ${colors.foreground};
       z-index: 300;
@@ -43,6 +42,7 @@ const AppHeader = props => (
 const AppHeaderContent = styled.div`
   display: flex;
   justify-content: space-between;
+  max-width: 1440px;
   padding: 0 12px;
   margin: 0 auto;
 `;

--- a/packages/netlify-cms-core/src/components/App/Header.js
+++ b/packages/netlify-cms-core/src/components/App/Header.js
@@ -29,6 +29,8 @@ const AppHeader = props => (
       ${shadows.dropMain};
       position: sticky;
       width: 100%;
+      min-width: 800px;
+      max-width: 1440px;
       top: 0;
       background-color: ${colors.foreground};
       z-index: 300;
@@ -41,8 +43,6 @@ const AppHeader = props => (
 const AppHeaderContent = styled.div`
   display: flex;
   justify-content: space-between;
-  min-width: 800px;
-  max-width: 1440px;
   padding: 0 12px;
   margin: 0 auto;
 `;


### PR DESCRIPTION
### How to generate the error ?
Open the Admin on mobile or any device having screen size less than 800px.

> Currently Navbar background is available for the available screen size. On Phone page width get bigger than the size of phone. So,  We are unable to see the  background in complete nav because now available width is less than page width.

## Code Change Summary
`Min width and max-width` added to the app header, which will make the background available for complete navbar. 

As we added min width to the appHeader therefore  we need not to keep the `Min width and max-width` for their child .

**Summary**

| Normal Screenshot on mobile  |  When Scroll Right |
|---|---|
| <img width="285" alt="Screenshot 2020-03-11 at 6 22 46 PM" src="https://user-images.githubusercontent.com/15886737/76419246-06fade00-63c6-11ea-8cf6-ea874fcb986d.png"> |<img width="285" alt="Screenshot 2020-03-11 at 6 22 52 PM" src="https://user-images.githubusercontent.com/15886737/76419257-09f5ce80-63c6-11ea-953e-41186dd3bf57.png">|

In the first screen there is background ( which is white in color) and as some part of the UI is going out of the screen. So, I scroll right to see and i found that there is not background.


There is possibility that I am not able to convince you the exact problem. So, please generate the error by yourself and get better understanding of the issue ?

### How to generate the error ?
Open the Admin on mobile or any device having screen size less than 800px.


Thank you