### PR TITLE
fix(large-media): match netlify.app as lfs host

### DIFF
--- a/packages/netlify-cms-backend-git-gateway/src/implementation.ts
+++ b/packages/netlify-cms-backend-git-gateway/src/implementation.ts
@@ -313,7 +313,9 @@ export default class GitGateway implements Implementation {
     const netlifyLargeMediaEnabledPromise = this.api!.readFile('.lfsconfig')
       .then(config => ini.decode<{ lfs: { url: string } }>(config as string))
       .then(({ lfs: { url } }) => new URL(url))
-      .then(lfsURL => ({ enabled: lfsURL.hostname.endsWith('netlify.com') }))
+      .then(lfsURL => ({
+        enabled: lfsURL.hostname.endsWith('netlify.com') || lfsURL.hostname.endsWith('netlify.app'),
+      }))
       .catch((err: Error) => ({ enabled: false, err }));
 
     const lfsPatternsPromise = this.api!.readFile('.gitattributes')


### PR DESCRIPTION
Context https://community.netlify.com/t/large-media-storage/12915/16?u=erez

The move from `netlify.com` to `netlify.app` trips the CMS's auto LFS detection.
