### PR TITLE
docs: scroll to widget on load, fix widget navigation history

### DIFF
--- a/website/netlify.toml
+++ b/website/netlify.toml
@@ -4,4 +4,4 @@
   publish = "dist/"
 
   [build.environment]
-    NODE_VERSION = "8"
+    NODE_VERSION = "12"

--- a/website/src/components/widgets.js
+++ b/website/src/components/widgets.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import styled from '@emotion/styled';
 
 import WidgetDoc from './widget-doc';
@@ -22,6 +22,8 @@ const WidgetsContent = styled.div`
 `;
 
 const Widgets = ({ widgets }) => {
+  const initialLoadRef = useRef(true);
+  const navRef = useRef(null);
   const [currentWidget, setWidget] = useState(null);
 
   useEffect(() => {
@@ -30,11 +32,15 @@ const Widgets = ({ widgets }) => {
     const widgetsContainHash = widgets.edges.some(w => w.node.frontmatter.title === hash);
 
     if (widgetsContainHash) {
-      return setWidget(hash);
+      setWidget(hash);
+      if (initialLoadRef.current) {
+        navRef.current.scrollIntoView({ behavior: 'smooth', block: 'start' });
+      }
+    } else {
+      setWidget(widgets.edges[0].node.frontmatter.title);
     }
-
-    setWidget(widgets.edges[0].node.frontmatter.title);
-  }, []);
+    initialLoadRef.current = false;
+  }, [widgets, window.location.hash]);
 
   const handleWidgetChange = (event, title) => {
     event.preventDefault();
@@ -46,7 +52,7 @@ const Widgets = ({ widgets }) => {
 
   return (
     <section>
-      <WidgetsNav>
+      <WidgetsNav ref={navRef}>
         {widgets.edges.map(({ node }) => {
           const { label, title } = node.frontmatter;
           return (

--- a/website/src/components/widgets.js
+++ b/website/src/components/widgets.js
@@ -21,13 +21,13 @@ const WidgetsContent = styled.div`
   border-radius: 4px;
 `;
 
-const Widgets = ({ widgets }) => {
+const Widgets = ({ widgets, location }) => {
   const initialLoadRef = useRef(true);
   const navRef = useRef(null);
   const [currentWidget, setWidget] = useState(null);
 
   useEffect(() => {
-    const hash = window.location.hash ? window.location.hash.replace('#', '') : '';
+    const hash = location.hash ? location.hash.replace('#', '') : '';
 
     const widgetsContainHash = widgets.edges.some(w => w.node.frontmatter.title === hash);
 
@@ -40,7 +40,7 @@ const Widgets = ({ widgets }) => {
       setWidget(widgets.edges[0].node.frontmatter.title);
     }
     initialLoadRef.current = false;
-  }, [widgets, typeof window !== `undefined` && window.location.hash]);
+  }, [widgets, location.hash]);
 
   const handleWidgetChange = (event, title) => {
     event.preventDefault();

--- a/website/src/components/widgets.js
+++ b/website/src/components/widgets.js
@@ -40,7 +40,7 @@ const Widgets = ({ widgets }) => {
       setWidget(widgets.edges[0].node.frontmatter.title);
     }
     initialLoadRef.current = false;
-  }, [widgets, window.location.hash]);
+  }, [widgets, typeof window !== `undefined` && window.location.hash]);
 
   const handleWidgetChange = (event, title) => {
     event.preventDefault();

--- a/website/src/templates/doc-page.js
+++ b/website/src/templates/doc-page.js
@@ -48,7 +48,7 @@ export const DocsTemplate = ({
         {filename && <EditLink collection={`docs_${group}`} filename={filename} />}
         <h1>{title}</h1>
         <Markdown body={body} html={html} />
-        {showWidgets && <Widgets widgets={widgets} />}
+        {showWidgets && <Widgets widgets={widgets} location={location} />}
       </article>
     </SidebarLayout>
   </Container>


### PR DESCRIPTION
Fixes two issues with the widgets docs:
1. Linking to a specific widget (e.g. https://www.netlifycms.org/docs/widgets/#datetime) doesn't scroll to the widget.
2. Clicking multiple widgets (e.g. Boolean, String, then Date) and clicking the back button in the browser only changes the browser hash, but doesn't actually navigates back to the widget.