### PR TITLE
feat: expose CMS moment

### DIFF
--- a/packages/netlify-cms-app/src/index.js
+++ b/packages/netlify-cms-app/src/index.js
@@ -1,4 +1,5 @@
 import { NetlifyCmsCore as CMS } from 'netlify-cms-core';
+import moment from 'moment';
 import './extensions.js';
 
 // Log version
@@ -10,5 +11,6 @@ if (typeof window !== 'undefined') {
 
 export const NetlifyCmsApp = {
   ...CMS,
+  moment,
 };
 export default CMS;


### PR DESCRIPTION
Fixes https://github.com/netlify/netlify-cms/issues/2578

Still undocumented as this is more of a workaround.

Allows changing the date widget locale without the overhead of bundling all moment locales with the CMS.

Usage with `netlify-cms`:
```html
<!DOCTYPE html>
<html>
  <head>
    <meta charset="utf-8" />

    <title>Netlify CMS Development Test</title>
  </head>
  <body>
    <script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.24.0/moment-with-locales.min.js"></script>
    <script src="https://unpkg.com/netlify-cms@^2.0.0/dist/netlify-cms.js"></script>
    <script>
      const data = moment.localeData('ja');
      let locale = {};
      Object.keys(data).forEach(key => {
        const value = data[key];
        if (key.startsWith('_')) {
          key = key.substring(1);
        }
        locale[key] = value;
      });
      CMS.moment.locale('ja', locale);
    </script>
  </body>
</html>
``` 

Usage with `netlify-cms-app`:

```js
import CMS from 'netlify-cms-app'
import moment from 'moment';
import 'moment/locale/ja';

const data = moment.localeData()
let locale = {}
Object.keys(data).forEach(key => {
    const value = data[key]
    if (key.startsWith('_')) {
        key = key.substring(1)
    }
    locale[key] = value
})
CMS.moment.locale('ja', locale)
```

Couldn't find a better way to extract the locale data from moment. Open to suggestions 