### PR TITLE
fix: sidebar icon shrinking when label wraps

### DIFF
--- a/packages/netlify-cms-core/src/components/Collection/Sidebar.js
+++ b/packages/netlify-cms-core/src/components/Collection/Sidebar.js
@@ -81,6 +81,7 @@ const SidebarNavLink = styled(NavLink)`
 
   ${Icon} {
     margin-right: 8px;
+    flex-shrink: 0;
   }
 
   ${props => css`


### PR DESCRIPTION
**Summary**

Icon for sidebar nav items shrinks if label wraps. 

Closes #3652

**Test plan**

I tested the fix in-browser using dev-tools but I don't see anything in the contributing docs about how to run a demo version of the CMS locally to verify the fix. If you can let me know how that goes I will do that.

**A picture of a cute animal (not mandatory but encouraged)**

![download](https://user-images.githubusercontent.com/161489/80210617-f461fe80-862b-11ea-8246-c4ad94023c5e.jpeg)

