### PR TITLE
add logo to inference for thumbnails

### DIFF
--- a/packages/netlify-cms-core/src/constants/fieldInference.js
+++ b/packages/netlify-cms-core/src/constants/fieldInference.js
@@ -58,7 +58,7 @@ export const INFERABLE_FIELDS = {
   image: {
     type: 'image',
     secondaryTypes: [],
-    synonyms: ['image', 'thumbnail', 'thumb', 'picture', 'avatar', 'photo', 'cover', 'hero'],
+    synonyms: ['image', 'thumbnail', 'thumb', 'picture', 'avatar', 'photo', 'cover', 'hero', 'logo'],
     defaultPreview: value => value,
     fallbackToFirstField: false,
     showError: false,


### PR DESCRIPTION
**Summary**

The list of image fields eligible for the grid view is a bit arbitrary (which is understandable and fine), I just want to add a field to it.

**Test plan**

There is no code, only a string. So existing test should cover it. :) ?

![45796754722_9685b745e5_w](https://user-images.githubusercontent.com/240684/77662984-ea78ad00-6f52-11ea-9aa4-2a4f275fe3dd.jpg)
