### PR TITLE
fix(open-authoring): prevent workflow view from breaking on entry error

### DIFF
--- a/packages/netlify-cms-backend-github/src/API.ts
+++ b/packages/netlify-cms-backend-github/src/API.ts
@@ -994,8 +994,8 @@ export default class API {
   }
 
   async getDifferences(from: string, to: string) {
-    const attempts = 10;
     // retry this as sometimes GitHub returns an initial 404 on cross repo compare
+    const attempts = this.useOpenAuthoring ? 10 : 1;
     for (let i = 1; i <= attempts; i++) {
       try {
         const result: Octokit.ReposCompareCommitsResponse = await this.request(

--- a/packages/netlify-cms-backend-github/src/API.ts
+++ b/packages/netlify-cms-backend-github/src/API.ts
@@ -994,7 +994,7 @@ export default class API {
   }
 
   async getDifferences(from: string, to: string) {
-    const attempts = 3;
+    const attempts = 10;
     // retry this as sometimes GitHub returns an initial 404 on cross repo compare
     for (let i = 1; i <= attempts; i++) {
       try {
@@ -1004,9 +1004,10 @@ export default class API {
         return result;
       } catch (e) {
         if (i === attempts) {
+          console.warn(`Reached maximum number of attempts '${attempts}' for getDifferences`);
           throw e;
         }
-        await new Promise(resolve => setTimeout(resolve, 500));
+        await new Promise(resolve => setTimeout(resolve, i * 500));
       }
     }
     throw new APIError('Not Found', 404, API_NAME);


### PR DESCRIPTION
Related to https://github.com/netlify/netlify-cms/issues/3506

Added logs to get more information for the error in the issue.
Also, when using open authoring and a single branch failed to load it broke the workflow view.
Added a fix for that and increased the timeout for cross repositories diff.