### PR TITLE
fix: prevent escaping of footnotes and references

### DIFF
--- a/packages/netlify-cms-widget-markdown/src/serializers/__tests__/remarkEscapeMarkdownEntities.spec.js
+++ b/packages/netlify-cms-widget-markdown/src/serializers/__tests__/remarkEscapeMarkdownEntities.spec.js
@@ -73,7 +73,13 @@ describe('remarkEscapeMarkdownEntities', () => {
     expect(process('a b <pre>*c*</pre> d e')).toEqual('a b <pre>*c*</pre> d e');
   });
 
-  it('should not parse footnotes', () => {
-    expect(process('[^a]')).toEqual('\\[^a]');
+  it('should not escape footnote references', () => {
+    expect(process('[^a]')).toEqual('[^a]');
+    expect(process('[^1]')).toEqual('[^1]');
+  });
+
+  it('should not escape footnotes', () => {
+    expect(process('[^a]:')).toEqual('[^a]:');
+    expect(process('[^1]:')).toEqual('[^1]:');
   });
 });

--- a/packages/netlify-cms-widget-markdown/src/serializers/remarkEscapeMarkdownEntities.js
+++ b/packages/netlify-cms-widget-markdown/src/serializers/remarkEscapeMarkdownEntities.js
@@ -124,14 +124,14 @@ const escapePatterns = [
   /(`+)[^`]*(\1)/g,
 
   /**
-   * Links, Images, References, and Footnotes
+   * Links and Images
    *
-   * Match strings surrounded by brackets. This could be improved to
-   * specifically match only the exact syntax of each covered entity, but
-   * doing so through current approach would incur a considerable performance
-   * penalty.
+   * Match strings surrounded by square brackets, except when the opening
+   * bracket is followed by a caret. This could be improved to specifically
+   * match only the exact syntax of each covered entity, but doing so through
+   * current approach would incur a considerable performance penalty.
    */
-  /(\[)[^\]]*]/g,
+  /(\[(?!\^)+)[^\]]*]/g,
 ];
 
 /**


### PR DESCRIPTION
**Summary**

Prevent markdown footnotes (`[^1]: blah`) and footnote references (`[^1]`) from being incorrectly escaped when switching between Markdown and Rich Text modes. Netlify CMS doesn't do anything with either of these entities, so they should not be transformed in any way. At present, switching mode to Rich Text, and making any kind of edit, for example to add an image using the widget, then switching back, results in all footnotes or references being escaped (`/[^1]`) which means whatever parses the markdown no-longer treats them as markdown entities. Switching mode without editing does not exhibit this behaviour.

Fixes #2386 

**Test plan**

I've amended existing tests and added tests to be slightly more granular (testing explicitly for both footnotes and both footnote references). 

**A picture of a cute animal (not mandatory but encouraged)**

![eed837efb19ab6672f41fb546502e7ab](https://user-images.githubusercontent.com/161489/79978614-188cd680-8498-11ea-8ff7-d8e2a6612890.jpg)

