### PR TITLE
fix: allow widgets to control value to be validated

### DIFF
--- a/packages/netlify-cms-core/src/components/Editor/EditorControlPane/Widget.js
+++ b/packages/netlify-cms-core/src/components/Editor/EditorControlPane/Widget.js
@@ -97,7 +97,7 @@ export default class Widget extends Component {
   };
 
   validate = (skipWrapped = false) => {
-    let value = this.props.value;
+    let value = this.innerWrappedControl?.getValidateValue?.() || this.props.value;
     // Convert list input widget value to string for validation test
     List.isList(value) && (value = value.join(','));
 

--- a/packages/netlify-cms-widget-file/src/withFileControl.js
+++ b/packages/netlify-cms-widget-file/src/withFileControl.js
@@ -7,6 +7,7 @@ import { once } from 'lodash';
 import uuid from 'uuid/v4';
 import { oneLine } from 'common-tags';
 import { lengths, components, buttons, borders, effects, shadows } from 'netlify-cms-ui-default';
+import { basename } from 'netlify-cms-lib-util';
 
 const MAX_DISPLAY_LENGTH = 50;
 
@@ -173,6 +174,14 @@ export default function withFileControl({ forImage } = {}) {
       e.preventDefault();
       this.props.onClearMediaControl(this.controlID);
       return this.props.onChange('');
+    };
+
+    getValidateValue = () => {
+      if (this.props.value) {
+        return basename(this.props.value);
+      }
+
+      return this.props.value;
     };
 
     renderFileLink = value => {


### PR DESCRIPTION
Fixes https://github.com/netlify/netlify-cms/issues/3436

When using collection/field level media folders the value that is validated includes the media folder.
Couldn't think of a better way to do it at the moment.

This moves us towards widgets controlling their own validation logic (I think this might be good as well as widgets controlling their defaults).

@erquhart thoughts?
