### PR TITLE
feat(widget-list): add hiding list content with minimize_collapsed option

### DIFF
--- a/dev-test/config.yml
+++ b/dev-test/config.yml
@@ -173,6 +173,7 @@ collections: # A list of collections the CMS should be able to edit
               - label: 'List'
                 name: 'list'
                 widget: 'list'
+                minimize_collapsed: true
                 fields:
                   - label: 'Related Post'
                     name: 'post'

--- a/dev-test/config.yml
+++ b/dev-test/config.yml
@@ -173,7 +173,6 @@ collections: # A list of collections the CMS should be able to edit
               - label: 'List'
                 name: 'list'
                 widget: 'list'
-                minimize_collapsed: true
                 fields:
                   - label: 'Related Post'
                     name: 'post'

--- a/packages/netlify-cms-widget-list/src/ListControl.js
+++ b/packages/netlify-cms-widget-list/src/ListControl.js
@@ -301,9 +301,10 @@ export default class ListControl extends React.Component {
         ? { [collectionName]: metadata.removeIn(metadataRemovePath) }
         : metadata;
 
-    const newItemsCollapsed = itemsCollapsed.slice(index);
-    const newKeys = keys.slice(index);
-    this.setState({ itemsCollapsed: newItemsCollapsed, keys: newKeys });
+    itemsCollapsed.splice(index, 1);
+    keys.splice(index, 1);
+
+    this.setState({ itemsCollapsed: [...itemsCollapsed], keys: [...keys] });
 
     onChange(value.remove(index), parsedMetadata);
     clearFieldErrors();
@@ -391,7 +392,8 @@ export default class ListControl extends React.Component {
 
     // Update collapsing
     const collapsed = itemsCollapsed[oldIndex];
-    const updatedItemsCollapsed = itemsCollapsed.slice(oldIndex);
+    itemsCollapsed.splice(oldIndex, 1);
+    const updatedItemsCollapsed = [...itemsCollapsed];
     updatedItemsCollapsed.splice(newIndex, 0, collapsed);
 
     // Reset item to ensure updated state

--- a/packages/netlify-cms-widget-list/src/__tests__/ListControl.spec.js
+++ b/packages/netlify-cms-widget-list/src/__tests__/ListControl.spec.js
@@ -454,4 +454,116 @@ describe('ListControl', () => {
     );
     expect(getByText('hello - world - index.md')).toBeInTheDocument();
   });
+
+  it('should render list with fields with default collapse ("true") and minimize_collapsed ("false")', () => {
+    const field = fromJS({
+      name: 'list',
+      label: 'List',
+      fields: [{ label: 'String', name: 'string', widget: 'string' }],
+    });
+    const { asFragment, getByTestId } = render(
+      <ListControl
+        {...props}
+        field={field}
+        value={fromJS([{ title: 'item 1' }, { title: 'item 2' }])}
+      />,
+    );
+
+    expect(getByTestId('styled-list-item-top-bar-0')).toHaveAttribute('collapsed', 'true');
+    expect(getByTestId('styled-list-item-top-bar-1')).toHaveAttribute('collapsed', 'true');
+
+    expect(getByTestId('object-control-0')).toHaveAttribute('collapsed', 'true');
+    expect(getByTestId('object-control-1')).toHaveAttribute('collapsed', 'true');
+
+    expect(asFragment()).toMatchSnapshot();
+  });
+
+  it('should render list with fields with collapse = "false" and default minimize_collapsed ("false")', () => {
+    const field = fromJS({
+      name: 'list',
+      label: 'List',
+      collapsed: false,
+      fields: [{ label: 'String', name: 'string', widget: 'string' }],
+    });
+    const { asFragment, getByTestId } = render(
+      <ListControl
+        {...props}
+        field={field}
+        value={fromJS([{ title: 'item 1' }, { title: 'item 2' }])}
+      />,
+    );
+
+    expect(getByTestId('styled-list-item-top-bar-0')).toHaveAttribute('collapsed', 'false');
+    expect(getByTestId('styled-list-item-top-bar-1')).toHaveAttribute('collapsed', 'false');
+
+    expect(getByTestId('object-control-0')).toHaveAttribute('collapsed', 'false');
+    expect(getByTestId('object-control-1')).toHaveAttribute('collapsed', 'false');
+
+    expect(asFragment()).toMatchSnapshot();
+  });
+
+  it('should render list with fields with default collapse ("true") and minimize_collapsed = "true"', () => {
+    const field = fromJS({
+      name: 'list',
+      label: 'List',
+      minimize_collapsed: true,
+      fields: [{ label: 'String', name: 'string', widget: 'string' }],
+    });
+    const { asFragment, getByTestId, queryByTestId } = render(
+      <ListControl
+        {...props}
+        field={field}
+        value={fromJS([{ title: 'item 1' }, { title: 'item 2' }])}
+      />,
+    );
+
+    expect(queryByTestId('styled-list-item-top-bar-0')).toBeNull();
+    expect(queryByTestId('styled-list-item-top-bar-1')).toBeNull();
+
+    expect(queryByTestId('object-control-0')).toBeNull();
+    expect(queryByTestId('object-control-1')).toBeNull();
+
+    expect(asFragment()).toMatchSnapshot();
+
+    fireEvent.click(getByTestId('expand-button'));
+
+    expect(getByTestId('styled-list-item-top-bar-0')).toHaveAttribute('collapsed', 'true');
+    expect(getByTestId('styled-list-item-top-bar-1')).toHaveAttribute('collapsed', 'true');
+
+    expect(getByTestId('object-control-0')).toHaveAttribute('collapsed', 'true');
+    expect(getByTestId('object-control-1')).toHaveAttribute('collapsed', 'true');
+  });
+
+  it('should render list with fields with collapse = "false" and default minimize_collapsed = "true"', () => {
+    const field = fromJS({
+      name: 'list',
+      label: 'List',
+      collapsed: false,
+      minimize_collapsed: true,
+      fields: [{ label: 'String', name: 'string', widget: 'string' }],
+    });
+    const { asFragment, getByTestId, queryByTestId } = render(
+      <ListControl
+        {...props}
+        field={field}
+        value={fromJS([{ title: 'item 1' }, { title: 'item 2' }])}
+      />,
+    );
+
+    expect(getByTestId('styled-list-item-top-bar-0')).toHaveAttribute('collapsed', 'false');
+    expect(getByTestId('styled-list-item-top-bar-1')).toHaveAttribute('collapsed', 'false');
+
+    expect(getByTestId('object-control-0')).toHaveAttribute('collapsed', 'false');
+    expect(getByTestId('object-control-1')).toHaveAttribute('collapsed', 'false');
+
+    expect(asFragment()).toMatchSnapshot();
+
+    fireEvent.click(getByTestId('expand-button'));
+
+    expect(queryByTestId('styled-list-item-top-bar-0')).toBeNull();
+    expect(queryByTestId('styled-list-item-top-bar-1')).toBeNull();
+
+    expect(queryByTestId('object-control-0')).toBeNull();
+    expect(queryByTestId('object-control-1')).toBeNull();
+  });
 });

--- a/packages/netlify-cms-widget-list/src/__tests__/__snapshots__/ListControl.spec.js.snap
+++ b/packages/netlify-cms-widget-list/src/__tests__/__snapshots__/ListControl.spec.js.snap
@@ -1,5 +1,715 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`ListControl should add to list when add button is clicked 1`] = `
+<DocumentFragment>
+  .emotion-18 {
+  padding: 0 14px 14px;
+}
+
+.emotion-12 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  background-color: #dfdfe3;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  margin: 0 -14px;
+  padding: 13px;
+}
+
+.emotion-5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  font-size: 14px;
+  font-weight: 500;
+  line-height: 1;
+}
+
+.emotion-3 {
+  border: 0;
+  border-radius: 5px;
+  cursor: pointer;
+  padding: 4px;
+  background-color: transparent;
+  color: inherit;
+}
+
+.emotion-3:last-of-type {
+  margin-right: 4px;
+}
+
+.emotion-10 {
+  border: 0;
+  border-radius: 5px;
+  cursor: pointer;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  padding: 2px 12px;
+  font-size: 12px;
+  font-weight: bold;
+  border-radius: 3px;
+}
+
+.emotion-10 .emotion-0 {
+  margin-left: 6px;
+}
+
+.emotion-8 {
+  display: inline-block;
+  line-height: 0;
+  width: 12px;
+  height: 12px;
+  -webkit-transform: rotate(0deg);
+  -ms-transform: rotate(0deg);
+  transform: rotate(0deg);
+}
+
+.emotion-8 path:not(.no-fill),
+.emotion-8 circle:not(.no-fill),
+.emotion-8 polygon:not(.no-fill),
+.emotion-8 rect:not(.no-fill) {
+  fill: currentColor;
+}
+
+.emotion-8 path.clipped {
+  fill: transparent;
+}
+
+.emotion-8 svg {
+  width: 100%;
+  height: 100%;
+}
+
+.emotion-1 {
+  display: inline-block;
+  line-height: 0;
+  width: 18px;
+  height: 18px;
+  -webkit-transform: rotate(0deg);
+  -ms-transform: rotate(0deg);
+  transform: rotate(0deg);
+}
+
+.emotion-1 path:not(.no-fill),
+.emotion-1 circle:not(.no-fill),
+.emotion-1 polygon:not(.no-fill),
+.emotion-1 rect:not(.no-fill) {
+  fill: currentColor;
+}
+
+.emotion-1 path.clipped {
+  fill: transparent;
+}
+
+.emotion-1 svg {
+  width: 100%;
+  height: 100%;
+}
+
+.emotion-16 {
+  margin-top: 18px;
+}
+
+.emotion-16:first-of-type {
+  margin-top: 26px;
+}
+
+.emotion-14 {
+  display: none;
+  border-top: 0;
+  color: inherit;
+  background-color: #dfdfe3;
+  padding: 13px;
+  border-radius: 0 0 5px 5px;
+}
+
+<div
+    class="classNameWrapper emotion-18"
+  >
+    <div
+      class="emotion-12 emotion-13"
+    >
+      <div
+        class="emotion-5 emotion-6"
+      >
+        <button
+          class="emotion-3 emotion-4"
+          data-testid="expand-button"
+        >
+          <span
+            class="emotion-0 emotion-1 emotion-2"
+          >
+            <svg
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M5.123 6.33l-2.26 2.137 8.656 9.15 9.344-9.105-2.17-2.228-7.084 6.902z"
+              />
+            </svg>
+          </span>
+        </button>
+        1 list
+      </div>
+      <button
+        class="emotion-10 emotion-11"
+      >
+        Add list 
+        <span
+          class="emotion-0 emotion-8 emotion-2"
+        >
+          <svg
+            height="24"
+            viewBox="0 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M19 14h-4a1 1 0 0 0-1 1v4a1 1 0 0 1-1 1h-2a1 1 0 0 1-1-1v-4a1 1 0 0 0-1-1H5a1 1 0 0 1-1-1v-2a1 1 0 0 1 1-1h4a1 1 0 0 0 1-1V5a1 1 0 0 1 1-1h2a1 1 0 0 1 1 1v4a1 1 0 0 0 1 1h4a1 1 0 0 1 1 1v2a1 1 0 0 1-1 1z"
+            />
+          </svg>
+        </span>
+      </button>
+    </div>
+    <div>
+      <div
+        class="emotion-16 emotion-17"
+      >
+        <mock-list-item-top-bar
+          classname="css-1e1b0lr-StyledListItemTopBar e14bfka81"
+          collapsed="false"
+          data-testid="styled-list-item-top-bar-0"
+        >
+          <button>
+            Remove
+          </button>
+        </mock-list-item-top-bar>
+        <div
+          class="emotion-14 emotion-15"
+        >
+          No string
+        </div>
+        <mock-object-control
+          classnamewrapper="classNameWrapper"
+          collapsed="false"
+          data-testid="object-control-0"
+          field="Map { \\"name\\": \\"list\\", \\"label\\": \\"List\\", \\"fields\\": List [ Map { \\"label\\": \\"String\\", \\"name\\": \\"string\\", \\"widget\\": \\"string\\" } ] }"
+          fieldserrors="Map {}"
+          forlist="true"
+          validationkey="0"
+          value="Map {}"
+        />
+      </div>
+    </div>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`ListControl should remove from list when remove button is clicked 1`] = `
+<DocumentFragment>
+  .emotion-22 {
+  padding: 0 14px 14px;
+}
+
+.emotion-12 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  background-color: #dfdfe3;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  margin: 0 -14px;
+  padding: 13px;
+}
+
+.emotion-5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  font-size: 14px;
+  font-weight: 500;
+  line-height: 1;
+}
+
+.emotion-3 {
+  border: 0;
+  border-radius: 5px;
+  cursor: pointer;
+  padding: 4px;
+  background-color: transparent;
+  color: inherit;
+}
+
+.emotion-3:last-of-type {
+  margin-right: 4px;
+}
+
+.emotion-10 {
+  border: 0;
+  border-radius: 5px;
+  cursor: pointer;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  padding: 2px 12px;
+  font-size: 12px;
+  font-weight: bold;
+  border-radius: 3px;
+}
+
+.emotion-10 .emotion-0 {
+  margin-left: 6px;
+}
+
+.emotion-8 {
+  display: inline-block;
+  line-height: 0;
+  width: 12px;
+  height: 12px;
+  -webkit-transform: rotate(0deg);
+  -ms-transform: rotate(0deg);
+  transform: rotate(0deg);
+}
+
+.emotion-8 path:not(.no-fill),
+.emotion-8 circle:not(.no-fill),
+.emotion-8 polygon:not(.no-fill),
+.emotion-8 rect:not(.no-fill) {
+  fill: currentColor;
+}
+
+.emotion-8 path.clipped {
+  fill: transparent;
+}
+
+.emotion-8 svg {
+  width: 100%;
+  height: 100%;
+}
+
+.emotion-1 {
+  display: inline-block;
+  line-height: 0;
+  width: 18px;
+  height: 18px;
+  -webkit-transform: rotate(0deg);
+  -ms-transform: rotate(0deg);
+  transform: rotate(0deg);
+}
+
+.emotion-1 path:not(.no-fill),
+.emotion-1 circle:not(.no-fill),
+.emotion-1 polygon:not(.no-fill),
+.emotion-1 rect:not(.no-fill) {
+  fill: currentColor;
+}
+
+.emotion-1 path.clipped {
+  fill: transparent;
+}
+
+.emotion-1 svg {
+  width: 100%;
+  height: 100%;
+}
+
+.emotion-16 {
+  margin-top: 18px;
+}
+
+.emotion-16:first-of-type {
+  margin-top: 26px;
+}
+
+.emotion-14 {
+  display: none;
+  border-top: 0;
+  color: inherit;
+  background-color: #dfdfe3;
+  padding: 13px;
+  border-radius: 0 0 5px 5px;
+}
+
+<div
+    class="classNameWrapper emotion-22"
+  >
+    <div
+      class="emotion-12 emotion-13"
+    >
+      <div
+        class="emotion-5 emotion-6"
+      >
+        <button
+          class="emotion-3 emotion-4"
+          data-testid="expand-button"
+        >
+          <span
+            class="emotion-0 emotion-1 emotion-2"
+          >
+            <svg
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M5.123 6.33l-2.26 2.137 8.656 9.15 9.344-9.105-2.17-2.228-7.084 6.902z"
+              />
+            </svg>
+          </span>
+        </button>
+        2 list
+      </div>
+      <button
+        class="emotion-10 emotion-11"
+      >
+        Add list 
+        <span
+          class="emotion-0 emotion-8 emotion-2"
+        >
+          <svg
+            height="24"
+            viewBox="0 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M19 14h-4a1 1 0 0 0-1 1v4a1 1 0 0 1-1 1h-2a1 1 0 0 1-1-1v-4a1 1 0 0 0-1-1H5a1 1 0 0 1-1-1v-2a1 1 0 0 1 1-1h4a1 1 0 0 0 1-1V5a1 1 0 0 1 1-1h2a1 1 0 0 1 1 1v4a1 1 0 0 0 1 1h4a1 1 0 0 1 1 1v2a1 1 0 0 1-1 1z"
+            />
+          </svg>
+        </span>
+      </button>
+    </div>
+    <div>
+      <div
+        class="emotion-16 emotion-17"
+      >
+        <mock-list-item-top-bar
+          classname="css-1e1b0lr-StyledListItemTopBar e14bfka81"
+          collapsed="false"
+          data-testid="styled-list-item-top-bar-0"
+        >
+          <button>
+            Remove
+          </button>
+        </mock-list-item-top-bar>
+        <div
+          class="emotion-14 emotion-15"
+        >
+          item 1
+        </div>
+        <mock-object-control
+          classnamewrapper="classNameWrapper"
+          collapsed="false"
+          data-testid="object-control-0"
+          field="Map { \\"name\\": \\"list\\", \\"label\\": \\"List\\", \\"collapsed\\": false, \\"minimize_collapsed\\": true, \\"fields\\": List [ Map { \\"label\\": \\"String\\", \\"name\\": \\"string\\", \\"widget\\": \\"string\\" } ] }"
+          fieldserrors="Map {}"
+          forlist="true"
+          validationkey="0"
+          value="Map { \\"string\\": \\"item 1\\" }"
+        />
+      </div>
+      <div
+        class="emotion-16 emotion-17"
+      >
+        <mock-list-item-top-bar
+          classname="css-1e1b0lr-StyledListItemTopBar e14bfka81"
+          collapsed="false"
+          data-testid="styled-list-item-top-bar-1"
+        >
+          <button>
+            Remove
+          </button>
+        </mock-list-item-top-bar>
+        <div
+          class="emotion-14 emotion-15"
+        >
+          item 2
+        </div>
+        <mock-object-control
+          classnamewrapper="classNameWrapper"
+          collapsed="false"
+          data-testid="object-control-1"
+          field="Map { \\"name\\": \\"list\\", \\"label\\": \\"List\\", \\"collapsed\\": false, \\"minimize_collapsed\\": true, \\"fields\\": List [ Map { \\"label\\": \\"String\\", \\"name\\": \\"string\\", \\"widget\\": \\"string\\" } ] }"
+          fieldserrors="Map {}"
+          forlist="true"
+          validationkey="1"
+          value="Map { \\"string\\": \\"item 2\\" }"
+        />
+      </div>
+    </div>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`ListControl should remove from list when remove button is clicked 2`] = `
+<DocumentFragment>
+  .emotion-18 {
+  padding: 0 14px 14px;
+}
+
+.emotion-12 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  background-color: #dfdfe3;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  margin: 0 -14px;
+  padding: 13px;
+}
+
+.emotion-5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  font-size: 14px;
+  font-weight: 500;
+  line-height: 1;
+}
+
+.emotion-3 {
+  border: 0;
+  border-radius: 5px;
+  cursor: pointer;
+  padding: 4px;
+  background-color: transparent;
+  color: inherit;
+}
+
+.emotion-3:last-of-type {
+  margin-right: 4px;
+}
+
+.emotion-10 {
+  border: 0;
+  border-radius: 5px;
+  cursor: pointer;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  padding: 2px 12px;
+  font-size: 12px;
+  font-weight: bold;
+  border-radius: 3px;
+}
+
+.emotion-10 .emotion-0 {
+  margin-left: 6px;
+}
+
+.emotion-8 {
+  display: inline-block;
+  line-height: 0;
+  width: 12px;
+  height: 12px;
+  -webkit-transform: rotate(0deg);
+  -ms-transform: rotate(0deg);
+  transform: rotate(0deg);
+}
+
+.emotion-8 path:not(.no-fill),
+.emotion-8 circle:not(.no-fill),
+.emotion-8 polygon:not(.no-fill),
+.emotion-8 rect:not(.no-fill) {
+  fill: currentColor;
+}
+
+.emotion-8 path.clipped {
+  fill: transparent;
+}
+
+.emotion-8 svg {
+  width: 100%;
+  height: 100%;
+}
+
+.emotion-16 {
+  margin-top: 18px;
+  padding-bottom: 0;
+}
+
+.emotion-16:first-of-type {
+  margin-top: 26px;
+}
+
+.emotion-14 {
+  display: block;
+  border-top: 0;
+  color: inherit;
+  background-color: #dfdfe3;
+  padding: 13px;
+  border-radius: 0 0 5px 5px;
+}
+
+.emotion-1 {
+  display: inline-block;
+  line-height: 0;
+  width: 18px;
+  height: 18px;
+  -webkit-transform: rotate(0deg);
+  -ms-transform: rotate(0deg);
+  transform: rotate(0deg);
+}
+
+.emotion-1 path:not(.no-fill),
+.emotion-1 circle:not(.no-fill),
+.emotion-1 polygon:not(.no-fill),
+.emotion-1 rect:not(.no-fill) {
+  fill: currentColor;
+}
+
+.emotion-1 path.clipped {
+  fill: transparent;
+}
+
+.emotion-1 svg {
+  width: 100%;
+  height: 100%;
+}
+
+<div
+    class="classNameWrapper emotion-18"
+  >
+    <div
+      class="emotion-12 emotion-13"
+    >
+      <div
+        class="emotion-5 emotion-6"
+      >
+        <button
+          class="emotion-3 emotion-4"
+          data-testid="expand-button"
+        >
+          <span
+            class="emotion-0 emotion-1 emotion-2"
+          >
+            <svg
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M5.123 6.33l-2.26 2.137 8.656 9.15 9.344-9.105-2.17-2.228-7.084 6.902z"
+              />
+            </svg>
+          </span>
+        </button>
+        1 list
+      </div>
+      <button
+        class="emotion-10 emotion-11"
+      >
+        Add list 
+        <span
+          class="emotion-0 emotion-8 emotion-2"
+        >
+          <svg
+            height="24"
+            viewBox="0 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M19 14h-4a1 1 0 0 0-1 1v4a1 1 0 0 1-1 1h-2a1 1 0 0 1-1-1v-4a1 1 0 0 0-1-1H5a1 1 0 0 1-1-1v-2a1 1 0 0 1 1-1h4a1 1 0 0 0 1-1V5a1 1 0 0 1 1-1h2a1 1 0 0 1 1 1v4a1 1 0 0 0 1 1h4a1 1 0 0 1 1 1v2a1 1 0 0 1-1 1z"
+            />
+          </svg>
+        </span>
+      </button>
+    </div>
+    <div>
+      <div
+        class="emotion-16 emotion-17"
+      >
+        <mock-list-item-top-bar
+          classname="css-1e1b0lr-StyledListItemTopBar e14bfka81"
+          collapsed="true"
+          data-testid="styled-list-item-top-bar-1"
+        >
+          <button>
+            Remove
+          </button>
+        </mock-list-item-top-bar>
+        <div
+          class="emotion-14 emotion-15"
+        >
+          item 2
+        </div>
+        <mock-object-control
+          classnamewrapper="classNameWrapper css-1pznrxi"
+          collapsed="true"
+          data-testid="object-control-1"
+          field="Map { \\"name\\": \\"list\\", \\"label\\": \\"List\\", \\"collapsed\\": false, \\"minimize_collapsed\\": true, \\"fields\\": List [ Map { \\"label\\": \\"String\\", \\"name\\": \\"string\\", \\"widget\\": \\"string\\" } ] }"
+          fieldserrors="Map {}"
+          forlist="true"
+          validationkey="1"
+          value="Map { \\"string\\": \\"item 2\\" }"
+        />
+      </div>
+    </div>
+  </div>
+</DocumentFragment>
+`;
+
 exports[`ListControl should render empty list 1`] = `
 <DocumentFragment>
   <input
@@ -211,11 +921,15 @@ exports[`ListControl should render list with fields with collapse = "false" and 
           classname="css-1e1b0lr-StyledListItemTopBar e14bfka81"
           collapsed="false"
           data-testid="styled-list-item-top-bar-0"
-        />
+        >
+          <button>
+            Remove
+          </button>
+        </mock-list-item-top-bar>
         <div
           class="emotion-14 emotion-15"
         >
-          No string
+          item 1
         </div>
         <mock-object-control
           classnamewrapper="classNameWrapper"
@@ -225,7 +939,7 @@ exports[`ListControl should render list with fields with collapse = "false" and 
           fieldserrors="Map {}"
           forlist="true"
           validationkey="0"
-          value="Map { \\"title\\": \\"item 1\\" }"
+          value="Map { \\"string\\": \\"item 1\\" }"
         />
       </div>
       <div
@@ -235,11 +949,15 @@ exports[`ListControl should render list with fields with collapse = "false" and 
           classname="css-1e1b0lr-StyledListItemTopBar e14bfka81"
           collapsed="false"
           data-testid="styled-list-item-top-bar-1"
-        />
+        >
+          <button>
+            Remove
+          </button>
+        </mock-list-item-top-bar>
         <div
           class="emotion-14 emotion-15"
         >
-          No string
+          item 2
         </div>
         <mock-object-control
           classnamewrapper="classNameWrapper"
@@ -249,7 +967,7 @@ exports[`ListControl should render list with fields with collapse = "false" and 
           fieldserrors="Map {}"
           forlist="true"
           validationkey="1"
-          value="Map { \\"title\\": \\"item 2\\" }"
+          value="Map { \\"string\\": \\"item 2\\" }"
         />
       </div>
     </div>
@@ -458,11 +1176,15 @@ exports[`ListControl should render list with fields with collapse = "false" and 
           classname="css-1e1b0lr-StyledListItemTopBar e14bfka81"
           collapsed="false"
           data-testid="styled-list-item-top-bar-0"
-        />
+        >
+          <button>
+            Remove
+          </button>
+        </mock-list-item-top-bar>
         <div
           class="emotion-14 emotion-15"
         >
-          No string
+          item 1
         </div>
         <mock-object-control
           classnamewrapper="classNameWrapper"
@@ -472,7 +1194,7 @@ exports[`ListControl should render list with fields with collapse = "false" and 
           fieldserrors="Map {}"
           forlist="true"
           validationkey="0"
-          value="Map { \\"title\\": \\"item 1\\" }"
+          value="Map { \\"string\\": \\"item 1\\" }"
         />
       </div>
       <div
@@ -482,11 +1204,15 @@ exports[`ListControl should render list with fields with collapse = "false" and 
           classname="css-1e1b0lr-StyledListItemTopBar e14bfka81"
           collapsed="false"
           data-testid="styled-list-item-top-bar-1"
-        />
+        >
+          <button>
+            Remove
+          </button>
+        </mock-list-item-top-bar>
         <div
           class="emotion-14 emotion-15"
         >
-          No string
+          item 2
         </div>
         <mock-object-control
           classnamewrapper="classNameWrapper"
@@ -496,7 +1222,7 @@ exports[`ListControl should render list with fields with collapse = "false" and 
           fieldserrors="Map {}"
           forlist="true"
           validationkey="1"
-          value="Map { \\"title\\": \\"item 2\\" }"
+          value="Map { \\"string\\": \\"item 2\\" }"
         />
       </div>
     </div>
@@ -706,11 +1432,15 @@ exports[`ListControl should render list with fields with default collapse ("true
           classname="css-1e1b0lr-StyledListItemTopBar e14bfka81"
           collapsed="true"
           data-testid="styled-list-item-top-bar-0"
-        />
+        >
+          <button>
+            Remove
+          </button>
+        </mock-list-item-top-bar>
         <div
           class="emotion-14 emotion-15"
         >
-          No string
+          item 1
         </div>
         <mock-object-control
           classnamewrapper="classNameWrapper css-1pznrxi"
@@ -720,7 +1450,7 @@ exports[`ListControl should render list with fields with default collapse ("true
           fieldserrors="Map {}"
           forlist="true"
           validationkey="0"
-          value="Map { \\"title\\": \\"item 1\\" }"
+          value="Map { \\"string\\": \\"item 1\\" }"
         />
       </div>
       <div
@@ -730,11 +1460,15 @@ exports[`ListControl should render list with fields with default collapse ("true
           classname="css-1e1b0lr-StyledListItemTopBar e14bfka81"
           collapsed="true"
           data-testid="styled-list-item-top-bar-1"
-        />
+        >
+          <button>
+            Remove
+          </button>
+        </mock-list-item-top-bar>
         <div
           class="emotion-14 emotion-15"
         >
-          No string
+          item 2
         </div>
         <mock-object-control
           classnamewrapper="classNameWrapper css-1pznrxi"
@@ -744,7 +1478,7 @@ exports[`ListControl should render list with fields with default collapse ("true
           fieldserrors="Map {}"
           forlist="true"
           validationkey="1"
-          value="Map { \\"title\\": \\"item 2\\" }"
+          value="Map { \\"string\\": \\"item 2\\" }"
         />
       </div>
     </div>
@@ -1134,7 +1868,11 @@ exports[`ListControl should render list with nested object 1`] = `
           classname="css-1e1b0lr-StyledListItemTopBar e14bfka81"
           collapsed="true"
           data-testid="styled-list-item-top-bar-0"
-        />
+        >
+          <button>
+            Remove
+          </button>
+        </mock-list-item-top-bar>
         <div
           class="emotion-14 emotion-15"
         >
@@ -1158,7 +1896,11 @@ exports[`ListControl should render list with nested object 1`] = `
           classname="css-1e1b0lr-StyledListItemTopBar e14bfka81"
           collapsed="true"
           data-testid="styled-list-item-top-bar-1"
-        />
+        >
+          <button>
+            Remove
+          </button>
+        </mock-list-item-top-bar>
         <div
           class="emotion-14 emotion-15"
         >
@@ -1381,7 +2123,11 @@ exports[`ListControl should render list with nested object with collapse = false
           classname="css-1e1b0lr-StyledListItemTopBar e14bfka81"
           collapsed="false"
           data-testid="styled-list-item-top-bar-0"
-        />
+        >
+          <button>
+            Remove
+          </button>
+        </mock-list-item-top-bar>
         <div
           class="emotion-14 emotion-15"
         >
@@ -1405,7 +2151,11 @@ exports[`ListControl should render list with nested object with collapse = false
           classname="css-1e1b0lr-StyledListItemTopBar e14bfka81"
           collapsed="false"
           data-testid="styled-list-item-top-bar-1"
-        />
+        >
+          <button>
+            Remove
+          </button>
+        </mock-list-item-top-bar>
         <div
           class="emotion-14 emotion-15"
         >

--- a/packages/netlify-cms-widget-list/src/__tests__/__snapshots__/ListControl.spec.js.snap
+++ b/packages/netlify-cms-widget-list/src/__tests__/__snapshots__/ListControl.spec.js.snap
@@ -10,6 +10,928 @@ exports[`ListControl should render empty list 1`] = `
 </DocumentFragment>
 `;
 
+exports[`ListControl should render list with fields with collapse = "false" and default minimize_collapsed ("false") 1`] = `
+<DocumentFragment>
+  .emotion-22 {
+  padding: 0 14px 14px;
+}
+
+.emotion-12 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  background-color: #dfdfe3;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  margin: 0 -14px;
+  padding: 13px;
+}
+
+.emotion-5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  font-size: 14px;
+  font-weight: 500;
+  line-height: 1;
+}
+
+.emotion-3 {
+  border: 0;
+  border-radius: 5px;
+  cursor: pointer;
+  padding: 4px;
+  background-color: transparent;
+  color: inherit;
+}
+
+.emotion-3:last-of-type {
+  margin-right: 4px;
+}
+
+.emotion-10 {
+  border: 0;
+  border-radius: 5px;
+  cursor: pointer;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  padding: 2px 12px;
+  font-size: 12px;
+  font-weight: bold;
+  border-radius: 3px;
+}
+
+.emotion-10 .emotion-0 {
+  margin-left: 6px;
+}
+
+.emotion-8 {
+  display: inline-block;
+  line-height: 0;
+  width: 12px;
+  height: 12px;
+  -webkit-transform: rotate(0deg);
+  -ms-transform: rotate(0deg);
+  transform: rotate(0deg);
+}
+
+.emotion-8 path:not(.no-fill),
+.emotion-8 circle:not(.no-fill),
+.emotion-8 polygon:not(.no-fill),
+.emotion-8 rect:not(.no-fill) {
+  fill: currentColor;
+}
+
+.emotion-8 path.clipped {
+  fill: transparent;
+}
+
+.emotion-8 svg {
+  width: 100%;
+  height: 100%;
+}
+
+.emotion-1 {
+  display: inline-block;
+  line-height: 0;
+  width: 18px;
+  height: 18px;
+  -webkit-transform: rotate(0deg);
+  -ms-transform: rotate(0deg);
+  transform: rotate(0deg);
+}
+
+.emotion-1 path:not(.no-fill),
+.emotion-1 circle:not(.no-fill),
+.emotion-1 polygon:not(.no-fill),
+.emotion-1 rect:not(.no-fill) {
+  fill: currentColor;
+}
+
+.emotion-1 path.clipped {
+  fill: transparent;
+}
+
+.emotion-1 svg {
+  width: 100%;
+  height: 100%;
+}
+
+.emotion-16 {
+  margin-top: 18px;
+}
+
+.emotion-16:first-of-type {
+  margin-top: 26px;
+}
+
+.emotion-14 {
+  display: none;
+  border-top: 0;
+  color: inherit;
+  background-color: #dfdfe3;
+  padding: 13px;
+  border-radius: 0 0 5px 5px;
+}
+
+<div
+    class="classNameWrapper emotion-22"
+  >
+    <div
+      class="emotion-12 emotion-13"
+    >
+      <div
+        class="emotion-5 emotion-6"
+      >
+        <button
+          class="emotion-3 emotion-4"
+          data-testid="expand-button"
+        >
+          <span
+            class="emotion-0 emotion-1 emotion-2"
+          >
+            <svg
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M5.123 6.33l-2.26 2.137 8.656 9.15 9.344-9.105-2.17-2.228-7.084 6.902z"
+              />
+            </svg>
+          </span>
+        </button>
+        2 list
+      </div>
+      <button
+        class="emotion-10 emotion-11"
+      >
+        Add list 
+        <span
+          class="emotion-0 emotion-8 emotion-2"
+        >
+          <svg
+            height="24"
+            viewBox="0 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M19 14h-4a1 1 0 0 0-1 1v4a1 1 0 0 1-1 1h-2a1 1 0 0 1-1-1v-4a1 1 0 0 0-1-1H5a1 1 0 0 1-1-1v-2a1 1 0 0 1 1-1h4a1 1 0 0 0 1-1V5a1 1 0 0 1 1-1h2a1 1 0 0 1 1 1v4a1 1 0 0 0 1 1h4a1 1 0 0 1 1 1v2a1 1 0 0 1-1 1z"
+            />
+          </svg>
+        </span>
+      </button>
+    </div>
+    <div>
+      <div
+        class="emotion-16 emotion-17"
+      >
+        <mock-list-item-top-bar
+          classname="css-1e1b0lr-StyledListItemTopBar e14bfka81"
+          collapsed="false"
+          data-testid="styled-list-item-top-bar-0"
+        />
+        <div
+          class="emotion-14 emotion-15"
+        >
+          No string
+        </div>
+        <mock-object-control
+          classnamewrapper="classNameWrapper"
+          collapsed="false"
+          data-testid="object-control-0"
+          field="Map { \\"name\\": \\"list\\", \\"label\\": \\"List\\", \\"collapsed\\": false, \\"fields\\": List [ Map { \\"label\\": \\"String\\", \\"name\\": \\"string\\", \\"widget\\": \\"string\\" } ] }"
+          fieldserrors="Map {}"
+          forlist="true"
+          validationkey="0"
+          value="Map { \\"title\\": \\"item 1\\" }"
+        />
+      </div>
+      <div
+        class="emotion-16 emotion-17"
+      >
+        <mock-list-item-top-bar
+          classname="css-1e1b0lr-StyledListItemTopBar e14bfka81"
+          collapsed="false"
+          data-testid="styled-list-item-top-bar-1"
+        />
+        <div
+          class="emotion-14 emotion-15"
+        >
+          No string
+        </div>
+        <mock-object-control
+          classnamewrapper="classNameWrapper"
+          collapsed="false"
+          data-testid="object-control-1"
+          field="Map { \\"name\\": \\"list\\", \\"label\\": \\"List\\", \\"collapsed\\": false, \\"fields\\": List [ Map { \\"label\\": \\"String\\", \\"name\\": \\"string\\", \\"widget\\": \\"string\\" } ] }"
+          fieldserrors="Map {}"
+          forlist="true"
+          validationkey="1"
+          value="Map { \\"title\\": \\"item 2\\" }"
+        />
+      </div>
+    </div>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`ListControl should render list with fields with collapse = "false" and default minimize_collapsed = "true" 1`] = `
+<DocumentFragment>
+  .emotion-22 {
+  padding: 0 14px 14px;
+}
+
+.emotion-12 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  background-color: #dfdfe3;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  margin: 0 -14px;
+  padding: 13px;
+}
+
+.emotion-5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  font-size: 14px;
+  font-weight: 500;
+  line-height: 1;
+}
+
+.emotion-3 {
+  border: 0;
+  border-radius: 5px;
+  cursor: pointer;
+  padding: 4px;
+  background-color: transparent;
+  color: inherit;
+}
+
+.emotion-3:last-of-type {
+  margin-right: 4px;
+}
+
+.emotion-10 {
+  border: 0;
+  border-radius: 5px;
+  cursor: pointer;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  padding: 2px 12px;
+  font-size: 12px;
+  font-weight: bold;
+  border-radius: 3px;
+}
+
+.emotion-10 .emotion-0 {
+  margin-left: 6px;
+}
+
+.emotion-8 {
+  display: inline-block;
+  line-height: 0;
+  width: 12px;
+  height: 12px;
+  -webkit-transform: rotate(0deg);
+  -ms-transform: rotate(0deg);
+  transform: rotate(0deg);
+}
+
+.emotion-8 path:not(.no-fill),
+.emotion-8 circle:not(.no-fill),
+.emotion-8 polygon:not(.no-fill),
+.emotion-8 rect:not(.no-fill) {
+  fill: currentColor;
+}
+
+.emotion-8 path.clipped {
+  fill: transparent;
+}
+
+.emotion-8 svg {
+  width: 100%;
+  height: 100%;
+}
+
+.emotion-1 {
+  display: inline-block;
+  line-height: 0;
+  width: 18px;
+  height: 18px;
+  -webkit-transform: rotate(0deg);
+  -ms-transform: rotate(0deg);
+  transform: rotate(0deg);
+}
+
+.emotion-1 path:not(.no-fill),
+.emotion-1 circle:not(.no-fill),
+.emotion-1 polygon:not(.no-fill),
+.emotion-1 rect:not(.no-fill) {
+  fill: currentColor;
+}
+
+.emotion-1 path.clipped {
+  fill: transparent;
+}
+
+.emotion-1 svg {
+  width: 100%;
+  height: 100%;
+}
+
+.emotion-16 {
+  margin-top: 18px;
+}
+
+.emotion-16:first-of-type {
+  margin-top: 26px;
+}
+
+.emotion-14 {
+  display: none;
+  border-top: 0;
+  color: inherit;
+  background-color: #dfdfe3;
+  padding: 13px;
+  border-radius: 0 0 5px 5px;
+}
+
+<div
+    class="classNameWrapper emotion-22"
+  >
+    <div
+      class="emotion-12 emotion-13"
+    >
+      <div
+        class="emotion-5 emotion-6"
+      >
+        <button
+          class="emotion-3 emotion-4"
+          data-testid="expand-button"
+        >
+          <span
+            class="emotion-0 emotion-1 emotion-2"
+          >
+            <svg
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M5.123 6.33l-2.26 2.137 8.656 9.15 9.344-9.105-2.17-2.228-7.084 6.902z"
+              />
+            </svg>
+          </span>
+        </button>
+        2 list
+      </div>
+      <button
+        class="emotion-10 emotion-11"
+      >
+        Add list 
+        <span
+          class="emotion-0 emotion-8 emotion-2"
+        >
+          <svg
+            height="24"
+            viewBox="0 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M19 14h-4a1 1 0 0 0-1 1v4a1 1 0 0 1-1 1h-2a1 1 0 0 1-1-1v-4a1 1 0 0 0-1-1H5a1 1 0 0 1-1-1v-2a1 1 0 0 1 1-1h4a1 1 0 0 0 1-1V5a1 1 0 0 1 1-1h2a1 1 0 0 1 1 1v4a1 1 0 0 0 1 1h4a1 1 0 0 1 1 1v2a1 1 0 0 1-1 1z"
+            />
+          </svg>
+        </span>
+      </button>
+    </div>
+    <div>
+      <div
+        class="emotion-16 emotion-17"
+      >
+        <mock-list-item-top-bar
+          classname="css-1e1b0lr-StyledListItemTopBar e14bfka81"
+          collapsed="false"
+          data-testid="styled-list-item-top-bar-0"
+        />
+        <div
+          class="emotion-14 emotion-15"
+        >
+          No string
+        </div>
+        <mock-object-control
+          classnamewrapper="classNameWrapper"
+          collapsed="false"
+          data-testid="object-control-0"
+          field="Map { \\"name\\": \\"list\\", \\"label\\": \\"List\\", \\"collapsed\\": false, \\"minimize_collapsed\\": true, \\"fields\\": List [ Map { \\"label\\": \\"String\\", \\"name\\": \\"string\\", \\"widget\\": \\"string\\" } ] }"
+          fieldserrors="Map {}"
+          forlist="true"
+          validationkey="0"
+          value="Map { \\"title\\": \\"item 1\\" }"
+        />
+      </div>
+      <div
+        class="emotion-16 emotion-17"
+      >
+        <mock-list-item-top-bar
+          classname="css-1e1b0lr-StyledListItemTopBar e14bfka81"
+          collapsed="false"
+          data-testid="styled-list-item-top-bar-1"
+        />
+        <div
+          class="emotion-14 emotion-15"
+        >
+          No string
+        </div>
+        <mock-object-control
+          classnamewrapper="classNameWrapper"
+          collapsed="false"
+          data-testid="object-control-1"
+          field="Map { \\"name\\": \\"list\\", \\"label\\": \\"List\\", \\"collapsed\\": false, \\"minimize_collapsed\\": true, \\"fields\\": List [ Map { \\"label\\": \\"String\\", \\"name\\": \\"string\\", \\"widget\\": \\"string\\" } ] }"
+          fieldserrors="Map {}"
+          forlist="true"
+          validationkey="1"
+          value="Map { \\"title\\": \\"item 2\\" }"
+        />
+      </div>
+    </div>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`ListControl should render list with fields with default collapse ("true") and minimize_collapsed ("false") 1`] = `
+<DocumentFragment>
+  .emotion-22 {
+  padding: 0 14px 14px;
+}
+
+.emotion-12 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  background-color: #dfdfe3;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  margin: 0 -14px;
+  padding: 13px;
+}
+
+.emotion-5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  font-size: 14px;
+  font-weight: 500;
+  line-height: 1;
+}
+
+.emotion-3 {
+  border: 0;
+  border-radius: 5px;
+  cursor: pointer;
+  padding: 4px;
+  background-color: transparent;
+  color: inherit;
+}
+
+.emotion-3:last-of-type {
+  margin-right: 4px;
+}
+
+.emotion-1 {
+  display: inline-block;
+  line-height: 0;
+  width: 18px;
+  height: 18px;
+  -webkit-transform: rotate(-90deg);
+  -ms-transform: rotate(-90deg);
+  transform: rotate(-90deg);
+}
+
+.emotion-1 path:not(.no-fill),
+.emotion-1 circle:not(.no-fill),
+.emotion-1 polygon:not(.no-fill),
+.emotion-1 rect:not(.no-fill) {
+  fill: currentColor;
+}
+
+.emotion-1 path.clipped {
+  fill: transparent;
+}
+
+.emotion-1 svg {
+  width: 100%;
+  height: 100%;
+}
+
+.emotion-10 {
+  border: 0;
+  border-radius: 5px;
+  cursor: pointer;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  padding: 2px 12px;
+  font-size: 12px;
+  font-weight: bold;
+  border-radius: 3px;
+}
+
+.emotion-10 .emotion-0 {
+  margin-left: 6px;
+}
+
+.emotion-8 {
+  display: inline-block;
+  line-height: 0;
+  width: 12px;
+  height: 12px;
+  -webkit-transform: rotate(0deg);
+  -ms-transform: rotate(0deg);
+  transform: rotate(0deg);
+}
+
+.emotion-8 path:not(.no-fill),
+.emotion-8 circle:not(.no-fill),
+.emotion-8 polygon:not(.no-fill),
+.emotion-8 rect:not(.no-fill) {
+  fill: currentColor;
+}
+
+.emotion-8 path.clipped {
+  fill: transparent;
+}
+
+.emotion-8 svg {
+  width: 100%;
+  height: 100%;
+}
+
+.emotion-16 {
+  margin-top: 18px;
+  padding-bottom: 0;
+}
+
+.emotion-16:first-of-type {
+  margin-top: 26px;
+}
+
+.emotion-14 {
+  display: block;
+  border-top: 0;
+  color: inherit;
+  background-color: #dfdfe3;
+  padding: 13px;
+  border-radius: 0 0 5px 5px;
+}
+
+<div
+    class="classNameWrapper emotion-22"
+  >
+    <div
+      class="emotion-12 emotion-13"
+    >
+      <div
+        class="emotion-5 emotion-6"
+      >
+        <button
+          class="emotion-3 emotion-4"
+          data-testid="expand-button"
+        >
+          <span
+            class="emotion-0 emotion-1 emotion-2"
+          >
+            <svg
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M5.123 6.33l-2.26 2.137 8.656 9.15 9.344-9.105-2.17-2.228-7.084 6.902z"
+              />
+            </svg>
+          </span>
+        </button>
+        2 list
+      </div>
+      <button
+        class="emotion-10 emotion-11"
+      >
+        Add list 
+        <span
+          class="emotion-0 emotion-8 emotion-2"
+        >
+          <svg
+            height="24"
+            viewBox="0 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M19 14h-4a1 1 0 0 0-1 1v4a1 1 0 0 1-1 1h-2a1 1 0 0 1-1-1v-4a1 1 0 0 0-1-1H5a1 1 0 0 1-1-1v-2a1 1 0 0 1 1-1h4a1 1 0 0 0 1-1V5a1 1 0 0 1 1-1h2a1 1 0 0 1 1 1v4a1 1 0 0 0 1 1h4a1 1 0 0 1 1 1v2a1 1 0 0 1-1 1z"
+            />
+          </svg>
+        </span>
+      </button>
+    </div>
+    <div>
+      <div
+        class="emotion-16 emotion-17"
+      >
+        <mock-list-item-top-bar
+          classname="css-1e1b0lr-StyledListItemTopBar e14bfka81"
+          collapsed="true"
+          data-testid="styled-list-item-top-bar-0"
+        />
+        <div
+          class="emotion-14 emotion-15"
+        >
+          No string
+        </div>
+        <mock-object-control
+          classnamewrapper="classNameWrapper css-1pznrxi"
+          collapsed="true"
+          data-testid="object-control-0"
+          field="Map { \\"name\\": \\"list\\", \\"label\\": \\"List\\", \\"fields\\": List [ Map { \\"label\\": \\"String\\", \\"name\\": \\"string\\", \\"widget\\": \\"string\\" } ] }"
+          fieldserrors="Map {}"
+          forlist="true"
+          validationkey="0"
+          value="Map { \\"title\\": \\"item 1\\" }"
+        />
+      </div>
+      <div
+        class="emotion-16 emotion-17"
+      >
+        <mock-list-item-top-bar
+          classname="css-1e1b0lr-StyledListItemTopBar e14bfka81"
+          collapsed="true"
+          data-testid="styled-list-item-top-bar-1"
+        />
+        <div
+          class="emotion-14 emotion-15"
+        >
+          No string
+        </div>
+        <mock-object-control
+          classnamewrapper="classNameWrapper css-1pznrxi"
+          collapsed="true"
+          data-testid="object-control-1"
+          field="Map { \\"name\\": \\"list\\", \\"label\\": \\"List\\", \\"fields\\": List [ Map { \\"label\\": \\"String\\", \\"name\\": \\"string\\", \\"widget\\": \\"string\\" } ] }"
+          fieldserrors="Map {}"
+          forlist="true"
+          validationkey="1"
+          value="Map { \\"title\\": \\"item 2\\" }"
+        />
+      </div>
+    </div>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`ListControl should render list with fields with default collapse ("true") and minimize_collapsed = "true" 1`] = `
+<DocumentFragment>
+  .emotion-14 {
+  padding: 0 14px 14px;
+}
+
+.emotion-12 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  background-color: #dfdfe3;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  margin: 0 -14px;
+  padding: 13px;
+}
+
+.emotion-5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  font-size: 14px;
+  font-weight: 500;
+  line-height: 1;
+}
+
+.emotion-3 {
+  border: 0;
+  border-radius: 5px;
+  cursor: pointer;
+  padding: 4px;
+  background-color: transparent;
+  color: inherit;
+}
+
+.emotion-3:last-of-type {
+  margin-right: 4px;
+}
+
+.emotion-1 {
+  display: inline-block;
+  line-height: 0;
+  width: 18px;
+  height: 18px;
+  -webkit-transform: rotate(-90deg);
+  -ms-transform: rotate(-90deg);
+  transform: rotate(-90deg);
+}
+
+.emotion-1 path:not(.no-fill),
+.emotion-1 circle:not(.no-fill),
+.emotion-1 polygon:not(.no-fill),
+.emotion-1 rect:not(.no-fill) {
+  fill: currentColor;
+}
+
+.emotion-1 path.clipped {
+  fill: transparent;
+}
+
+.emotion-1 svg {
+  width: 100%;
+  height: 100%;
+}
+
+.emotion-10 {
+  border: 0;
+  border-radius: 5px;
+  cursor: pointer;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  padding: 2px 12px;
+  font-size: 12px;
+  font-weight: bold;
+  border-radius: 3px;
+}
+
+.emotion-10 .emotion-0 {
+  margin-left: 6px;
+}
+
+.emotion-8 {
+  display: inline-block;
+  line-height: 0;
+  width: 12px;
+  height: 12px;
+  -webkit-transform: rotate(0deg);
+  -ms-transform: rotate(0deg);
+  transform: rotate(0deg);
+}
+
+.emotion-8 path:not(.no-fill),
+.emotion-8 circle:not(.no-fill),
+.emotion-8 polygon:not(.no-fill),
+.emotion-8 rect:not(.no-fill) {
+  fill: currentColor;
+}
+
+.emotion-8 path.clipped {
+  fill: transparent;
+}
+
+.emotion-8 svg {
+  width: 100%;
+  height: 100%;
+}
+
+<div
+    class="classNameWrapper emotion-14"
+  >
+    <div
+      class="emotion-12 emotion-13"
+    >
+      <div
+        class="emotion-5 emotion-6"
+      >
+        <button
+          class="emotion-3 emotion-4"
+          data-testid="expand-button"
+        >
+          <span
+            class="emotion-0 emotion-1 emotion-2"
+          >
+            <svg
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M5.123 6.33l-2.26 2.137 8.656 9.15 9.344-9.105-2.17-2.228-7.084 6.902z"
+              />
+            </svg>
+          </span>
+        </button>
+        2 list
+      </div>
+      <button
+        class="emotion-10 emotion-11"
+      >
+        Add list 
+        <span
+          class="emotion-0 emotion-8 emotion-2"
+        >
+          <svg
+            height="24"
+            viewBox="0 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M19 14h-4a1 1 0 0 0-1 1v4a1 1 0 0 1-1 1h-2a1 1 0 0 1-1-1v-4a1 1 0 0 0-1-1H5a1 1 0 0 1-1-1v-2a1 1 0 0 1 1-1h4a1 1 0 0 0 1-1V5a1 1 0 0 1 1-1h2a1 1 0 0 1 1 1v4a1 1 0 0 0 1 1h4a1 1 0 0 1 1 1v2a1 1 0 0 1-1 1z"
+            />
+          </svg>
+        </span>
+      </button>
+    </div>
+  </div>
+</DocumentFragment>
+`;
+
 exports[`ListControl should render list with nested object 1`] = `
 <DocumentFragment>
   .emotion-22 {

--- a/website/content/docs/widgets/list.md
+++ b/website/content/docs/widgets/list.md
@@ -13,6 +13,7 @@ The list widget allows you to create a repeatable item in the UI which saves as 
   - `allow_add`: if added and labeled `false`, button to add additional widgets disappears
   - `collapsed`: if added and labeled `false`, the list widget's content does not collapse by default
   - `summary`: allows customization of a collapsed list item object in a similar way to a [collection summary](/docs/configuration-options/?#summary)
+  - `minimize_collapsed`: if added and labeled `true`, the list widget's content will be completely hidden instead of only collapsed if the list widget itself is collapsed
   - `field`: a single widget field to be repeated
   - `fields`: a nested list of multiple widget fields to be included in each repeatable iteration
 - **Example** (`field`/`fields` not specified):
@@ -58,6 +59,16 @@ The list widget allows you to create a repeatable item in the UI which saves as 
     - label: "Testimonials"
       name: "testimonials"
       collapsed: false
+      widget: "list"
+      fields:
+        - {label: Quote, name: quote, widget: string, default: "Everything is awesome!"}
+        - {label: Author, name: author, widget: string }
+    ```
+- **Example** (`minimize_collapsed` marked `true`):
+    ```yaml
+    - label: "Testimonials"
+      name: "testimonials"
+      minimize_collapsed: true
       widget: "list"
       fields:
         - {label: Quote, name: quote, widget: string, default: "Everything is awesome!"}


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines.

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first two fields are mandatory:
-->

**Summary**
This adds the option to completely hide list content when the list widget itself is collapsed. 
If the option `minimize_collapsed` is set to `true` all list items are hidden rather then only collapsed when the list collapse toggle is used. 

This is a direct response to https://github.com/netlify/netlify-cms/pull/3606#issuecomment-613952382. 
Instead of completely changing the behavior of the `collapsed` option as suggested in https://github.com/netlify/netlify-cms/pull/3606#issuecomment-613977784 I added the `minimize_collapsed` option such that the change is not breaking and a list with just `collapsed: true` will still expand it's items. 

I feel like there are valid use cases for having a list expand it's items when the collapsed state is toggled., e.g. object with single items in them. I'm totally open for discussion on this one though. 

Right now the behavior is:
- `collapsed: true` & `minimize_collapsed: false`: collapse but don't hide list items and the list widget collapse button toggles the collapse state of all items (as before)
- `collapsed: true` & `minimize_collapsed: true`: when opening the list widget the items are shown, but remain collapsed; when collapsing the list widget all items are collapsed and hidden
- `collapsed: false` & `minimize_collapsed: false`: item are not collapsed  by default but can be collapsed using the collapse toggle on the list widget (as before)
- `collapsed: false` & `minimize_collapsed: true`:  items are expanded by default, but can be hidden when using the collapse toggle on the list widget

<!--
Explain the **motivation** for making this change.
What existing problem does the pull request solve?
-->

**Test plan**
Added `minimize_collapsed: true` to the nested list in the object in the list (that's a handful) in the kitchen sink collection.

![image](https://user-images.githubusercontent.com/4376726/79332983-110c8100-7f1e-11ea-948e-8a377f00d965.png)

<!--
Demonstrate the code is solid.
Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.
-->

