### PR TITLE
fix EditorComponentData

### DIFF
--- a/packages/netlify-cms-core/index.d.ts
+++ b/packages/netlify-cms-core/index.d.ts
@@ -117,7 +117,7 @@ declare module 'netlify-cms-core' {
   }
 
   export interface EditorComponentData {
-    id: number;
+    id: number | string;
   }
 
   export interface EditorComponentOptions {


### PR DESCRIPTION

**Summary**
EditorComponentData doesn't accept string
But in [docs](https://www.netlifycms.org/docs/custom-widgets/#registereditorcomponent) it accept that.