### PR TITLE
fix: missing widgets

### DIFF
--- a/packages/netlify-cms-core/src/lib/__tests__/registry.spec.js
+++ b/packages/netlify-cms-core/src/lib/__tests__/registry.spec.js
@@ -147,26 +147,4 @@ describe('registry', () => {
       });
     });
   });
-
-  describe('getWidget', () => {
-    it('should throw on missing widget', () => {
-      const { getWidget } = require('../registry');
-
-      expect(() => getWidget('Unknown')).toThrow(
-        new Error(
-          `Could not find widget 'Unknown'. Please make sure the widget name is configured correctly or register it via 'registerwidget'.`,
-        ),
-      );
-    });
-
-    it('should throw on missing widget and suggest lowercase name', () => {
-      const { getWidget, registerWidget } = require('../registry');
-
-      registerWidget('string', {});
-
-      expect(() => getWidget('String')).toThrow(
-        new Error(`Could not find widget 'String'. Did you mean 'string'?`),
-      );
-    });
-  });
 });

--- a/packages/netlify-cms-core/src/lib/registry.js
+++ b/packages/netlify-cms-core/src/lib/registry.js
@@ -113,16 +113,7 @@ export function registerWidget(name, control, preview) {
   }
 }
 export function getWidget(name) {
-  const widget = registry.widgets[name];
-  if (!widget) {
-    const nameLowerCase = name.toLowerCase();
-    const hasLowerCase = !!registry.widgets[nameLowerCase];
-    const message = hasLowerCase
-      ? `Could not find widget '${name}'. Did you mean '${nameLowerCase}'?`
-      : `Could not find widget '${name}'. Please make sure the widget name is configured correctly or register it via 'registerwidget'.`;
-    throw new Error(message);
-  }
-  return widget;
+  return registry.widgets[name];
 }
 export function getWidgets() {
   return produce(Object.entries(registry.widgets), draft => {


### PR DESCRIPTION
Fixes: https://github.com/netlify/netlify-cms/issues/3535 and https://github.com/netlify/netlify-cms/issues/3540

To reproduce - create a config with a list widget containing a hidden widget.

Reverts https://github.com/netlify/netlify-cms/pull/3377.

Re-checked and couldn't reproduce the original issue https://github.com/netlify/netlify-cms/issues/3283

Now the CMS loads the "unknown widget properly":
![image](https://user-images.githubusercontent.com/26760571/78499035-e882cb00-7756-11ea-9912-2fc9e43a00cf.png)
