### PR TITLE
build: fix windows build, build on multiple os using node 12 only

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -36,9 +36,6 @@ jobs:
           key: ${{ runner.os }}-yarn-${{ hashFiles(format('{0}{1}', github.workspace, '/yarn.lock')) }}
           restore-keys: |
             ${{ runner.os }}-yarn-
-      - name: update yarn to latest version
-        run: |
-          sudo apt update && sudo apt install yarn
       - name: npm install, unit test and build
         run: |
           node --version
@@ -83,9 +80,6 @@ jobs:
         with:
           name: dev-test-website-${{ runner.os }}-node-${{ matrix.node-version }}
           path: dev-test
-      - name: update yarn to latest version
-        run: |
-          sudo apt update && sudo apt install yarn
       - name: npm install and e2e test
         run: |
           node --version
@@ -124,9 +118,6 @@ jobs:
         with:
           name: dev-test-website-${{ runner.os }}-node-${{ matrix.node-version }}
           path: dev-test
-      - name: update yarn to latest version
-        run: |
-          sudo apt update && sudo apt install yarn
       - name: npm install and e2e test
         run: |
           node --version

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -18,11 +18,11 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
-
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        node-version: [10.x, 12.x]
+        os: [macos-latest, windows-latest, ubuntu-latest]
+        node-version: [12.x]
 
     steps:
       - uses: actions/checkout@v1
@@ -53,25 +53,26 @@ jobs:
           NODE_OPTIONS: --max-old-space-size=4096
       - uses: actions/upload-artifact@master
         with:
-          name: dev-test-website-node-${{ matrix.node-version }}
+          name: dev-test-website-${{ runner.os }}-node-${{ matrix.node-version }}
           path: dev-test
 
   # non forked workflow (has access to build secrets)
   e2e-with-cypress-record:
     needs: build
     if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false)
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-latest
 
     strategy:
       matrix:
         machine: [1, 2, 3, 4, 5, 6, 7, 8]
+        node-version: [12.x]
 
     steps:
       - uses: actions/checkout@v1
-      - name: Use Node.js 10.x
+      - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v1
         with:
-          node-version: 10.x
+          node-version: ${{ matrix.node-version }}
       - uses: actions/cache@v1
         with:
           path: ~/.cache/yarn
@@ -80,7 +81,7 @@ jobs:
             ${{ runner.os }}-yarn-
       - uses: actions/download-artifact@master
         with:
-          name: dev-test-website-node-10.x
+          name: dev-test-website-${{ runner.os }}-node-${{ matrix.node-version }}
           path: dev-test
       - name: update yarn to latest version
         run: |
@@ -101,14 +102,18 @@ jobs:
   e2e-no-cypress-record:
     needs: build
     if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == true
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [12.x]
 
     steps:
       - uses: actions/checkout@v1
-      - name: Use Node.js 10.x
+      - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v1
         with:
-          node-version: 10.x
+          node-version: ${{ matrix.node-version }}
       - uses: actions/cache@v1
         with:
           path: ~/.cache/yarn
@@ -117,7 +122,7 @@ jobs:
             ${{ runner.os }}-yarn-
       - uses: actions/download-artifact@master
         with:
-          name: dev-test-website-node-10.x
+          name: dev-test-website-${{ runner.os }}-node-${{ matrix.node-version }}
           path: dev-test
       - name: update yarn to latest version
         run: |

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -25,7 +25,7 @@ jobs:
         node-version: [12.x]
 
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v1
         with:
@@ -65,7 +65,7 @@ jobs:
         node-version: [12.x]
 
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v1
         with:
@@ -103,7 +103,7 @@ jobs:
         node-version: [12.x]
 
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v1
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,7 +28,7 @@ jobs:
         node-version: [12.x]
 
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v1
         with:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,12 +7,14 @@ For details on contributing to documentation, see [Website Directory Readme](htt
 
 ## Setup
 
+> Install Node.js (LTS) on your system: [https://nodejs.org/](https://nodejs.org/)
+
 > Install yarn on your system: [https://yarnpkg.com/en/docs/install](https://yarnpkg.com/en/docs/install)
 
 ### Install dependencies
 
 > Only required on the first run, subsequent runs can use `yarn start` to both
-bootstrap and run the development server.
+> bootstrap and run the development server.
 
 ```sh
 $ git clone https://github.com/netlify/netlify-cms
@@ -44,6 +46,7 @@ Watches all CMS packages and transpiles them on change.
 ```sh
 yarn watch
 ```
+
 ### start
 
 Starts the development server. This task runs both the `bootstrap` and `watch` scripts.
@@ -134,12 +137,12 @@ Netlify CMS uses the [Forking Workflow](https://www.atlassian.com/git/tutorials/
 
 1. Fork the repo.
 2. Create a branch from `master`. If you're addressing a specific issue, prefix your branch name with the issue number.
-2. If you've added code that should be tested, add tests.
-3. If you've changed APIs, update the documentation.
-4. Run `yarn test` and ensure the test suite passes.
-5. Use `yarn format` to format and lint your code.
-6. PR's must be rebased before merge (feel free to ask for help).
-7. PR should be reviewed by two maintainers prior to merging.
+3. If you've added code that should be tested, add tests.
+4. If you've changed APIs, update the documentation.
+5. Run `yarn test` and ensure the test suite passes.
+6. Use `yarn format` to format and lint your code.
+7. PR's must be rebased before merge (feel free to ask for help).
+8. PR should be reviewed by two maintainers prior to merging.
 
 ## License
 

--- a/scripts/webpack.js
+++ b/scripts/webpack.js
@@ -7,7 +7,7 @@ const pkg = require(path.join(process.cwd(), 'package.json'));
 
 const isProduction = process.env.NODE_ENV === 'production';
 const isTest = process.env.NODE_ENV === 'test';
-const moduleNameToPath = libName => `${path.resolve(__dirname, `../node_modules/${libName}`)}/`;
+const moduleNameToPath = libName => path.resolve(__dirname, '..', 'node_modules', libName);
 
 const rules = () => ({
   js: () => ({


### PR DESCRIPTION
Fixes https://github.com/netlify/netlify-cms/issues/3444

Also, added build jobs for Mac OS and Windows and removed building on Node 10 (updated the contributing guide).

I think we can use Node LTS as a convention.

@erquhart Do you see any reason to build on non LTS versions? 