### PR TITLE
fix: use resolveBackend instead of currentBackend

### DIFF
--- a/packages/netlify-cms-core/src/actions/__tests__/config.spec.js
+++ b/packages/netlify-cms-core/src/actions/__tests__/config.spec.js
@@ -4,7 +4,7 @@ import { applyDefaults, detectProxyServer, handleLocalBackend } from '../config'
 jest.spyOn(console, 'log').mockImplementation(() => {});
 jest.mock('coreSrc/backend', () => {
   return {
-    currentBackend: jest.fn(() => ({ isGitBackend: jest.fn(() => true) })),
+    resolveBackend: jest.fn(() => ({ isGitBackend: jest.fn(() => true) })),
   };
 });
 

--- a/packages/netlify-cms-core/src/actions/config.js
+++ b/packages/netlify-cms-core/src/actions/config.js
@@ -5,7 +5,7 @@ import { authenticateUser } from 'Actions/auth';
 import * as publishModes from 'Constants/publishModes';
 import { validateConfig } from 'Constants/configSchema';
 import { selectDefaultSortableFields } from '../reducers/collections';
-import { currentBackend } from 'coreSrc/backend';
+import { resolveBackend } from 'coreSrc/backend';
 
 export const CONFIG_REQUEST = 'CONFIG_REQUEST';
 export const CONFIG_SUCCESS = 'CONFIG_SUCCESS';
@@ -87,7 +87,7 @@ export function applyDefaults(config) {
           }
 
           if (!collection.has('sortableFields')) {
-            const backend = currentBackend(config);
+            const backend = resolveBackend(config);
             const defaultSortable = selectDefaultSortableFields(collection, backend);
             collection = collection.set('sortableFields', fromJS(defaultSortable));
           }


### PR DESCRIPTION
Since `currentBackend` memoize the backend using it when applying config defaults will memoize the backend with a config without defaults applied