### PR TITLE
feat(widget-object): add collapsed option to collapse object by default

### DIFF
--- a/dev-test/config.yml
+++ b/dev-test/config.yml
@@ -124,6 +124,7 @@ collections: # A list of collections the CMS should be able to edit
       - label: 'Object'
         name: 'object'
         widget: 'object'
+        collapsed: true
         fields:
           - label: 'Related Post'
             name: 'post'

--- a/packages/netlify-cms-widget-object/src/ObjectControl.js
+++ b/packages/netlify-cms-widget-object/src/ObjectControl.js
@@ -42,7 +42,7 @@ export default class ObjectControl extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
-      collapsed: false,
+      collapsed: props.field.get('collapsed', false),
     };
   }
 

--- a/website/content/docs/widgets/object.md
+++ b/website/content/docs/widgets/object.md
@@ -10,6 +10,7 @@ The object widget allows you to group multiple widgets together, nested under a 
 - **Data type:** list of child widget values
 - **Options:**
   - `default`: you can set defaults within each sub-field's configuration
+  - `collapsed`: if added and labeled `true`, the widget's content is collapsed by default
   - `fields`: (**required**) a nested list of widget fields to include in your widget
 - **Example:**
     ```yaml
@@ -27,6 +28,7 @@ The object widget allows you to group multiple widgets together, nested under a 
         - label: "Address"
           name: "address"
           widget: "object"
+          collapsed: true
           fields: 
             - {label: "Street Address", name: "street", widget: "string"}
             - {label: "City", name: "city", widget: "string"}


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines.

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first two fields are mandatory:
-->

**Summary**
This adds the possibility for objects to be collapsed by default.

It was not possible to collapse an object by default before which sometimes added a lot of clutter for long object fields. This allows the user to better control the initial UI state.

The collapsed state defaults to false so this does not change the default behavior.

<!--
Explain the **motivation** for making this change.
What existing problem does the pull request solve?
-->

**Test plan**
The option has been added to the `object` in the kitchen sink dev test collection to verify that it's working.
<!--
Demonstrate the code is solid.
Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.
-->
