### PR TITLE
fix: removed error regarding warnings due to missing generic type closes #3572

### DIFF
--- a/packages/netlify-cms-core/index.d.ts
+++ b/packages/netlify-cms-core/index.d.ts
@@ -204,7 +204,7 @@ declare module 'netlify-cms-core' {
     registerLocale: (locale: string, phrases: CmsLocalePhrases) => void;
     registerMediaLibrary: (mediaLibrary: CmsMediaLibrary, options?: CmsMediaLibraryOptions) => void;
     registerPreviewStyle: (filePath: string, options?: PreviewStyleOptions) => void;
-    registerPreviewTemplate: (name: string, component: ComponentType) => void;
+    registerPreviewTemplate: (name: string, component: ComponentType<P>) => void;
     registerWidget: (
       widget: string | CmsWidgetParam,
       control?: ComponentType,


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines.

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first two fields are mandatory:
-->

**Summary**

<!--
Explain the **motivation** for making this change.
What existing problem does the pull request solve?
-->
The error: JSX.Element' is not assignable to parameter of type 'ComponentType<{}>' was coming up due to missing generic


**Test plan**

<!--
Demonstrate the code is solid.
Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.
-->
`yarn test` passed 66 of 68 total tests and skipped 2 as configured with a few warnings unrelated to this commit.
