### PR TITLE
fix: redirect to default path after login success if url has previous error

### DIFF
--- a/packages/netlify-cms-core/src/components/App/App.js
+++ b/packages/netlify-cms-core/src/components/App/App.js
@@ -195,6 +195,12 @@ class App extends React.Component {
           <Switch>
             <Redirect exact from="/" to={defaultPath} />
             <Redirect exact from="/search/" to={defaultPath} />
+            <Redirect
+              // This happens on Identity + Invite Only + External Provider email not matching
+              // the registered user
+              from="/error=access_denied&error_description=Signups+not+allowed+for+this+instance"
+              to={defaultPath}
+            />
             {hasWorkflow ? <Route path="/workflow" component={Workflow} /> : null}
             <RouteInCollection
               exact


### PR DESCRIPTION
Fixes https://github.com/netlify/netlify-cms/issues/3587
Replaces https://github.com/netlify/netlify-cms/pull/3595

Due to https://github.com/netlify/netlify-identity-widget/issues/86, in order to test locally change your local env url to `http://localhost:8080/#/error=access_denied&error_description=Signups+not+allowed+for+this+instance` to simulate an unsuccessful external login. 