### PR TITLE
fix(git-gateway): wait for identity widget to initialize

### DIFF
--- a/packages/netlify-cms-backend-git-gateway/src/AuthenticationPage.js
+++ b/packages/netlify-cms-backend-git-gateway/src/AuthenticationPage.js
@@ -125,7 +125,7 @@ export default class GitGatewayAuthenticationPage extends React.Component {
     this.setState({ ...this.state, [name]: e.target.value });
   };
 
-  handleLogin = e => {
+  handleLogin = async e => {
     e.preventDefault();
 
     const { email, password } = this.state;
@@ -143,17 +143,16 @@ export default class GitGatewayAuthenticationPage extends React.Component {
       return;
     }
 
-    GitGatewayAuthenticationPage.authClient
-      .login(this.state.email, this.state.password, true)
-      .then(user => {
-        this.props.onLogin(user);
-      })
-      .catch(error => {
-        this.setState({
-          errors: { server: error.description || error.msg || error },
-          loggingIn: false,
-        });
+    try {
+      const client = await GitGatewayAuthenticationPage.authClient();
+      const user = await client.login(this.state.email, this.state.password, true);
+      this.props.onLogin(user);
+    } catch (error) {
+      this.setState({
+        errors: { server: error.description || error.msg || error },
+        loggingIn: false,
       });
+    }
   };
 
   render() {


### PR DESCRIPTION
Fixes https://github.com/netlify/netlify-cms/issues/2260
Also related https://community.netlify.com/t/manual-initialisation-with-identitywidget-enabled/12194/6

Reproduces only in Gatsby prod build in the following repo: https://github.com/erezrokah/netlify-cms-2260-overlay-intial-load. The effect in that repo is that the login dialog opens immediately when opening the CMS and not only after clicking the login button.
When deployed the effect is a bit different of a overlay like the original bug:
https://amazing-swirles-f2a7bc.netlify.app/admin/


This underlying issue is a race condition where the CMS is trying to access the Identity widget before it was initialized.

The Identity widget can be imported from CDN as so:
```js
<script type="text/javascript" src="https://identity.netlify.com/v1/netlify-identity-widget.js"></script>
```
Which will initialize the widget on load:
https://github.com/netlify/netlify-identity-widget/blob/05152b12587e5093940c004f647d59799daaa21f/src/index.js
In that case the bug shouldn't happen.

Another option of using the widget is as a module and initializing it manually. This is done in the Gatsby plugin: https://github.com/gatsbyjs/gatsby/blob/1e59c65ed5117eba8f7fdc2f31d379c92383e474/packages/gatsby-plugin-netlify-cms/src/cms-identity.js#L24

The issue is that the CMS might access the widget properties before it was initialized here:
https://github.com/netlify/netlify-cms/blob/a9d0699a82a25d79dd99af4f1ed9643ce7bba220/packages/netlify-cms-backend-git-gateway/src/implementation.ts#L129
Which calls https://github.com/netlify/netlify-identity-widget/blob/05152b12587e5093940c004f647d59799daaa21f/src/netlify-identity.js#L45 which eventually cause the overlay to be shown once the widget is initialized.

This is more evident when using manual initialization with the Gatsby plugin.

The solution was to wait for the widget to initialize before accessing its methods.

### TODO
- [x] Test that the fix didn't break anything

Update: see a deployed version with the fix https://fix-use-custom-netify-cms-app--amazing-swirles-f2a7bc.netlify.app/admin/#/