### PR TITLE
fix(open-authoring): properly delete open authoring branches

### DIFF
--- a/packages/netlify-cms-backend-github/src/API.ts
+++ b/packages/netlify-cms-backend-github/src/API.ts
@@ -712,16 +712,15 @@ export default class API {
 
   filterOpenAuthoringBranches = async (branch: string) => {
     try {
-      const contentKey = contentKeyFromBranch(branch);
-      const { pullRequest, collection, slug } = await this.retrieveMetadata(contentKey);
+      const pullRequest = await this.getBranchPullRequest(branch);
       const { state: currentState, merged_at: mergedAt } = pullRequest;
       if (
         pullRequest.number !== MOCK_PULL_REQUEST &&
         currentState === PullRequestState.Closed &&
         mergedAt
       ) {
-        // pr was merged, delete entry
-        await this.deleteUnpublishedEntry(collection, slug);
+        // pr was merged, delete branch
+        await this.deleteBranch(branch);
         return { branch, filter: false };
       } else {
         return { branch, filter: true };


### PR DESCRIPTION
Fixes https://github.com/netlify/netlify-cms/issues/3506

Underlying issue - open authoring branches were only deleted if they were merged using "squash and merge" and not deleted when using "create merge commit".

The fix was to call `getBranchPullRequest` directly instead of using `retrieveMetadata` since it uses the diff API which returned an empty diff for merge commits.