### PR TITLE
fix: DropdownList z-index increased

### DIFF
--- a/packages/netlify-cms-ui-default/src/Dropdown.js
+++ b/packages/netlify-cms-ui-default/src/Dropdown.js
@@ -38,7 +38,7 @@ const DropdownList = styled.ul`
   top: 0;
   left: 0;
   min-width: 100%;
-  z-index: ${zIndex.zIndex2};
+  z-index: ${zIndex.zIndex299};
 
   ${props => css`
     width: ${props.width};


### PR DESCRIPTION
fixes #3503 

**Summary**
Seems that z-index:299 is high enough to bring dropdown items in front of other widgets. 
Probably the easiest way to achieve expected behaviour would be change z-index in DropdownList