### PR TITLE
fix(locale): add missing translation strings for 'es' locale

### DIFF
--- a/packages/netlify-cms-locales/src/es/index.js
+++ b/packages/netlify-cms-locales/src/es/index.js
@@ -1,4 +1,18 @@
 const es = {
+  auth: {
+    login: 'Iniciar sesión',
+    loggingIn: 'Iniciando sesión...',
+    loginWithNetlifyIdentity: 'Iniciar sesión con Netlify Identity',
+    loginWithBitbucket: 'Iniciar sesión con Bitbucket',
+    loginWithGitHub: 'Iniciar sesión con GitHub',
+    loginWithGitLab: 'Iniciar sesión con GitLab',
+    errors: {
+      email: 'Asegurate de ingresar tu correo electrónico.',
+      password: 'Por favor ingresa tu contraseña.',
+      identitySettings:
+        'No se pudo accesder a la configuración de Identity. Cuando uses el backend git-gateway asegurate de habilitar el servicio Identity y Git Gateway.',
+    },
+  },
   app: {
     header: {
       content: 'Contenido',
@@ -23,13 +37,25 @@ const es = {
       searchAll: 'Buscar todos',
     },
     collectionTop: {
+      sortBy: 'Ordenar por',
       viewAs: 'Ver como',
       newButton: 'Nuevo %{collectionLabel}',
+      ascending: 'Ascendente',
+      descending: 'Descendente',
     },
     entries: {
       loadingEntries: 'Cargando entradas',
       cachingEntries: 'Almacenando entradas en caché',
       longerLoading: 'Esto puede tardar varios minutos',
+      noEntries: 'Ninguna entrada',
+    },
+    defaultFields: {
+      author: {
+        label: 'Autor',
+      },
+      updatedOn: {
+        label: 'Actualizado en',
+      },
     },
   },
   editor: {
@@ -45,7 +71,11 @@ const es = {
         processing: '%{fieldLabel} está procesando.',
         range: '%{fieldLabel} debe estar entre %{minValue} y %{maxValue}.',
         min: '%{fieldLabel} debe ser por lo menos %{minValue}.',
-        max: '%{fieldLabel} debe ser %{maxValue} o más.',
+        max: '%{fieldLabel} debe ser %{maxValue} o menos.',
+        rangeCount: '%{fieldLabel} debe tener entre %{minCount} y %{maxCount} elemento(s).',
+        rangeCountExact: '%{fieldLabel} debe tener exactamente %{count} elemento(s).',
+        minCount: '%{fieldLabel} debe ser por lo menos %{minCount} elemento(s).',
+        maxCount: '%{fieldLabel} debe ser %{maxCount} o menos elemento(s).',
       },
     },
     editor: {
@@ -56,6 +86,7 @@ const es = {
       onPublishingWithUnsavedChanges:
         'Tiene cambios no guardados, por favor guárdelos antes de publicarlos.',
       onPublishing: '¿Estás seguro de que quieres publicar esta entrada?',
+      onUnpublishing: '¿Estás seguro de que quieres retirar esta entrada?',
       onDeleteWithUnsavedChanges:
         '¿Está seguro de que desea eliminar esta entrada publicada, así como los cambios no guardados de la sesión actual?',
       onDeletePublishedEntry: '¿Estás seguro de que quieres borrar esta entrada publicada?',
@@ -71,7 +102,11 @@ const es = {
       publishing: 'Publicando...',
       publish: 'Publicar',
       published: 'Publicado',
+      unpublish: 'Retirado',
+      duplicate: 'Duplicar',
+      unpublishing: 'Retirando...',
       publishAndCreateNew: 'Publicar y crear nuevo',
+      publishAndDuplicate: 'Publicar y duplicar',
       deleteUnpublishedChanges: 'Eliminar cambios no publicados',
       deleteUnpublishedEntry: 'Eliminar entrada no publicada',
       deletePublishedEntry: 'Eliminar entrada publicada',
@@ -93,6 +128,10 @@ const es = {
       deployButtonLabel: 'Ver publicación',
     },
     editorWidgets: {
+      markdown: {
+        richText: 'Texto enriquecido',
+        markdown: 'Markdown',
+      },
       image: {
         choose: 'Elige una imagen',
         chooseDifferent: 'Elige una imagen diferente',
@@ -110,12 +149,15 @@ const es = {
         noPreview: "No existe una vista previa para el widget '%{widget}'.",
       },
       headingOptions: {
-        headingOne: 'Heading 1',
-        headingTwo: 'Heading 2',
-        headingThree: 'Heading 3',
-        headingFour: 'Heading 4',
-        headingFive: 'Heading 5',
-        headingSix: 'Heading 6',
+        headingOne: 'Encabezado 1',
+        headingTwo: 'Encabezado 2',
+        headingThree: 'Encabezado 3',
+        headingFour: 'Encabezado 4',
+        headingFive: 'Encabezado 5',
+        headingSix: 'Encabezado 6',
+      },
+      datetime: {
+        now: 'Ahora',
       },
     },
   },
@@ -125,6 +167,8 @@ const es = {
     },
     mediaLibrary: {
       onDelete: '¿Está seguro de que desea eliminar el medio seleccionado?',
+      fileTooLarge:
+        'Archivo muy pesado.\nConfigurado para no permitir archivos más pesados que %{size} kB.',
     },
     mediaLibraryModal: {
       loading: 'Cargando...',
@@ -143,11 +187,16 @@ const es = {
     },
   },
   ui: {
+    default: {
+      goBackToSite: 'Regresar al sitio',
+    },
     errorBoundary: {
       title: 'Error',
       details: 'Se ha producido un error - por favor ',
       reportIt: 'infórmenos de ello.',
       detailsHeading: 'Detalles',
+      privacyWarning:
+        'Abrir un reporte lo rellena previamente con el mensaje de error y los datos de depuración.\nPor favor verifica que la información es correcta y elimina cualquier dato sensible.',
       recoveredEntry: {
         heading: 'Documento recuperado',
         warning: '¡Por favor, copie/pegue esto en algún lugar antes de ir a otra página!',
@@ -167,7 +216,9 @@ const es = {
         'Oops, no ha rellenado un campo obligatorio. Por favor, rellenelo antes de guardar.',
       entrySaved: 'Entrada guardada',
       entryPublished: 'Entrada publicada',
+      entryUnpublished: 'Entrada retirada',
       onFailToPublishEntry: 'No se ha podido publicar: %{details}',
+      onFailToUnpublishEntry: 'No se ha podido retirar la entrada: %{details}',
       entryUpdated: 'Estado de entrada actualizado',
       onDeleteUnpublishedChanges: 'Cambios no publicados eliminados',
       onFailToAuth: '%{details}',


### PR DESCRIPTION
**Summary**

My native language is spanish, I started trying Netlify cms, found that I could change the default language to spanish using netlify-cms-locales but that some translations were missing so I decided to add it.

**Test plan**

Test output
![image](https://user-images.githubusercontent.com/41461969/79682132-1df4e180-824a-11ea-8cc9-91dee4128e1e.png)
```
npm run test

> @ test /home/cajotafer/Projects/netlify-cms
> run-s clean lint type-check test:unit


> @ clean /home/cajotafer/Projects/netlify-cms
> rimraf "packages/*/dist" dev-test/dist


> @ lint /home/cajotafer/Projects/netlify-cms
> run-p -c --aggregate-output "lint:*"


> @ lint:css /home/cajotafer/Projects/netlify-cms
> stylelint --ignore-path .gitignore "{packages/**/*.{css,js,jsx,ts,tsx},website/**/*.css}"

Build Package: netlify-cms

> @ lint:format /home/cajotafer/Projects/netlify-cms
> prettier "{{packages,scripts,website}/**/,}*.{js,jsx,ts,tsx,css}" --list-different


> @ lint:js /home/cajotafer/Projects/netlify-cms
> eslint --color --ignore-path .gitignore "{{packages,scripts,website}/**/,}*.{js,jsx,ts,tsx}"

Build Package: netlify-cms

> @ type-check /home/cajotafer/Projects/netlify-cms
> tsc --noEmit


> @ test:unit /home/cajotafer/Projects/netlify-cms
> cross-env NODE_ENV=test jest --no-cache

Build Package: netlify-cms
Build Package: netlify-cms
Build Package: netlify-cms
 PASS  packages/netlify-cms-backend-github/src/__tests__/API.spec.js (6.552s)
  ● Console

    console.log packages/netlify-cms-backend-github/src/API.ts:816
      Migrating Pull Request '1' (undefined)
    console.log packages/netlify-cms-backend-github/src/API.ts:827
      Migrating Pull Request '1' to version 1
    console.log packages/netlify-cms-backend-github/src/API.ts:837
      Done migrating Pull Request '1' to version 1. New pull request '2' created.
    console.log packages/netlify-cms-backend-github/src/API.ts:843
      Migrating Pull Request '2' to labels
    console.log packages/netlify-cms-backend-github/src/API.ts:846
      Done migrating Pull Request '2' to labels
    console.log packages/netlify-cms-backend-github/src/API.ts:849
      Done migrating Pull Request '1 => 2'
    console.log packages/netlify-cms-backend-github/src/API.ts:816
      Migrating Pull Request '1' (undefined)
    console.log packages/netlify-cms-backend-github/src/API.ts:843
      Migrating Pull Request '1' to labels
    console.log packages/netlify-cms-backend-github/src/API.ts:846
      Done migrating Pull Request '1' to labels
    console.log packages/netlify-cms-backend-github/src/API.ts:849
      Done migrating Pull Request '1'

 PASS  packages/netlify-cms-core/src/actions/__tests__/config.spec.js (10.823s)
 PASS  packages/netlify-cms-core/src/reducers/__tests__/entries.spec.js (11.017s)
 PASS  packages/netlify-cms-widget-markdown/src/MarkdownControl/__tests__/parser.spec.js (6.86s)
 PASS  packages/netlify-cms-proxy-server/src/middlewares/joi/index.spec.ts
 PASS  packages/netlify-cms-core/src/reducers/__tests__/collections.spec.js (6.618s)
 PASS  packages/netlify-cms-core/src/lib/__tests__/formatters.spec.js (7.039s)
 PASS  packages/netlify-cms-backend-gitlab/src/__tests__/gitlab.spec.js (12.923s)
 PASS  packages/netlify-cms-backend-github/src/__tests__/implementation.spec.js (6.122s)
 PASS  packages/netlify-cms-core/src/formats/__tests__/frontmatter.spec.js
 PASS  packages/netlify-cms-core/src/__tests__/backend.spec.js (5.76s)
 PASS  packages/netlify-cms-widget-select/src/__tests__/select.spec.js
  ● Console

    console.warn node_modules/react-dom/cjs/react-dom.development.js:88
      Warning: componentWillReceiveProps has been renamed, and is not recommended for use. See https://fb.me/react-unsafe-component-lifecycles for details.
      
      * Move data fetching code or side effects to componentDidUpdate.
      * If you're updating state whenever props change, refactor your code to use memoization techniques or move it to static getDerivedStateFromProps. Learn more at: https://fb.me/react-derived-state
      * Rename componentWillReceiveProps to UNSAFE_componentWillReceiveProps to suppress this warning in non-strict mode. In React 17.x, only the UNSAFE_ name will work. To rename all deprecated lifecycles to their new names, you can run `npx react-codemod rename-unsafe-lifecycles` in your project source folder.
      
      Please update the following components: Select

 PASS  packages/netlify-cms-media-library-uploadcare/src/__tests__/index.spec.js
 PASS  packages/netlify-cms-core/src/actions/__tests__/mediaLibrary.spec.js (5.637s)
 PASS  packages/netlify-cms-media-library-cloudinary/src/__tests__/index.spec.js
 PASS  packages/netlify-cms-core/src/actions/__tests__/entries.spec.js
 PASS  packages/netlify-cms-widget-relation/src/__tests__/relation.spec.js (6.659s)
  ● Console

    console.warn node_modules/react-dom/cjs/react-dom.development.js:88
      Warning: componentWillReceiveProps has been renamed, and is not recommended for use. See https://fb.me/react-unsafe-component-lifecycles for details.
      
      * Move data fetching code or side effects to componentDidUpdate.
      * If you're updating state whenever props change, refactor your code to use memoization techniques or move it to static getDerivedStateFromProps. Learn more at: https://fb.me/react-derived-state
      * Rename componentWillReceiveProps to UNSAFE_componentWillReceiveProps to suppress this warning in non-strict mode. In React 17.x, only the UNSAFE_ name will work. To rename all deprecated lifecycles to their new names, you can run `npx react-codemod rename-unsafe-lifecycles` in your project source folder.
      
      Please update the following components: Async, Select

 PASS  packages/netlify-cms-backend-gitlab/src/__tests__/API.spec.js
 PASS  packages/netlify-cms-core/src/constants/__tests__/configSchema.spec.js
 PASS  packages/netlify-cms-widget-markdown/src/serializers/__tests__/slate.spec.js
 PASS  packages/netlify-cms-widget-number/src/__tests__/number.spec.js
 PASS  packages/netlify-cms-core/src/actions/__tests__/editorialWorkflow.spec.js
 PASS  packages/netlify-cms-widget-markdown/src/serializers/__tests__/remarkAssertParents.spec.js
 PASS  packages/netlify-cms-core/src/lib/__tests__/urlHelper.spec.js
 PASS  packages/netlify-cms-backend-test/src/__tests__/implementation.spec.js
 PASS  packages/netlify-cms-core/src/components/Editor/__tests__/Editor.spec.js (5.324s)
 PASS  packages/netlify-cms-widget-markdown/src/serializers/__tests__/remarkSlate.spec.js
 PASS  packages/netlify-cms-proxy-server/src/middlewares/localGit/index.spec.ts
 PASS  packages/netlify-cms-core/src/lib/__tests__/registry.spec.js
 PASS  packages/netlify-cms-widget-markdown/src/__tests__/renderer.spec.js
 PASS  packages/netlify-cms-core/src/reducers/__tests__/entryDraft.spec.js (5.209s)
 PASS  packages/netlify-cms-core/src/formats/__tests__/yaml.spec.js
 PASS  packages/netlify-cms-core/src/reducers/__tests__/mediaLibrary.spec.js (5.053s)
 PASS  packages/netlify-cms-core/src/actions/__tests__/media.spec.js
 PASS  packages/netlify-cms-lib-util/src/__tests__/backendUtil.spec.js
 PASS  packages/netlify-cms-core/src/lib/__tests__/stringTemplate.spec.js
 PASS  packages/netlify-cms-widget-markdown/src/serializers/__tests__/remarkEscapeMarkdownEntities.spec.js
 PASS  packages/netlify-cms-core/src/lib/__tests__/phrases.spec.js
 PASS  packages/netlify-cms-core/src/actions/__tests__/search.spec.js (6.019s)
 PASS  packages/netlify-cms-editor-component-image/src/__tests__/index.spec.js
 PASS  packages/netlify-cms-backend-git-gateway/src/__tests__/GitHubAPI.spec.js (5.504s)
 PASS  packages/netlify-cms-widget-markdown/src/serializers/__tests__/remarkShortcodes.spec.js
 PASS  packages/netlify-cms-proxy-server/src/middlewares/localFs/index.spec.ts
 PASS  packages/netlify-cms-lib-util/src/__tests__/asyncLock.spec.js
 PASS  packages/netlify-cms-lib-util/src/__tests__/path.spec.js
 PASS  packages/netlify-cms-lib-util/src/__tests__/implementation.spec.js
 PASS  packages/netlify-cms-core/src/components/UI/__tests__/ErrorBoundary.spec.js
 PASS  packages/netlify-cms-core/src/reducers/__tests__/globalUI.js
 PASS  packages/netlify-cms-core/src/reducers/__tests__/integrations.spec.ts
 PASS  packages/netlify-cms-core/src/components/MediaLibrary/__tests__/MediaLibraryCard.spec.js
 PASS  packages/netlify-cms-widget-markdown/src/MarkdownControl/__tests__/VisualEditor.spec.js
 PASS  packages/netlify-cms-backend-github/src/__tests__/GraphQLAPI.spec.js
 PASS  packages/netlify-cms-widget-markdown/src/serializers/__tests__/remarkPaddedLinks.spec.js
 PASS  packages/netlify-cms-widget-markdown/src/serializers/__tests__/index.spec.js
 PASS  packages/netlify-cms-core/src/reducers/__tests__/medias.spec.ts
 PASS  packages/netlify-cms-lib-util/src/__tests__/apiUtils.spec.js
 PASS  packages/netlify-cms-backend-bitbucket/src/__tests__/api.spec.js
 PASS  packages/netlify-cms-backend-git-gateway/src/__tests__/AuthenticationPage.spec.js
 PASS  packages/netlify-cms-widget-markdown/src/serializers/__tests__/remarkStripTrailingBreaks.spec.js
 PASS  packages/netlify-cms-core/src/lib/__tests__/serializeEntryValues.spec.js
 PASS  packages/netlify-cms-widget-markdown/src/serializers/__tests__/remarkAllowHtmlEntities.spec.js
 PASS  packages/netlify-cms-lib-util/src/__tests__/unsentRequest.spec.js
 PASS  packages/netlify-cms-lib-util/src/__tests__/api.spec.js
 PASS  packages/netlify-cms-core/src/formats/__tests__/toml.spec.js
 PASS  packages/netlify-cms-core/src/reducers/__tests__/auth.spec.js
 PASS  packages/netlify-cms-core/src/reducers/__tests__/config.spec.js (5.087s)

Test Suites: 2 skipped, 66 passed, 66 of 68 total
Tests:       650 skipped, 683 passed, 1333 total
Snapshots:   64 passed, 64 total
Time:        76.755s
Ran all test suites.
```

----

Format output
![image](https://user-images.githubusercontent.com/41461969/79682146-37962900-824a-11ea-91f5-9148b0873920.png)
...
![image](https://user-images.githubusercontent.com/41461969/79682156-48469f00-824a-11ea-965b-5b2a1068791f.png)


**A picture of a cute animal**
![image](https://user-images.githubusercontent.com/41461969/79682175-61e7e680-824a-11ea-9b4c-b56c4db386f1.png)

----
_If I am adding something unnecessary or there is something missing, please, I would like to know, this is my first PR_ :1st_place_medal: 