### PR TITLE
Remove reference to Date widget from DateTime widget docs

### DIFF
--- a/website/content/docs/widgets/datetime.md
+++ b/website/content/docs/widgets/datetime.md
@@ -3,7 +3,7 @@ title: datetime
 label: "DateTime"
 ---
 
-The datetime widget translates a datetime picker to a datetime string. For saving the date only, use the date widget.
+The datetime widget translates a datetime picker to a datetime string.
 
 - **Name:** `datetime`
 - **UI:** datetime picker


### PR DESCRIPTION
**Summary**

The Date widget is [being deprecated](https://github.com/netlify/netlify-cms/issues/1688) in favor of the DateTime widget. Currently, the DateTime widget docs suggest using the Date widget for saving the date only. This PR removes that reference so that we don't encourage folks to use the deprecated Date widget.

**Test plan**

None. This is a docs-only change.

**A picture of a cute animal (not mandatory but encouraged)**

![](https://media.giphy.com/media/oYQSUOVe97yQ8/source.gif)