### PR TITLE
fix: unify the title used in entry cards and workflow cards (#3573)

### DIFF
--- a/packages/netlify-cms-core/src/components/Collection/Entries/EntryCard.js
+++ b/packages/netlify-cms-core/src/components/Collection/Entries/EntryCard.js
@@ -5,9 +5,8 @@ import { boundGetAsset } from 'Actions/media';
 import { Link } from 'react-router-dom';
 import { colors, colorsRaw, components, lengths, zIndex } from 'netlify-cms-ui-default';
 import { VIEW_STYLE_LIST, VIEW_STYLE_GRID } from 'Constants/collectionViews';
-import { summaryFormatter } from 'Lib/formatters';
-import { keyToPathArray } from 'Lib/stringTemplate';
 import { selectIsLoadingAsset } from 'Reducers/medias';
+import { selectEntryCollectionTitle } from 'Reducers/collections';
 
 const ListCard = styled.li`
   ${components.card};
@@ -122,15 +121,8 @@ const EntryCard = ({
 
 const mapStateToProps = (state, ownProps) => {
   const { entry, inferedFields, collection } = ownProps;
-  const label = entry.get('label');
   const entryData = entry.get('data');
-  const defaultTitle =
-    label ||
-    (inferedFields.titleField && entryData.getIn(keyToPathArray(inferedFields.titleField)));
-  const summaryTemplate = collection.get('summary');
-  const summary = summaryTemplate
-    ? summaryFormatter(summaryTemplate, entry, collection)
-    : defaultTitle;
+  const summary = selectEntryCollectionTitle(collection, entry);
 
   let image = entryData.get(inferedFields.imageField);
   if (image) {

--- a/packages/netlify-cms-core/src/components/Workflow/WorkflowList.js
+++ b/packages/netlify-cms-core/src/components/Workflow/WorkflowList.js
@@ -9,6 +9,7 @@ import { colors, lengths } from 'netlify-cms-ui-default';
 import { status } from 'Constants/publishModes';
 import { DragSource, DropTarget, HTML5DragDrop } from 'UI';
 import WorkflowCard from './WorkflowCard';
+import { selectEntryCollectionTitle } from 'Reducers/collections';
 
 const WorkflowListContainer = styled.div`
   min-height: 60%;
@@ -232,7 +233,7 @@ class WorkflowList extends React.Component {
                   <div>
                     <WorkflowCard
                       collectionLabel={collectionLabel || collectionName}
-                      title={entry.get('label') || entry.getIn(['data', 'title'])}
+                      title={selectEntryCollectionTitle(collection, entry)}
                       authorLastChange={entry.getIn(['metaData', 'user'])}
                       body={entry.getIn(['data', 'body'])}
                       isModification={isModification}

--- a/packages/netlify-cms-core/src/reducers/__tests__/collections.spec.js
+++ b/packages/netlify-cms-core/src/reducers/__tests__/collections.spec.js
@@ -6,6 +6,7 @@ import collections, {
   selectEntrySlug,
   selectFieldsWithMediaFolders,
   selectMediaFolders,
+  selectEntryCollectionTitle,
   getFieldsNames,
   selectField,
   updateFieldByKey,
@@ -380,6 +381,66 @@ describe('collections', () => {
           .get('types')
           .get(0),
       );
+    });
+  });
+
+  describe('selectEntryCollectionTitle', () => {
+    const entry = fromJS({ data: { title: 'entry title', otherField: 'other field' } });
+
+    it('should return the entry title if set', () => {
+      const collection = fromJS({
+        fields: [{ name: 'title' }, { name: 'otherField' }],
+      });
+
+      expect(selectEntryCollectionTitle(collection, entry)).toEqual('entry title');
+    });
+
+    it('should return some other inferreable title if set', () => {
+      const headlineEntry = fromJS({
+        data: { headline: 'entry headline', otherField: 'other field' },
+      });
+      const collection = fromJS({
+        fields: [{ name: 'headline' }, { name: 'otherField' }],
+      });
+
+      expect(selectEntryCollectionTitle(collection, headlineEntry)).toEqual('entry headline');
+    });
+
+    it('should return the identifier_field content if defined in collection', () => {
+      const collection = fromJS({
+        identifier_field: 'otherField',
+        fields: [{ name: 'title' }, { name: 'otherField' }],
+      });
+
+      expect(selectEntryCollectionTitle(collection, entry)).toEqual('other field');
+    });
+
+    it('should return the entry label of a file collection', () => {
+      const labelEntry = fromJS({
+        slug: 'entry-name',
+        data: { title: 'entry title', otherField: 'other field' },
+      });
+      const collection = fromJS({
+        type: FILES,
+        files: [
+          {
+            name: 'entry-name',
+            label: 'entry label',
+          },
+        ],
+      });
+
+      expect(selectEntryCollectionTitle(collection, labelEntry)).toEqual('entry label');
+    });
+
+    it('should return a formatted summary before everything else', () => {
+      const collection = fromJS({
+        summary: '{{title}} -- {{otherField}}',
+        identifier_field: 'otherField',
+        fields: [{ name: 'title' }, { name: 'otherField' }],
+      });
+
+      expect(selectEntryCollectionTitle(collection, entry)).toEqual('entry title -- other field');
     });
   });
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines.

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first two fields are mandatory:
-->

**Summary**

Fix #3573 

This also fixes the currently broken label for file type collections mentioned in #3573.

<!--
Explain the **motivation** for making this change.
What existing problem does the pull request solve?
-->

**Test plan**

<!--
Demonstrate the code is solid.
Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.
-->

Added unit tests for the new helper.

As can be seen below the title for a file type entry works correctly now and the folder collection uses the summary field.

![image](https://user-images.githubusercontent.com/4376726/79009996-30439100-7b61-11ea-98e0-a8507c568f57.png)

