### PR TITLE
fix: don't use getAsset for draft entries

### DIFF
--- a/packages/netlify-cms-core/src/__tests__/backend.spec.js
+++ b/packages/netlify-cms-core/src/__tests__/backend.spec.js
@@ -349,7 +349,7 @@ describe('Backend', () => {
         init: jest.fn(() => implementation),
         unpublishedEntry: jest.fn().mockResolvedValue(unpublishedEntryResult),
       };
-      const config = Map({});
+      const config = Map({ media_folder: 'static/images' });
 
       const backend = new Backend(implementation, { config, backendName: 'github' });
 
@@ -357,9 +357,15 @@ describe('Backend', () => {
         name: 'posts',
       });
 
+      const state = {
+        config,
+        integrations: Map({}),
+        mediaLibrary: Map({}),
+      };
+
       const slug = 'slug';
 
-      const result = await backend.unpublishedEntry(collection, slug);
+      const result = await backend.unpublishedEntry(state, collection, slug);
       expect(result).toEqual({
         collection: 'posts',
         slug: '',
@@ -370,7 +376,7 @@ describe('Backend', () => {
         label: null,
         metaData: {},
         isModification: true,
-        mediaFiles: [{ id: '1' }],
+        mediaFiles: [{ id: '1', draft: true }],
       });
     });
   });

--- a/packages/netlify-cms-core/src/actions/__tests__/editorialWorkflow.spec.js
+++ b/packages/netlify-cms-core/src/actions/__tests__/editorialWorkflow.spec.js
@@ -38,7 +38,7 @@ describe('editorialWorkflow actions', () => {
       const { createAssetProxy } = require('ValueObjects/AssetProxy');
 
       const assetProxy = { name: 'name', path: 'path' };
-      const entry = { mediaFiles: [{ file: { name: 'name' }, id: '1' }] };
+      const entry = { mediaFiles: [{ file: { name: 'name' }, id: '1', draft: true }] };
       const backend = {
         unpublishedEntry: jest.fn().mockResolvedValue(entry),
       };

--- a/packages/netlify-cms-core/src/actions/__tests__/entries.spec.js
+++ b/packages/netlify-cms-core/src/actions/__tests__/entries.spec.js
@@ -19,6 +19,13 @@ const mockStore = configureMockStore(middlewares);
 
 describe('entries', () => {
   describe('createEmptyDraft', () => {
+    const { currentBackend } = require('coreSrc/backend');
+    const backend = {
+      processEntry: jest.fn((_state, _collection, entry) => Promise.resolve(entry)),
+    };
+
+    currentBackend.mockReturnValue(backend);
+
     beforeEach(() => {
       jest.clearAllMocks();
     });
@@ -39,7 +46,7 @@ describe('entries', () => {
             data: {},
             isModification: null,
             label: null,
-            mediaFiles: fromJS([]),
+            mediaFiles: [],
             metaData: null,
             partial: false,
             path: '',
@@ -68,7 +75,7 @@ describe('entries', () => {
             data: { title: 'title', boolean: true },
             isModification: null,
             label: null,
-            mediaFiles: fromJS([]),
+            mediaFiles: [],
             metaData: null,
             partial: false,
             path: '',
@@ -99,7 +106,7 @@ describe('entries', () => {
               data: { title: '&lt;script&gt;alert(&#039;hello&#039;)&lt;/script&gt;' },
               isModification: null,
               label: null,
-              mediaFiles: fromJS([]),
+              mediaFiles: [],
               metaData: null,
               partial: false,
               path: '',

--- a/packages/netlify-cms-core/src/actions/__tests__/entries.spec.js
+++ b/packages/netlify-cms-core/src/actions/__tests__/entries.spec.js
@@ -8,15 +8,9 @@ import {
 } from '../entries';
 import configureMockStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
+import AssetProxy from '../../valueObjects/AssetProxy';
 
 jest.mock('coreSrc/backend');
-jest.mock('../media', () => {
-  const media = jest.requireActual('../media');
-  return {
-    ...media,
-    getAsset: jest.fn(),
-  };
-});
 jest.mock('netlify-cms-lib-util');
 jest.mock('../mediaLibrary');
 
@@ -286,20 +280,11 @@ describe('entries', () => {
       jest.clearAllMocks();
     });
 
-    it('should map mediaFiles to assets', async () => {
-      const { getAsset } = require('../media');
+    it('should map mediaFiles to assets', () => {
       const mediaFiles = fromJS([{ path: 'path1' }, { path: 'path2', draft: true }]);
 
-      const asset = { path: 'path1' };
-
-      getAsset.mockReturnValue(() => asset);
-
-      const collection = Map();
       const entry = Map({ mediaFiles });
-      await expect(getMediaAssets({ entry, collection })).resolves.toEqual([asset]);
-
-      expect(getAsset).toHaveBeenCalledTimes(1);
-      expect(getAsset).toHaveBeenCalledWith({ collection, path: 'path2', entry });
+      expect(getMediaAssets({ entry })).toEqual([new AssetProxy({ path: 'path2' })]);
     });
   });
 });

--- a/packages/netlify-cms-core/src/actions/editorialWorkflow.ts
+++ b/packages/netlify-cms-core/src/actions/editorialWorkflow.ts
@@ -375,10 +375,7 @@ export function persistUnpublishedEntry(collection: Collection, existingUnpublis
     const backend = currentBackend(state.config);
     const transactionID = uuid();
     const entry = entryDraft.get('entry');
-    const assetProxies = await getMediaAssets({
-      getState,
-      dispatch,
-      collection,
+    const assetProxies = getMediaAssets({
       entry,
     });
 

--- a/packages/netlify-cms-core/src/actions/entries.ts
+++ b/packages/netlify-cms-core/src/actions/entries.ts
@@ -14,7 +14,7 @@ import ValidationErrorTypes from '../constants/validationErrorTypes';
 import { addAssets, getAsset } from './media';
 import { Collection, EntryMap, MediaFile, State, EntryFields, EntryField } from '../types/redux';
 import { ThunkDispatch } from 'redux-thunk';
-import { AnyAction, Dispatch } from 'redux';
+import { AnyAction } from 'redux';
 import { waitForMediaLibraryToLoad, loadMedia } from './mediaLibrary';
 import { waitUntil } from './waitUntil';
 
@@ -592,28 +592,13 @@ export function createEmptyDraftData(fields: EntryFields, withNameKey = true) {
   );
 }
 
-export async function getMediaAssets({
-  getState,
-  dispatch,
-  collection,
-  entry,
-}: {
-  getState: () => State;
-  collection: Collection;
-  entry: EntryMap;
-  dispatch: Dispatch;
-}) {
+export function getMediaAssets({ entry }: { entry: EntryMap }) {
   const filesArray = entry.get('mediaFiles').toArray();
-  const assets = await Promise.all(
-    filesArray
-      .filter(file => file.get('draft'))
-      .map(file =>
-        getAsset({ collection, entry, path: file.get('path'), field: file.get('field') })(
-          dispatch,
-          getState,
-        ),
-      ),
-  );
+  const assets = filesArray
+    .filter(file => file.get('draft'))
+    .map(file =>
+      createAssetProxy({ path: file.get('path'), file: file.get('file'), url: file.get('url') }),
+    );
 
   return assets;
 }
@@ -648,10 +633,7 @@ export function persistEntry(collection: Collection) {
 
     const backend = currentBackend(state.config);
     const entry = entryDraft.get('entry');
-    const assetProxies = await getMediaAssets({
-      getState,
-      dispatch,
-      collection,
+    const assetProxies = getMediaAssets({
       entry,
     });
 

--- a/packages/netlify-cms-core/src/actions/mediaLibrary.ts
+++ b/packages/netlify-cms-core/src/actions/mediaLibrary.ts
@@ -198,6 +198,7 @@ function createMediaFileFromAsset({
     name: basename(assetProxy.path),
     displayURL: assetProxy.url,
     draft,
+    file,
     size: file.size,
     url: assetProxy.url,
     path: assetProxy.path,

--- a/packages/netlify-cms-core/src/backend.ts
+++ b/packages/netlify-cms-core/src/backend.ts
@@ -494,27 +494,16 @@ export class Backend {
     const path = selectEntryPath(collection, slug) as string;
     const label = selectFileEntryLabel(collection, slug);
 
-    const integration = selectIntegration(state.integrations, null, 'assetStore');
-
     const loadedEntry = await this.implementation.getEntry(path);
-    const entry = createEntry(collection.get('name'), slug, loadedEntry.file.path, {
+    let entry = createEntry(collection.get('name'), slug, loadedEntry.file.path, {
       raw: loadedEntry.data,
       label,
       mediaFiles: [],
     });
 
-    const entryWithFormat = this.entryWithFormat(collection)(entry);
-    const mediaFolders = selectMediaFolders(state, collection, fromJS(entryWithFormat));
-    if (mediaFolders.length > 0 && !integration) {
-      entry.mediaFiles = [];
-      for (const folder of mediaFolders) {
-        entry.mediaFiles = [...entry.mediaFiles, ...(await this.implementation.getMedia(folder))];
-      }
-    } else {
-      entry.mediaFiles = state.mediaLibrary.get('files') || [];
-    }
-
-    return entryWithFormat;
+    entry = this.entryWithFormat(collection)(entry);
+    entry = await this.processEntry(state, collection, entry);
+    return entry;
   }
 
   getMedia() {
@@ -536,9 +525,9 @@ export class Backend {
     return Promise.reject(err);
   }
 
-  entryWithFormat(collectionOrEntity: unknown) {
+  entryWithFormat(collection: Collection) {
     return (entry: EntryValue): EntryValue => {
-      const format = resolveFormat(collectionOrEntity, entry);
+      const format = resolveFormat(collection, entry);
       if (entry && entry.raw !== undefined) {
         const data = (format && attempt(format.fromFile.bind(format, entry.raw))) || {};
         if (isError(data)) console.error(data);
@@ -579,18 +568,37 @@ export class Backend {
       }));
   }
 
-  unpublishedEntry(collection: Collection, slug: string) {
-    return this.implementation!.unpublishedEntry!(collection.get('name') as string, slug)
-      .then(loadedEntry => {
-        const entry = createEntry(collection.get('name'), loadedEntry.slug, loadedEntry.file.path, {
-          raw: loadedEntry.data,
-          isModification: loadedEntry.isModification,
-          metaData: loadedEntry.metaData,
-          mediaFiles: loadedEntry.mediaFiles,
-        });
-        return entry;
-      })
-      .then(this.entryWithFormat(collection));
+  async processEntry(state: State, collection: Collection, entry: EntryValue) {
+    const integration = selectIntegration(state.integrations, null, 'assetStore');
+    const mediaFolders = selectMediaFolders(state, collection, fromJS(entry));
+    if (mediaFolders.length > 0 && !integration) {
+      const files = await Promise.all(
+        mediaFolders.map(folder => this.implementation.getMedia(folder)),
+      );
+      entry.mediaFiles = entry.mediaFiles.concat(...files);
+    } else {
+      entry.mediaFiles = entry.mediaFiles.concat(state.mediaLibrary.get('files') || []);
+    }
+
+    return entry;
+  }
+
+  async unpublishedEntry(state: State, collection: Collection, slug: string) {
+    const loadedEntry = await this.implementation!.unpublishedEntry!(
+      collection.get('name') as string,
+      slug,
+    );
+
+    let entry = createEntry(collection.get('name'), loadedEntry.slug, loadedEntry.file.path, {
+      raw: loadedEntry.data,
+      isModification: loadedEntry.isModification,
+      metaData: loadedEntry.metaData,
+      mediaFiles: loadedEntry.mediaFiles?.map(file => ({ ...file, draft: true })) || [],
+    });
+
+    entry = this.entryWithFormat(collection)(entry);
+    entry = await this.processEntry(state, collection, entry);
+    return entry;
   }
 
   /**

--- a/packages/netlify-cms-core/src/formats/formats.js
+++ b/packages/netlify-cms-core/src/formats/formats.js
@@ -40,15 +40,15 @@ const formatByName = (name, customDelimiter) =>
     'yaml-frontmatter': frontmatterYAML(customDelimiter),
   }[name]);
 
-export function resolveFormat(collectionOrEntity, entry) {
+export function resolveFormat(collection, entry) {
   // Check for custom delimiter
-  const frontmatter_delimiter = collectionOrEntity.get('frontmatter_delimiter');
+  const frontmatter_delimiter = collection.get('frontmatter_delimiter');
   const customDelimiter = List.isList(frontmatter_delimiter)
     ? frontmatter_delimiter.toArray()
     : frontmatter_delimiter;
 
   // If the format is specified in the collection, use that format.
-  const formatSpecification = collectionOrEntity.get('format');
+  const formatSpecification = collection.get('format');
   if (formatSpecification) {
     return formatByName(formatSpecification, customDelimiter);
   }
@@ -62,7 +62,7 @@ export function resolveFormat(collectionOrEntity, entry) {
 
   // If creating a new file, and an `extension` is specified in the
   //   collection config, infer the format from that extension.
-  const extension = collectionOrEntity.get('extension');
+  const extension = collection.get('extension');
   if (extension) {
     return get(extensionFormatters, extension);
   }

--- a/packages/netlify-cms-core/src/reducers/__tests__/entries.spec.js
+++ b/packages/netlify-cms-core/src/reducers/__tests__/entries.spec.js
@@ -142,7 +142,7 @@ describe('entries', () => {
             folder: 'src/docs/getting-started',
             media_folder: '/static/images/docs/getting-started',
           }),
-          fromJS({ path: 'src/docs/getting-started/with-github.md' }),
+          fromJS({}),
           undefined,
         ),
       ).toEqual('static/images/docs/getting-started');
@@ -184,7 +184,6 @@ describe('entries', () => {
       };
 
       const entry = fromJS({
-        path: 'src/docs/extending/overview.md',
         data: { title: 'Overview' },
       });
       const collection = fromJS({

--- a/packages/netlify-cms-core/src/reducers/entries.ts
+++ b/packages/netlify-cms-core/src/reducers/entries.ts
@@ -351,18 +351,15 @@ export const selectMediaFolder = (
   const customFolder = hasCustomFolder(name, collection, entryMap?.get('slug'), field);
 
   if (customFolder) {
-    const entryPath = entryMap?.get('path');
-    if (entryPath) {
-      const entryDir = dirname(entryPath);
-      const folder = evaluateFolder(name, config, collection!, entryMap, field);
+    const folder = evaluateFolder(name, config, collection!, entryMap, field);
+    if (folder.startsWith('/')) {
       // return absolute paths as is
-      if (folder.startsWith('/')) {
-        mediaFolder = join(folder);
-      } else {
-        mediaFolder = join(entryDir, folder as string);
-      }
+      mediaFolder = join(folder);
     } else {
-      mediaFolder = join(collection!.get('folder') as string, DRAFT_MEDIA_FILES);
+      const entryPath = entryMap?.get('path');
+      mediaFolder = entryPath
+        ? join(dirname(entryPath), folder)
+        : join(collection!.get('folder') as string, DRAFT_MEDIA_FILES);
     }
   }
 


### PR DESCRIPTION
Fixes the following scenario:
1. Create an entry in editorial workflow and save it.
2. Manually add an image that is not mapped to any media folder (either collection/file/field media folder) to the CMS PR branch.
3. Update the editorial workflow entry and save it.
See that the previously added image is replaced with an empty svg file.

Underlying issue:
When persisting an entry `getMediaAssets` was used to retrieve entry assets. `getMediaAssets` calls `getAsset` which tries to get the asset from the redux store or initiates a load asset action.
When persisting an entry all of those entries assets should already be loaded into the store, but since the specific image is not mapped to any media folder, an empty asset is returned.

The solution was to dump `getAsset` and create the asset directly using the information stored on the draft entry (draft entry media files are retrieved using the diff API and will have the relevant image).

### Update

Made some changes to how `media_folder` works with absolute paths.
Initially we assumed that setting a `media_folder` on a collection (and later fields) means that value is used to bundle media files with entries, thus it is to be treated as a relative path. Hence we could figure out where to save media files only after initial save of an entry.
That resulted in the approach of showing an empty media library on draft entries with collection level `media_folder`.
Since then we've added support for absolute paths for collection level `media_folder` (and fields level `media_folder`), so at least cases of absolute paths we could show existing media files and not an empty media library.

Fixes https://github.com/netlify/netlify-cms/issues/3451