### PR TITLE
fix(core): dispatch loadEntry, pass entities to widget

### DIFF
--- a/packages/netlify-cms-core/src/actions/entries.ts
+++ b/packages/netlify-cms-core/src/actions/entries.ts
@@ -333,20 +333,15 @@ export function deleteLocalBackup(collection: Collection, slug: string) {
  * Exported Thunk Action Creators
  */
 
-export function loadEntry(collection: Collection, slug: string, createDraft = true) {
+export function loadEntry(collection: Collection, slug: string) {
   return async (dispatch: ThunkDispatch<State, {}, AnyAction>, getState: () => State) => {
-    const state = getState();
-    const backend = currentBackend(state.config);
     await waitForMediaLibraryToLoad(dispatch, getState());
     dispatch(entryLoading(collection, slug));
 
     try {
-      const loadedEntry = await backend.getEntry(getState(), collection, slug);
+      const loadedEntry = await tryLoadEntry(getState(), collection, slug);
       dispatch(entryLoaded(collection, loadedEntry));
-
-      if (createDraft) {
-        dispatch(createDraftFromEntry(loadedEntry));
-      }
+      dispatch(createDraftFromEntry(loadedEntry));
     } catch (error) {
       console.error(error);
       dispatch(
@@ -362,6 +357,12 @@ export function loadEntry(collection: Collection, slug: string, createDraft = tr
       dispatch(entryLoadError(error, collection, slug));
     }
   };
+}
+
+export async function tryLoadEntry(state: State, collection: Collection, slug: string) {
+  const backend = currentBackend(state.config);
+  const loadedEntry = await backend.getEntry(state, collection, slug);
+  return loadedEntry;
 }
 
 const appendActions = fromJS({

--- a/packages/netlify-cms-core/src/actions/entries.ts
+++ b/packages/netlify-cms-core/src/actions/entries.ts
@@ -333,7 +333,7 @@ export function deleteLocalBackup(collection: Collection, slug: string) {
  * Exported Thunk Action Creators
  */
 
-export function loadEntry(collection: Collection, slug: string) {
+export function loadEntry(collection: Collection, slug: string, createDraft = true) {
   return async (dispatch: ThunkDispatch<State, {}, AnyAction>, getState: () => State) => {
     const state = getState();
     const backend = currentBackend(state.config);
@@ -343,7 +343,10 @@ export function loadEntry(collection: Collection, slug: string) {
     try {
       const loadedEntry = await backend.getEntry(getState(), collection, slug);
       dispatch(entryLoaded(collection, loadedEntry));
-      dispatch(createDraftFromEntry(loadedEntry));
+
+      if (createDraft) {
+        dispatch(createDraftFromEntry(loadedEntry));
+      }
     } catch (error) {
       console.error(error);
       dispatch(

--- a/packages/netlify-cms-core/src/components/Editor/EditorControlPane/EditorControl.js
+++ b/packages/netlify-cms-core/src/components/Editor/EditorControlPane/EditorControl.js
@@ -270,7 +270,7 @@ const mapStateToProps = state => {
   const entry = entryDraft.get('entry');
   const collection = collections.get(entryDraft.getIn(['entry', 'collection']));
   const isLoadingAsset = selectIsLoadingAsset(state.medias);
-  const entities = entries.get('entities')
+  const entities = entries.get('entities');
 
   return {
     mediaPaths: state.mediaLibrary.get('controlMedia'),
@@ -306,9 +306,9 @@ const mapDispatchToProps = dispatch => {
 
 function loadEntryWidget(collectionName, slug) {
   return (dispatch, getState) => {
-    const collection = getState().collections.get(collectionName)
-    dispatch(loadEntry(collection, slug, false))
-  }
+    const collection = getState().collections.get(collectionName);
+    dispatch(loadEntry(collection, slug, false));
+  };
 }
 
 const mergeProps = (stateProps, dispatchProps, ownProps) => {

--- a/packages/netlify-cms-core/src/components/Editor/EditorControlPane/EditorControl.js
+++ b/packages/netlify-cms-core/src/components/Editor/EditorControlPane/EditorControl.js
@@ -270,7 +270,8 @@ const mapStateToProps = state => {
   const isLoadingAsset = selectIsLoadingAsset(state.medias);
 
   const loadEntry = (collectionName, slug) => {
-    return tryLoadEntry(state, collection, slug);
+    const targetCollection = collections.get(collectionName)
+    return tryLoadEntry(state, targetCollection, slug);
   };
 
   return {

--- a/packages/netlify-cms-core/src/components/Editor/EditorControlPane/EditorControl.js
+++ b/packages/netlify-cms-core/src/components/Editor/EditorControlPane/EditorControl.js
@@ -270,7 +270,7 @@ const mapStateToProps = state => {
   const isLoadingAsset = selectIsLoadingAsset(state.medias);
 
   const loadEntry = (collectionName, slug) => {
-    const targetCollection = collections.get(collectionName)
+    const targetCollection = collections.get(collectionName);
     return tryLoadEntry(state, targetCollection, slug);
   };
 

--- a/packages/netlify-cms-core/src/components/Editor/EditorControlPane/EditorControl.js
+++ b/packages/netlify-cms-core/src/components/Editor/EditorControlPane/EditorControl.js
@@ -151,6 +151,7 @@ class EditorControl extends React.Component {
       isEditorComponent,
       isNewEditorComponent,
       t,
+      entities,
     } = this.props;
 
     const widgetName = field.get('widget');
@@ -250,6 +251,7 @@ class EditorControl extends React.Component {
               isEditorComponent={isEditorComponent}
               isNewEditorComponent={isNewEditorComponent}
               t={t}
+              entities={entities}
             />
             {fieldHint && (
               <ControlHint active={isSelected || this.state.styleActive} error={!!errors}>
@@ -264,10 +266,11 @@ class EditorControl extends React.Component {
 }
 
 const mapStateToProps = state => {
-  const { collections, entryDraft } = state;
+  const { collections, entryDraft, entries } = state;
   const entry = entryDraft.get('entry');
   const collection = collections.get(entryDraft.getIn(['entry', 'collection']));
   const isLoadingAsset = selectIsLoadingAsset(state.medias);
+  const entities = entries.get('entities')
 
   return {
     mediaPaths: state.mediaLibrary.get('controlMedia'),
@@ -276,6 +279,7 @@ const mapStateToProps = state => {
     collection,
     entry,
     isLoadingAsset,
+    entities,
   };
 };
 
@@ -290,18 +294,22 @@ const mapDispatchToProps = dispatch => {
       query,
       clearSearch,
       clearFieldErrors,
+      loadEntry: loadEntryWidget,
     },
     dispatch,
   );
   return {
     ...creators,
-    loadEntry: (collectionName, slug) => (dispatch, getState) => {
-      const collection = getState().collections.get(collectionName);
-      return loadEntry(collection, slug)(dispatch, getState);
-    },
     boundGetAsset: (collection, entry) => boundGetAsset(dispatch, collection, entry),
   };
 };
+
+function loadEntryWidget(collectionName, slug) {
+  return (dispatch, getState) => {
+    const collection = getState().collections.get(collectionName)
+    dispatch(loadEntry(collection, slug, false))
+  }
+}
 
 const mergeProps = (stateProps, dispatchProps, ownProps) => {
   return {

--- a/packages/netlify-cms-core/src/components/Editor/EditorControlPane/EditorControl.js
+++ b/packages/netlify-cms-core/src/components/Editor/EditorControlPane/EditorControl.js
@@ -269,9 +269,14 @@ const mapStateToProps = state => {
   const collection = collections.get(entryDraft.getIn(['entry', 'collection']));
   const isLoadingAsset = selectIsLoadingAsset(state.medias);
 
-  const loadEntry = (collectionName, slug) => {
+  const loadEntry = async (collectionName, slug) => {
     const targetCollection = collections.get(collectionName);
-    return tryLoadEntry(state, targetCollection, slug);
+    if (targetCollection) {
+      const loadedEntry = await tryLoadEntry(state, targetCollection, slug);
+      return loadedEntry;
+    } else {
+      throw new Error(`Can't find collection '${collectionName}'`);
+    }
   };
 
   return {

--- a/packages/netlify-cms-core/src/components/Editor/EditorControlPane/Widget.js
+++ b/packages/netlify-cms-core/src/components/Editor/EditorControlPane/Widget.js
@@ -255,7 +255,6 @@ export default class Widget extends Component {
       isEditorComponent,
       isNewEditorComponent,
       t,
-      entities,
     } = this.props;
     return React.createElement(controlComponent, {
       field,
@@ -297,7 +296,6 @@ export default class Widget extends Component {
       fieldsErrors,
       controlRef,
       t,
-      entities,
     });
   }
 }

--- a/packages/netlify-cms-core/src/components/Editor/EditorControlPane/Widget.js
+++ b/packages/netlify-cms-core/src/components/Editor/EditorControlPane/Widget.js
@@ -255,6 +255,7 @@ export default class Widget extends Component {
       isEditorComponent,
       isNewEditorComponent,
       t,
+      entities,
     } = this.props;
     return React.createElement(controlComponent, {
       field,
@@ -296,6 +297,7 @@ export default class Widget extends Component {
       fieldsErrors,
       controlRef,
       t,
+      entities,
     });
   }
 }


### PR DESCRIPTION
Hi folks, I'm so glad to see many updates to this project in the last few months. Thanks for the hardwork!

**Summary**

In the latest version, the method `loadEntry` that was passed down to widgets no longer work (I've been relying on this API for a few custom widgets in production). I digged around the repo to see what changed & send this PR just to facilitate communication.

This is how it worked before:

```js
async componentDidMount() {
  const { loadEntry } = this.props
  const results = await loadEntry(collectionName, slug)
  // results.payload.data. etc etc</p>
}
```

I found 3 issues:

- In EditorControl, it seems that `loadEntry` wasn't properly dispatched here, resulting in failed call
https://github.com/netlify/netlify-cms/blob/ab7ba435baf07862e7adbfaf0f6cd9950af7ad52/packages/netlify-cms-core/src/components/Editor/EditorControlPane/EditorControl.js#L282-L304

- In `actions/entries/loadEntry`, `createDraftFromEntry(loadedEntry)` refreshes the widget component and cause an infinite loop. I patched this by adding a flag, but there's probably better ways to handle this. https://github.com/netlify/netlify-cms/blob/ab7ba435baf07862e7adbfaf0f6cd9950af7ad52/packages/netlify-cms-core/src/actions/entries.ts#L343-L347

- Also in the same code, in the previous version the action's payload is returned, but no longer the case in the latest version:
```js
    await waitForMediaLibraryToLoad(dispatch, getState());
    dispatch(entryLoading(collection, slug));
    return backend
      .getEntry(getState(), collection, slug)
      .then((loadedEntry: EntryValue) => {
        return dispatch(entryLoaded(collection, loadedEntry)); // return payload
      })
``` 
I think it is more correct to not return data from action (however this is currently still the case with the `query` method). But then, widgets can't access the returned data. I ended up passing `state.entries.entities` to widget. this works but now handling data in widget is a bit more acrobatic. Here's what that [looks like](https://github.com/d4rekanguok/netlify-cms-widgets/blob/707169003d8eed68289b2abcac71f564e6dafa4f/packages/widget-file-relation/src/control.tsx#L18-L50):

```js
  public async componentDidMount() {
    const { loadEntry, field } = this.props
    
    // ✂ snipped some code

    loadEntry(collection, file)
  }

  public componentDidUpdate() {
    const { field, entities } = this.props

    // ✂ snipped some code

    const entity = entities.get(`${collection}.${file}`)
    if (entity) {
      const data = entity.get('data').get(fieldName)
      const options = data.map(option => ({
        value: option.get(fieldId),
        label: option.get(fieldDisplay),
      }))
      this.setState({ options })
    }
  }
```

What do you think? Could there be a better way to allow widget accessing data from collections other than its own? If there's already a plan for this feature in version 3, I think it'd make sense to return the payload in `loadEntry` for now so it doesn't break widgets that have already rely on this action.

Thank you again for the work here!

**Test plan**

If `loadEntry` is to stay in widget, I can add a test for it.

<!--
Demonstrate the code is solid.
Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.
-->

**A picture of a cute animal (not mandatory but encouraged)**
