### PR TITLE
fix(sort): don't clear sort data on entries request

### DIFF
--- a/packages/netlify-cms-core/src/reducers/entries.ts
+++ b/packages/netlify-cms-core/src/reducers/entries.ts
@@ -123,11 +123,9 @@ const entries = (
     case ENTRIES_REQUEST: {
       const payload = action.payload as EntriesRequestPayload;
       const newState = state.withMutations(map => {
-        map.deleteIn(['sort', payload.collection]);
         map.setIn(['pages', payload.collection, 'isFetching'], true);
       });
 
-      clearSort();
       return newState;
     }
 


### PR DESCRIPTION
Fixes https://github.com/netlify/netlify-cms/issues/3647
The cleanup was done as an optimization to return to a lazy loaded list when the sort direction for a collection is `none`.
This is not required since we check for it here: https://github.com/netlify/netlify-cms/blob/f8603c5d920c5105fa6d267ac2eb9e1cbd119f7d/packages/netlify-cms-core/src/actions/entries.ts#L468
`selectEntriesSortFields` filters out `none` sort directions.