### PR TITLE
feat(netlify-cms-widget-list): allow 'summary' field

### DIFF
--- a/dev-test/config.yml
+++ b/dev-test/config.yml
@@ -124,6 +124,7 @@ collections: # A list of collections the CMS should be able to edit
       - label: 'Object'
         name: 'object'
         widget: 'object'
+        collapsed: true
         fields:
           - label: 'Related Post'
             name: 'post'

--- a/dev-test/config.yml
+++ b/dev-test/config.yml
@@ -51,6 +51,43 @@ collections: # A list of collections the CMS should be able to edit
     editor:
       preview: false
     files:
+      - name: 'listTest'
+        label: 'List Test'
+        file: '_data/list.json'
+        description: 'Test file for list, will remove'
+        fields:
+          - label: 'Hi'
+            name: 'hi'
+            widget: string
+
+          - label: 'Typed List'
+            name: 'typed_list'
+            widget: 'list'
+            types:
+              - label: 'Type 1 Object'
+                name: 'type_1_object'
+                summary: 'hi {{string}}, {{year}}'
+                widget: 'object'
+                fields:
+                  - { label: 'String', name: 'string', widget: 'string' }
+                  - { label: 'Boolean', name: 'boolean', widget: 'boolean' }
+                  - { label: 'Text', name: 'text', widget: 'text' }
+              - label: 'Type 2 Object'
+                name: 'type_2_object'
+                widget: 'object'
+                fields:
+                  - { label: 'Number', name: 'number', widget: 'number' }
+                  - { label: 'Select', name: 'select', widget: 'select', options: ['a', 'b', 'c'] }
+                  - { label: 'Datetime', name: 'datetime', widget: 'datetime' }
+                  - { label: 'Markdown', name: 'markdown', widget: 'markdown' }
+              - label: 'Type 3 Object'
+                name: 'type_3_object'
+                widget: 'object'
+                fields:
+                  - { label: 'Date', name: 'date', widget: 'date' }
+                  - { label: 'Image', name: 'image', widget: 'image' }
+                  - { label: 'File', name: 'file', widget: 'file' }
+
       - name: 'general'
         label: 'Site Settings'
         file: '_data/settings.json'

--- a/dev-test/config.yml
+++ b/dev-test/config.yml
@@ -66,10 +66,10 @@ collections: # A list of collections the CMS should be able to edit
             types:
               - label: 'Type 1 Object'
                 name: 'type_1_object'
-                summary: 'hi {{string}}, {{year}}'
+                summary: 'hi {{label}} {{fields.label}}'
                 widget: 'object'
                 fields:
-                  - { label: 'String', name: 'string', widget: 'string' }
+                  - { label: 'Label', name: 'label', widget: 'string' }
                   - { label: 'Boolean', name: 'boolean', widget: 'boolean' }
                   - { label: 'Text', name: 'text', widget: 'text' }
               - label: 'Type 2 Object'
@@ -82,6 +82,7 @@ collections: # A list of collections the CMS should be able to edit
                   - { label: 'Markdown', name: 'markdown', widget: 'markdown' }
               - label: 'Type 3 Object'
                 name: 'type_3_object'
+                summary: '3 {{date}}'
                 widget: 'object'
                 fields:
                   - { label: 'Date', name: 'date', widget: 'date' }

--- a/dev-test/config.yml
+++ b/dev-test/config.yml
@@ -51,44 +51,6 @@ collections: # A list of collections the CMS should be able to edit
     editor:
       preview: false
     files:
-      - name: 'listTest'
-        label: 'List Test'
-        file: '_data/list.json'
-        description: 'Test file for list, will remove'
-        fields:
-          - label: 'Hi'
-            name: 'hi'
-            widget: string
-
-          - label: 'Typed List'
-            name: 'typed_list'
-            widget: 'list'
-            types:
-              - label: 'Type 1 Object'
-                name: 'type_1_object'
-                summary: 'hi {{label}} {{fields.label}}'
-                widget: 'object'
-                fields:
-                  - { label: 'Label', name: 'label', widget: 'string' }
-                  - { label: 'Boolean', name: 'boolean', widget: 'boolean' }
-                  - { label: 'Text', name: 'text', widget: 'text' }
-              - label: 'Type 2 Object'
-                name: 'type_2_object'
-                widget: 'object'
-                fields:
-                  - { label: 'Number', name: 'number', widget: 'number' }
-                  - { label: 'Select', name: 'select', widget: 'select', options: ['a', 'b', 'c'] }
-                  - { label: 'Datetime', name: 'datetime', widget: 'datetime' }
-                  - { label: 'Markdown', name: 'markdown', widget: 'markdown' }
-              - label: 'Type 3 Object'
-                name: 'type_3_object'
-                summary: '3 {{date}}'
-                widget: 'object'
-                fields:
-                  - { label: 'Date', name: 'date', widget: 'date' }
-                  - { label: 'Image', name: 'image', widget: 'image' }
-                  - { label: 'File', name: 'file', widget: 'file' }
-
       - name: 'general'
         label: 'Site Settings'
         file: '_data/settings.json'
@@ -162,7 +124,6 @@ collections: # A list of collections the CMS should be able to edit
       - label: 'Object'
         name: 'object'
         widget: 'object'
-        collapsed: true
         fields:
           - label: 'Related Post'
             name: 'post'

--- a/packages/netlify-cms-widget-list/package.json
+++ b/packages/netlify-cms-widget-list/package.json
@@ -29,6 +29,7 @@
     "@emotion/styled": "^10.0.9",
     "immutable": "^3.7.6",
     "lodash": "^4.17.11",
+    "netlify-cms-core": "^2.24.3",
     "netlify-cms-ui-default": "^2.6.0",
     "netlify-cms-widget-object": "^2.2.0",
     "prop-types": "^15.7.2",

--- a/packages/netlify-cms-widget-list/package.json
+++ b/packages/netlify-cms-widget-list/package.json
@@ -22,6 +22,7 @@
     "build:esm": "cross-env NODE_ENV=esm babel src --out-dir dist/esm --ignore \"**/__tests__\" --root-mode upward"
   },
   "dependencies": {
+    "netlify-cms-lib-widgets": "^1.3.0",
     "react-sortable-hoc": "^1.0.0"
   },
   "peerDependencies": {

--- a/packages/netlify-cms-widget-list/package.json
+++ b/packages/netlify-cms-widget-list/package.json
@@ -22,7 +22,6 @@
     "build:esm": "cross-env NODE_ENV=esm babel src --out-dir dist/esm --ignore \"**/__tests__\" --root-mode upward"
   },
   "dependencies": {
-    "netlify-cms-lib-widgets": "^1.3.0",
     "react-sortable-hoc": "^1.0.0"
   },
   "peerDependencies": {
@@ -30,9 +29,9 @@
     "@emotion/styled": "^10.0.9",
     "immutable": "^3.7.6",
     "lodash": "^4.17.11",
-    "netlify-cms-core": "^2.24.3",
     "netlify-cms-ui-default": "^2.6.0",
     "netlify-cms-widget-object": "^2.2.0",
+    "netlify-cms-lib-widgets": "^1.0.0",
     "prop-types": "^15.7.2",
     "react": "^16.8.4",
     "react-immutable-proptypes": "^2.1.0"

--- a/packages/netlify-cms-widget-list/src/ListControl.js
+++ b/packages/netlify-cms-widget-list/src/ListControl.js
@@ -342,7 +342,8 @@ export default class ListControl extends React.Component {
         const singleField = field.get('field');
         const label = singleField.get('label', singleField.get('name'));
         const summary = field.get('summary');
-        const labelReturn = summary ? handleSummary(summary, entry, label, item) : label;
+        const data = fromJS({ [singleField.get('name')]: item });
+        const labelReturn = summary ? handleSummary(summary, entry, label, data) : label;
         return labelReturn;
       }
       case valueTypes.MULTIPLE: {

--- a/packages/netlify-cms-widget-list/src/ListControl.js
+++ b/packages/netlify-cms-widget-list/src/ListControl.js
@@ -15,7 +15,7 @@ import {
   getErrorMessageForTypedFieldAndValue,
 } from './typedListHelpers';
 import { ListItemTopBar, ObjectWidgetTopBar, colors, lengths } from 'netlify-cms-ui-default';
-import { compileStringTemplate } from 'netlify-cms-core/dist/esm/lib/stringTemplate';
+import { stringTemplate } from 'netlify-cms-lib-widgets';
 
 function valueToString(value) {
   return value ? value.join(',').replace(/,([^\s]|$)/g, ', $1') : '';
@@ -321,11 +321,14 @@ export default class ListControl extends React.Component {
     const { field } = this.props;
     if (this.getValueType() === valueTypes.MIXED) {
       const itemType = getTypedFieldForValue(field, item);
-      const fallbackLabel = itemType.get('label');
-      const summaryTemplate = itemType.get('summary');
-      return summaryTemplate
-        ? compileStringTemplate(summaryTemplate, null, '', item)
-        : fallbackLabel;
+      const label = itemType.get('label', field.get('name'));
+      const summary = itemType.get('summary');
+      let labelReturn = label
+      if (summary) {
+        const data = item.set('label', label)
+        labelReturn = stringTemplate.compileStringTemplate(summary, null, '', data)
+      }
+      return labelReturn
     }
 
     const multiFields = field.get('fields');

--- a/packages/netlify-cms-widget-list/src/ListControl.js
+++ b/packages/netlify-cms-widget-list/src/ListControl.js
@@ -72,6 +72,14 @@ const valueTypes = {
   MIXED: 'MIXED',
 };
 
+const handleSummary = (summary, entry, label, item) => {
+  const data = stringTemplate.addFileTemplateFields(
+    entry.get('path'),
+    item.set('fields.label', label),
+  );
+  return stringTemplate.compileStringTemplate(summary, null, '', data);
+};
+
 export default class ListControl extends React.Component {
   validations = [];
 
@@ -97,6 +105,7 @@ export default class ListControl extends React.Component {
     resolveWidget: PropTypes.func.isRequired,
     clearFieldErrors: PropTypes.func.isRequired,
     fieldsErrors: ImmutablePropTypes.map.isRequired,
+    entry: ImmutablePropTypes.map.isRequired,
   };
 
   static defaultProps = {
@@ -318,26 +327,34 @@ export default class ListControl extends React.Component {
   };
 
   objectLabel(item) {
-    const { field } = this.props;
-    if (this.getValueType() === valueTypes.MIXED) {
-      const itemType = getTypedFieldForValue(field, item);
-      const label = itemType.get('label', field.get('name'));
-      const summary = itemType.get('summary');
-      let labelReturn = label
-      if (summary) {
-        const data = item.set('label', label)
-        labelReturn = stringTemplate.compileStringTemplate(summary, null, '', data)
+    const { field, entry } = this.props;
+    const valueType = this.getValueType();
+    switch (valueType) {
+      case valueTypes.MIXED: {
+        const itemType = getTypedFieldForValue(field, item);
+        const label = itemType.get('label', itemType.get('name'));
+        // each type can have its own summary, but default to the list summary if exists
+        const summary = itemType.get('summary', field.get('summary'));
+        const labelReturn = summary ? handleSummary(summary, entry, label, item) : label;
+        return labelReturn;
       }
-      return labelReturn
+      case valueTypes.SINGLE: {
+        const singleField = field.get('field');
+        const label = singleField.get('label', singleField.get('name'));
+        const summary = field.get('summary');
+        const labelReturn = summary ? handleSummary(summary, entry, label, item) : label;
+        return labelReturn;
+      }
+      case valueTypes.MULTIPLE: {
+        const multiFields = field.get('fields');
+        const labelField = multiFields && multiFields.first();
+        const value = item.get(labelField.get('name'));
+        const summary = field.get('summary');
+        const labelReturn = summary ? handleSummary(summary, entry, value, item) : value;
+        return (labelReturn || `No ${labelField.get('name')}`).toString();
+      }
     }
-
-    const multiFields = field.get('fields');
-    const singleField = field.get('field');
-    const labelField = (multiFields && multiFields.first()) || singleField;
-    const value = multiFields
-      ? item.get(multiFields.first().get('name'))
-      : singleField.get('label');
-    return (value || `No ${labelField.get('name')}`).toString();
+    return '';
   }
 
   onSortEnd = ({ oldIndex, newIndex }) => {

--- a/packages/netlify-cms-widget-list/src/ListControl.js
+++ b/packages/netlify-cms-widget-list/src/ListControl.js
@@ -15,6 +15,7 @@ import {
   getErrorMessageForTypedFieldAndValue,
 } from './typedListHelpers';
 import { ListItemTopBar, ObjectWidgetTopBar, colors, lengths } from 'netlify-cms-ui-default';
+import { compileStringTemplate } from 'netlify-cms-core/dist/esm/lib/stringTemplate';
 
 function valueToString(value) {
   return value ? value.join(',').replace(/,([^\s]|$)/g, ', $1') : '';
@@ -319,8 +320,14 @@ export default class ListControl extends React.Component {
   objectLabel(item) {
     const { field } = this.props;
     if (this.getValueType() === valueTypes.MIXED) {
-      return getTypedFieldForValue(field, item).get('label', field.get('name'));
+      const itemType = getTypedFieldForValue(field, item);
+      const fallbackLabel = itemType.get('label');
+      const summaryTemplate = itemType.get('summary');
+      return summaryTemplate
+        ? compileStringTemplate(summaryTemplate, null, '', item)
+        : fallbackLabel;
     }
+
     const multiFields = field.get('fields');
     const singleField = field.get('field');
     const labelField = (multiFields && multiFields.first()) || singleField;

--- a/packages/netlify-cms-widget-list/src/__tests__/ListControl.spec.js
+++ b/packages/netlify-cms-widget-list/src/__tests__/ListControl.spec.js
@@ -363,24 +363,11 @@ describe('ListControl', () => {
       name: 'list',
       label: 'List',
       collapsed: true,
-      field: {
-        name: 'first_and_last_name',
-        widget: 'object',
-        fields: [
-          { name: 'first_name', widget: 'string', label: 'First Name' },
-          { name: 'last_name', widget: 'string', label: 'Last Name' },
-        ],
-      },
+      field: { name: 'name', widget: 'string' },
     });
 
-    const { getByText } = render(
-      <ListControl
-        {...props}
-        field={field}
-        value={fromJS([{ object: { first_name: 'hello', last_name: 'world' } }])}
-      />,
-    );
-    expect(getByText('first_and_last_name')).toBeInTheDocument();
+    const { getByText } = render(<ListControl {...props} field={field} value={fromJS(['Name'])} />);
+    expect(getByText('name')).toBeInTheDocument();
   });
 
   it('should use label when no summary is configured for a single field', () => {
@@ -388,25 +375,11 @@ describe('ListControl', () => {
       name: 'list',
       label: 'List',
       collapsed: true,
-      field: {
-        name: 'first_and_last_name',
-        widget: 'object',
-        label: 'First and Last Name',
-        fields: [
-          { name: 'first_name', widget: 'string', label: 'First Name' },
-          { name: 'last_name', widget: 'string', label: 'Last Name' },
-        ],
-      },
+      field: { name: 'name', widget: 'string', label: 'Name' },
     });
 
-    const { getByText } = render(
-      <ListControl
-        {...props}
-        field={field}
-        value={fromJS([{ object: { first_name: 'hello', last_name: 'world' } }])}
-      />,
-    );
-    expect(getByText('First and Last Name')).toBeInTheDocument();
+    const { getByText } = render(<ListControl {...props} field={field} value={fromJS(['Name'])} />);
+    expect(getByText('Name')).toBeInTheDocument();
   });
 
   it('should use summary when configured for a single field', () => {
@@ -414,26 +387,12 @@ describe('ListControl', () => {
       name: 'list',
       label: 'List',
       collapsed: true,
-      summary: '{{object.first_name}} - {{object.last_name}} - {{filename}}.{{extension}}',
-      field: {
-        name: 'single_field_object',
-        widget: 'object',
-        label: 'Single Field Object',
-        fields: [
-          { name: 'first_name', widget: 'string', label: 'First Name' },
-          { name: 'last_name', widget: 'string', label: 'Last Name' },
-        ],
-      },
+      summary: 'Name - {{fields.name}}',
+      field: { name: 'name', widget: 'string', label: 'Name' },
     });
 
-    const { getByText } = render(
-      <ListControl
-        {...props}
-        field={field}
-        value={fromJS([{ object: { first_name: 'hello', last_name: 'world' } }])}
-      />,
-    );
-    expect(getByText('hello - world - index.md')).toBeInTheDocument();
+    const { getByText } = render(<ListControl {...props} field={field} value={fromJS(['Name'])} />);
+    expect(getByText('Name - Name')).toBeInTheDocument();
   });
 
   it('should use first field value when no summary or label are configured for multiple fields', () => {

--- a/packages/netlify-cms-widget-list/src/__tests__/ListControl.spec.js
+++ b/packages/netlify-cms-widget-list/src/__tests__/ListControl.spec.js
@@ -48,6 +48,9 @@ describe('ListControl', () => {
     resolveWidget: jest.fn(),
     clearFieldErrors: jest.fn(),
     fieldsErrors: fromJS({}),
+    entry: fromJS({
+      path: 'posts/index.md',
+    }),
   };
 
   beforeEach(() => {
@@ -269,5 +272,227 @@ describe('ListControl', () => {
 
     expect(getByTestId('object-control-0')).toHaveAttribute('collapsed', 'false');
     expect(getByTestId('object-control-1')).toHaveAttribute('collapsed', 'true');
+  });
+
+  it('should use widget name when no summary or label are configured for mixed types', () => {
+    const field = fromJS({
+      name: 'list',
+      label: 'List',
+      collapsed: true,
+      types: [
+        {
+          name: 'type_1_object',
+          widget: 'object',
+          fields: [
+            { label: 'First Name', name: 'first_name', widget: 'string' },
+            { label: 'Last Name', name: 'last_name', widget: 'string' },
+          ],
+        },
+      ],
+    });
+
+    const { getByText } = render(
+      <ListControl
+        {...props}
+        field={field}
+        value={fromJS([{ first_name: 'hello', last_name: 'world', type: 'type_1_object' }])}
+      />,
+    );
+    expect(getByText('type_1_object')).toBeInTheDocument();
+  });
+
+  it('should use label when no summary is configured for mixed types', () => {
+    const field = fromJS({
+      name: 'list',
+      label: 'List',
+      collapsed: true,
+      types: [
+        {
+          label: 'Type 1 Object',
+          name: 'type_1_object',
+          widget: 'object',
+          fields: [
+            { label: 'First Name', name: 'first_name', widget: 'string' },
+            { label: 'Last Name', name: 'last_name', widget: 'string' },
+          ],
+        },
+      ],
+    });
+
+    const { getByText } = render(
+      <ListControl
+        {...props}
+        field={field}
+        value={fromJS([{ first_name: 'hello', last_name: 'world', type: 'type_1_object' }])}
+      />,
+    );
+    expect(getByText('Type 1 Object')).toBeInTheDocument();
+  });
+
+  it('should use summary when configured for mixed types', () => {
+    const field = fromJS({
+      name: 'list',
+      label: 'List',
+      collapsed: true,
+      types: [
+        {
+          label: 'Type 1 Object',
+          name: 'type_1_object',
+          summary: '{{first_name}} - {{last_name}} - {{filename}}.{{extension}}',
+          widget: 'object',
+          fields: [
+            { label: 'First Name', name: 'first_name', widget: 'string' },
+            { label: 'Last Name', name: 'last_name', widget: 'string' },
+          ],
+        },
+      ],
+    });
+
+    const { getByText } = render(
+      <ListControl
+        {...props}
+        field={field}
+        value={fromJS([{ first_name: 'hello', last_name: 'world', type: 'type_1_object' }])}
+      />,
+    );
+    expect(getByText('hello - world - index.md')).toBeInTheDocument();
+  });
+
+  it('should use widget name when no summary or label are configured for a single field', () => {
+    const field = fromJS({
+      name: 'list',
+      label: 'List',
+      collapsed: true,
+      field: {
+        name: 'first_and_last_name',
+        widget: 'object',
+        fields: [
+          { name: 'first_name', widget: 'string', label: 'First Name' },
+          { name: 'last_name', widget: 'string', label: 'Last Name' },
+        ],
+      },
+    });
+
+    const { getByText } = render(
+      <ListControl
+        {...props}
+        field={field}
+        value={fromJS([{ object: { first_name: 'hello', last_name: 'world' } }])}
+      />,
+    );
+    expect(getByText('first_and_last_name')).toBeInTheDocument();
+  });
+
+  it('should use label when no summary is configured for a single field', () => {
+    const field = fromJS({
+      name: 'list',
+      label: 'List',
+      collapsed: true,
+      field: {
+        name: 'first_and_last_name',
+        widget: 'object',
+        label: 'First and Last Name',
+        fields: [
+          { name: 'first_name', widget: 'string', label: 'First Name' },
+          { name: 'last_name', widget: 'string', label: 'Last Name' },
+        ],
+      },
+    });
+
+    const { getByText } = render(
+      <ListControl
+        {...props}
+        field={field}
+        value={fromJS([{ object: { first_name: 'hello', last_name: 'world' } }])}
+      />,
+    );
+    expect(getByText('First and Last Name')).toBeInTheDocument();
+  });
+
+  it('should use summary when configured for a single field', () => {
+    const field = fromJS({
+      name: 'list',
+      label: 'List',
+      collapsed: true,
+      summary: '{{object.first_name}} - {{object.last_name}} - {{filename}}.{{extension}}',
+      field: {
+        name: 'single_field_object',
+        widget: 'object',
+        label: 'Single Field Object',
+        fields: [
+          { name: 'first_name', widget: 'string', label: 'First Name' },
+          { name: 'last_name', widget: 'string', label: 'Last Name' },
+        ],
+      },
+    });
+
+    const { getByText } = render(
+      <ListControl
+        {...props}
+        field={field}
+        value={fromJS([{ object: { first_name: 'hello', last_name: 'world' } }])}
+      />,
+    );
+    expect(getByText('hello - world - index.md')).toBeInTheDocument();
+  });
+
+  it('should use first field value when no summary or label are configured for multiple fields', () => {
+    const field = fromJS({
+      name: 'list',
+      label: 'List',
+      collapsed: true,
+      fields: [
+        { name: 'first_name', widget: 'string', label: 'First Name' },
+        { name: 'last_name', widget: 'string', label: 'Last Name' },
+      ],
+    });
+
+    const { getByText } = render(
+      <ListControl
+        {...props}
+        field={field}
+        value={fromJS([{ first_name: 'hello', last_name: 'world' }])}
+      />,
+    );
+    expect(getByText('hello')).toBeInTheDocument();
+  });
+
+  it('should show `No <field>` when value is missing from first field for multiple fields', () => {
+    const field = fromJS({
+      name: 'list',
+      label: 'List',
+      collapsed: true,
+      fields: [
+        { name: 'first_name', widget: 'string', label: 'First Name' },
+        { name: 'last_name', widget: 'string', label: 'Last Name' },
+      ],
+    });
+
+    const { getByText } = render(
+      <ListControl {...props} field={field} value={fromJS([{ last_name: 'world' }])} />,
+    );
+    expect(getByText('No first_name')).toBeInTheDocument();
+  });
+
+  it('should use summary when configured for multiple fields', () => {
+    const field = fromJS({
+      name: 'list',
+      label: 'List',
+      collapsed: true,
+      summary: '{{first_name}} - {{last_name}} - {{filename}}.{{extension}}',
+      fields: [
+        { name: 'first_name', widget: 'string', label: 'First Name' },
+        { name: 'last_name', widget: 'string', label: 'Last Name' },
+      ],
+    });
+
+    const { getByText } = render(
+      <ListControl
+        {...props}
+        field={field}
+        value={fromJS([{ first_name: 'hello', last_name: 'world' }])}
+      />,
+    );
+    expect(getByText('hello - world - index.md')).toBeInTheDocument();
   });
 });

--- a/website/content/docs/beta-features.md
+++ b/website/content/docs/beta-features.md
@@ -163,7 +163,7 @@ To use variable types in the list widget, update your field configuration as fol
 
 - `types`: a nested list of object widgets. All widgets must be of type `object`. Every object widget may define different set of fields.
 - `typeKey`: the name of the field that will be added to every item in list representing the name of the object widget that item belongs to. Ignored if `types` is not defined. Default is `type`.
-- `summary`: allows customization of a collapsed list item object in a similar way to a [collection summary](http://localhost:8000/docs/configuration-options/?#summary)
+- `summary`: allows customization of a collapsed list item object in a similar way to a [collection summary](/docs/configuration-options/?#summary)
 
 ### Example Configuration
 

--- a/website/content/docs/beta-features.md
+++ b/website/content/docs/beta-features.md
@@ -163,6 +163,7 @@ To use variable types in the list widget, update your field configuration as fol
 
 - `types`: a nested list of object widgets. All widgets must be of type `object`. Every object widget may define different set of fields.
 - `typeKey`: the name of the field that will be added to every item in list representing the name of the object widget that item belongs to. Ignored if `types` is not defined. Default is `type`.
+- `summary`: allows customization of a collapsed list item object in a similar way to a [collection summary](http://localhost:8000/docs/configuration-options/?#summary)
 
 ### Example Configuration
 
@@ -177,6 +178,7 @@ either a "carousel" or a "spotlight". Each type has a unique name and set of fie
     - label: 'Carousel'
       name: 'carousel'
       widget: object
+      summary: '{{fields.header}}'
       fields:
         - { label: Header, name: header, widget: string, default: 'Image Gallery' }
         - { label: Template, name: template, widget: string, default: 'carousel.html' }

--- a/website/content/docs/widgets/list.md
+++ b/website/content/docs/widgets/list.md
@@ -12,7 +12,7 @@ The list widget allows you to create a repeatable item in the UI which saves as 
   - `default`: if `fields` is specified, declare defaults on the child widgets; if not, you may specify a list of strings to populate the text field
   - `allow_add`: if added and labeled `false`, button to add additional widgets disappears
   - `collapsed`: if added and labeled `false`, the list widget's content does not collapse by default
-  - `summary`: allows customization of a collapsed list item object in a similar way to a [collection summary](http://localhost:8000/docs/configuration-options/?#summary)
+  - `summary`: allows customization of a collapsed list item object in a similar way to a [collection summary](/docs/configuration-options/?#summary)
   - `field`: a single widget field to be repeated
   - `fields`: a nested list of multiple widget fields to be included in each repeatable iteration
 - **Example** (`field`/`fields` not specified):

--- a/website/content/docs/widgets/list.md
+++ b/website/content/docs/widgets/list.md
@@ -12,6 +12,7 @@ The list widget allows you to create a repeatable item in the UI which saves as 
   - `default`: if `fields` is specified, declare defaults on the child widgets; if not, you may specify a list of strings to populate the text field
   - `allow_add`: if added and labeled `false`, button to add additional widgets disappears
   - `collapsed`: if added and labeled `false`, the list widget's content does not collapse by default
+  - `summary`: allows customization of a collapsed list item object in a similar way to a [collection summary](http://localhost:8000/docs/configuration-options/?#summary)
   - `field`: a single widget field to be repeated
   - `fields`: a nested list of multiple widget fields to be included in each repeatable iteration
 - **Example** (`field`/`fields` not specified):
@@ -34,6 +35,7 @@ The list widget allows you to create a repeatable item in the UI which saves as 
     - label: "Gallery"
       name: "galleryImages"
       widget: "list"
+      summary: '{{fields.image}}'
       field: {label: Image, name: image, widget: image}
     ```
 - **Example** (with `fields`):
@@ -41,6 +43,7 @@ The list widget allows you to create a repeatable item in the UI which saves as 
     - label: "Testimonials"
       name: "testimonials"
       widget: "list"
+      summary: '{{fields.quote}} - {{fields.author.name}}'
       fields:
         - {label: Quote, name: quote, widget: string, default: "Everything is awesome!"}
         - label: Author


### PR DESCRIPTION
Hi folks! This PR is a WIP, in collaboration with @djMax 

**Summary**

Fixes https://github.com/netlify/netlify-cms/issues/3713

<!--
Explain the **motivation** for making this change.
What existing problem does the pull request solve?
-->

In the list widget's control, when an item is collapsed, only its type name is displayed. This makes it difficult for editors to understand the content of a list at a glance. This issue is more pronounced when editing a large list with many items of the same type.

<img width="825" alt="image" src="https://user-images.githubusercontent.com/3383539/79532008-e56cd080-80ae-11ea-9406-351cb94cf943.png">

This PR explores adding a `summary` field to each list's type, allow each item to display a summary based on its content, in the same fashion as a folder collection.

```diff
  - label: 'Typed List'
    name: 'typed_list'
    widget: 'list'
    types:
      - label: 'Type 1 Object'
        name: 'type_1_object'
+       summary: 'Type 1 | {{string}}'
        widget: 'object'
        fields:
          - { label: 'String', name: 'string', widget: 'string' }
          - { label: 'Boolean', name: 'boolean', widget: 'boolean' }
          - { label: 'Text', name: 'text', widget: 'text' }
```

<img width="819" alt="image" src="https://user-images.githubusercontent.com/3383539/79532184-544a2980-80af-11ea-9275-21fbd0fb9601.png">

We'd love to get feedback on this! We've also consider adding a `summary` field for the list widget itself that can be applied to all types.

**Test plan**

<!--
Demonstrate the code is solid.
Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.
-->
[TBA]
