### PR TITLE
fix: added-download-btn-for-media-files closes #3429

### DIFF
--- a/packages/netlify-cms-core/src/components/MediaLibrary/MediaLibraryCard.js
+++ b/packages/netlify-cms-core/src/components/MediaLibrary/MediaLibraryCard.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import ImmutablePropTypes from 'react-immutable-proptypes';
 import styled from '@emotion/styled';
-import { colors, borders, lengths, shadows, effects } from 'netlify-cms-ui-default';
+import { buttons, colors, borders, lengths, shadows, effects } from 'netlify-cms-ui-default';
 
 const IMAGE_HEIGHT = 160;
 
@@ -62,6 +62,57 @@ const DraftText = styled.p`
   border-radius: ${lengths.borderRadius} 0px ${lengths.borderRadius} 0;
 `;
 
+const FileDownloadButton = ({ className, url }) => (
+  <label className={`nc-fileDownloadButton ${className || ''}`}>
+    <a href={url} download>
+      <span>
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          width="24"
+          height="24"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        >
+          <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path>
+          <polyline points="7 10 12 15 17 10"></polyline>
+          <line x1="12" y1="15" x2="12" y2="3"></line>
+        </svg>
+      </span>
+    </a>
+  </label>
+);
+
+FileDownloadButton.propTypes = {
+  className: PropTypes.string,
+  url: PropTypes.string.isRequired,
+};
+
+const StyledFileDownloadButton = styled(FileDownloadButton)`
+  ${buttons.button};
+  ${buttons.default};
+  ${buttons.gray};
+  ${shadows.dropMain};
+  margin: 0;
+  padding: 0;
+  width: 36px;
+  position: absolute;
+  top: 5px;
+  right: 5px;
+  z-index: 2;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+
+  a {
+    color: inherit;
+    cursor: pointer;
+  }
+`;
+
 class MediaLibraryCard extends React.Component {
   render() {
     const {
@@ -89,6 +140,7 @@ class MediaLibraryCard extends React.Component {
         tabIndex="-1"
         isPrivate={isPrivate}
       >
+        <StyledFileDownloadButton url={url} />
         <CardImageWrapper>
           {isDraft ? <DraftText data-testid="draft-text">{draftText}</DraftText> : null}
           {url && isViewableImage ? (

--- a/packages/netlify-cms-core/src/components/MediaLibrary/__tests__/__snapshots__/MediaLibraryCard.spec.js.snap
+++ b/packages/netlify-cms-core/src/components/MediaLibrary/__tests__/__snapshots__/MediaLibraryCard.spec.js.snap
@@ -2,6 +2,165 @@
 
 exports[`MediaLibraryCard should match snapshot for draft image 1`] = `
 <DocumentFragment>
+  .emotion-10 {
+  width: 100px;
+  height: 240px;
+  margin: 10px;
+  border: solid 2px #dfdfe3;
+  border-radius: 5px;
+  cursor: pointer;
+  overflow: hidden;
+}
+
+.emotion-10:focus {
+  outline: none;
+}
+
+.emotion-0 {
+  border: 0;
+  border-radius: 5px;
+  cursor: pointer;
+  height: 36px;
+  line-height: 36px;
+  font-weight: 500;
+  padding: 0 15px;
+  background-color: #798291;
+  color: #fff;
+  background-color: #798291;
+  color: #fff;
+  box-shadow: 0 2px 6px 0 rgba(68,74,87,0.05),0 1px 3px 0 rgba(68,74,87,0.1);
+  margin: 0;
+  padding: 0;
+  width: 36px;
+  position: absolute;
+  top: 5px;
+  right: 5px;
+  z-index: 2;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.emotion-0:focus,
+.emotion-0:hover {
+  color: #fff;
+  background-color: #555a65;
+}
+
+.emotion-0 a {
+  color: inherit;
+  cursor: pointer;
+}
+
+.emotion-6 {
+  height: 162px;
+  background-color: #f2f2f2;
+  background-size: 16px 16px;
+  background-position: 0 0,8px 8px;
+  background-image: linear-gradient( 45deg, #e6e6e6 25%, transparent 25%, transparent 75%, #e6e6e6 75%, #e6e6e6 ) , linear-gradient( 45deg, #e6e6e6 25%, transparent 25%, transparent 75%, #e6e6e6 75%, #e6e6e6 );
+  box-shadow: inset 0 0 4px rgba(68,74,87,0.3);
+  border-bottom: solid 2px #dfdfe3;
+  position: relative;
+}
+
+.emotion-4 {
+  width: 100%;
+  height: 160px;
+  object-fit: contain;
+  border-radius: 2px 2px 0 0;
+}
+
+.emotion-8 {
+  color: #798291;
+  padding: 8px;
+  margin-top: 20px;
+  overflow-wrap: break-word;
+  line-height: 1.3 !important;
+}
+
+.emotion-2 {
+  color: #70399f;
+  background-color: #f6d8ff;
+  position: absolute;
+  padding: 8px;
+  border-radius: 5px 0px 5px 0;
+}
+
+<div
+    class="emotion-10 emotion-11"
+    height="240px"
+    tabindex="-1"
+    width="100px"
+  >
+    <label
+      class="nc-fileDownloadButton emotion-0 emotion-1"
+    >
+      <a
+        download=""
+        href="url"
+      >
+        <span>
+          <svg
+            fill="none"
+            height="24"
+            stroke="currentColor"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            viewBox="0 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"
+            />
+            <polyline
+              points="7 10 12 15 17 10"
+            />
+            <line
+              x1="12"
+              x2="12"
+              y1="15"
+              y2="3"
+            />
+          </svg>
+        </span>
+      </a>
+    </label>
+    <div
+      class="emotion-6 emotion-7"
+    >
+      <p
+        class="emotion-2 emotion-3"
+        data-testid="draft-text"
+      >
+        Draft
+      </p>
+      <img
+        class="emotion-4 emotion-5"
+        src="url"
+      />
+    </div>
+    <p
+      class="emotion-8 emotion-9"
+    >
+      image.png
+    </p>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`MediaLibraryCard should match snapshot for non draft image 1`] = `
+<DocumentFragment>
   .emotion-8 {
   width: 100px;
   height: 240px;
@@ -14,6 +173,51 @@ exports[`MediaLibraryCard should match snapshot for draft image 1`] = `
 
 .emotion-8:focus {
   outline: none;
+}
+
+.emotion-0 {
+  border: 0;
+  border-radius: 5px;
+  cursor: pointer;
+  height: 36px;
+  line-height: 36px;
+  font-weight: 500;
+  padding: 0 15px;
+  background-color: #798291;
+  color: #fff;
+  background-color: #798291;
+  color: #fff;
+  box-shadow: 0 2px 6px 0 rgba(68,74,87,0.05),0 1px 3px 0 rgba(68,74,87,0.1);
+  margin: 0;
+  padding: 0;
+  width: 36px;
+  position: absolute;
+  top: 5px;
+  right: 5px;
+  z-index: 2;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.emotion-0:focus,
+.emotion-0:hover {
+  color: #fff;
+  background-color: #555a65;
+}
+
+.emotion-0 a {
+  color: inherit;
+  cursor: pointer;
 }
 
 .emotion-4 {
@@ -42,29 +246,50 @@ exports[`MediaLibraryCard should match snapshot for draft image 1`] = `
   line-height: 1.3 !important;
 }
 
-.emotion-0 {
-  color: #70399f;
-  background-color: #f6d8ff;
-  position: absolute;
-  padding: 8px;
-  border-radius: 5px 0px 5px 0;
-}
-
 <div
     class="emotion-8 emotion-9"
     height="240px"
     tabindex="-1"
     width="100px"
   >
+    <label
+      class="nc-fileDownloadButton emotion-0 emotion-1"
+    >
+      <a
+        download=""
+        href="url"
+      >
+        <span>
+          <svg
+            fill="none"
+            height="24"
+            stroke="currentColor"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            viewBox="0 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"
+            />
+            <polyline
+              points="7 10 12 15 17 10"
+            />
+            <line
+              x1="12"
+              x2="12"
+              y1="15"
+              y2="3"
+            />
+          </svg>
+        </span>
+      </a>
+    </label>
     <div
       class="emotion-4 emotion-5"
     >
-      <p
-        class="emotion-0 emotion-1"
-        data-testid="draft-text"
-      >
-        Draft
-      </p>
       <img
         class="emotion-2 emotion-3"
         src="url"
@@ -79,74 +304,9 @@ exports[`MediaLibraryCard should match snapshot for draft image 1`] = `
 </DocumentFragment>
 `;
 
-exports[`MediaLibraryCard should match snapshot for non draft image 1`] = `
-<DocumentFragment>
-  .emotion-6 {
-  width: 100px;
-  height: 240px;
-  margin: 10px;
-  border: solid 2px #dfdfe3;
-  border-radius: 5px;
-  cursor: pointer;
-  overflow: hidden;
-}
-
-.emotion-6:focus {
-  outline: none;
-}
-
-.emotion-2 {
-  height: 162px;
-  background-color: #f2f2f2;
-  background-size: 16px 16px;
-  background-position: 0 0,8px 8px;
-  background-image: linear-gradient( 45deg, #e6e6e6 25%, transparent 25%, transparent 75%, #e6e6e6 75%, #e6e6e6 ) , linear-gradient( 45deg, #e6e6e6 25%, transparent 25%, transparent 75%, #e6e6e6 75%, #e6e6e6 );
-  box-shadow: inset 0 0 4px rgba(68,74,87,0.3);
-  border-bottom: solid 2px #dfdfe3;
-  position: relative;
-}
-
-.emotion-0 {
-  width: 100%;
-  height: 160px;
-  object-fit: contain;
-  border-radius: 2px 2px 0 0;
-}
-
-.emotion-4 {
-  color: #798291;
-  padding: 8px;
-  margin-top: 20px;
-  overflow-wrap: break-word;
-  line-height: 1.3 !important;
-}
-
-<div
-    class="emotion-6 emotion-7"
-    height="240px"
-    tabindex="-1"
-    width="100px"
-  >
-    <div
-      class="emotion-2 emotion-3"
-    >
-      <img
-        class="emotion-0 emotion-1"
-        src="url"
-      />
-    </div>
-    <p
-      class="emotion-4 emotion-5"
-    >
-      image.png
-    </p>
-  </div>
-</DocumentFragment>
-`;
-
 exports[`MediaLibraryCard should match snapshot for non viewable image 1`] = `
 <DocumentFragment>
-  .emotion-6 {
+  .emotion-8 {
   width: 100px;
   height: 240px;
   margin: 10px;
@@ -156,11 +316,56 @@ exports[`MediaLibraryCard should match snapshot for non viewable image 1`] = `
   overflow: hidden;
 }
 
-.emotion-6:focus {
+.emotion-8:focus {
   outline: none;
 }
 
-.emotion-2 {
+.emotion-0 {
+  border: 0;
+  border-radius: 5px;
+  cursor: pointer;
+  height: 36px;
+  line-height: 36px;
+  font-weight: 500;
+  padding: 0 15px;
+  background-color: #798291;
+  color: #fff;
+  background-color: #798291;
+  color: #fff;
+  box-shadow: 0 2px 6px 0 rgba(68,74,87,0.05),0 1px 3px 0 rgba(68,74,87,0.1);
+  margin: 0;
+  padding: 0;
+  width: 36px;
+  position: absolute;
+  top: 5px;
+  right: 5px;
+  z-index: 2;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.emotion-0:focus,
+.emotion-0:hover {
+  color: #fff;
+  background-color: #555a65;
+}
+
+.emotion-0 a {
+  color: inherit;
+  cursor: pointer;
+}
+
+.emotion-4 {
   height: 162px;
   background-color: #f2f2f2;
   background-size: 16px 16px;
@@ -171,7 +376,7 @@ exports[`MediaLibraryCard should match snapshot for non viewable image 1`] = `
   position: relative;
 }
 
-.emotion-4 {
+.emotion-6 {
   color: #798291;
   padding: 8px;
   margin-top: 20px;
@@ -179,7 +384,7 @@ exports[`MediaLibraryCard should match snapshot for non viewable image 1`] = `
   line-height: 1.3 !important;
 }
 
-.emotion-0 {
+.emotion-2 {
   width: 100%;
   height: 160px;
   object-fit: cover;
@@ -189,23 +394,58 @@ exports[`MediaLibraryCard should match snapshot for non viewable image 1`] = `
 }
 
 <div
-    class="emotion-6 emotion-7"
+    class="emotion-8 emotion-9"
     height="240px"
     tabindex="-1"
     width="100px"
   >
+    <label
+      class="nc-fileDownloadButton emotion-0 emotion-1"
+    >
+      <a
+        download=""
+        href="url"
+      >
+        <span>
+          <svg
+            fill="none"
+            height="24"
+            stroke="currentColor"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            viewBox="0 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"
+            />
+            <polyline
+              points="7 10 12 15 17 10"
+            />
+            <line
+              x1="12"
+              x2="12"
+              y1="15"
+              y2="3"
+            />
+          </svg>
+        </span>
+      </a>
+    </label>
     <div
-      class="emotion-2 emotion-3"
+      class="emotion-4 emotion-5"
     >
       <div
-        class="emotion-0 emotion-1"
+        class="emotion-2 emotion-3"
         data-testid="card-file-icon"
       >
         Not Viewable
       </div>
     </div>
     <p
-      class="emotion-4 emotion-5"
+      class="emotion-6 emotion-7"
     >
       image.png
     </p>


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines.

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first two fields are mandatory:
-->

**Summary**

<!--
Explain the **motivation** for making this change.
What existing problem does the pull request solve?
-->
The commit adds a download button for all kind of media files which was not possible earlier as only upload and delete options were left. (Images could be downloaded earlier through `Save as..` but it was not possible to download PDF files or other documents.)
**Test plan**

<!--
Demonstrate the code is solid.
Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.
-->
Ran `yarn test` after `jest --updateSnapshot` as there was a UI change. All tests passed successfully. Code was formatted with `yarn format`.
<img width="296" alt="Screen Shot 2020-04-14 at 11 19 58 PM" src="https://user-images.githubusercontent.com/51631122/79307001-cede4200-7f13-11ea-96a9-a56eee2b8f36.png">


