### PR TITLE
fix: pass prettyErrors to yaml when parsing config

### DIFF
--- a/packages/netlify-cms-core/src/actions/config.js
+++ b/packages/netlify-cms-core/src/actions/config.js
@@ -119,7 +119,7 @@ function mergePreloadedConfig(preloadedConfig, loadedConfig) {
 }
 
 function parseConfig(data) {
-  const config = yaml.parse(data, { maxAliasCount: -1 });
+  const config = yaml.parse(data, { maxAliasCount: -1, prettyErrors: true });
   if (typeof CMS_ENV === 'string' && config[CMS_ENV]) {
     Object.keys(config[CMS_ENV]).forEach(key => {
       config[key] = config[CMS_ENV][key];


### PR DESCRIPTION
Prints error location on parse failure