### PR TITLE
feat: add entry, collection and config prop to control widget

### DIFF
--- a/packages/netlify-cms-core/src/components/Editor/EditorControlPane/EditorControl.js
+++ b/packages/netlify-cms-core/src/components/Editor/EditorControlPane/EditorControl.js
@@ -126,6 +126,9 @@ class EditorControl extends React.Component {
   render() {
     const {
       value,
+      entry,
+      collection,
+      config,
       field,
       fieldsMetaData,
       fieldsErrors,
@@ -217,6 +220,9 @@ class EditorControl extends React.Component {
                 ${styleStrings.labelActive};
               `}
               controlComponent={widget.control}
+              entry={entry}
+              collection={collection}
+              config={config}
               field={field}
               uniqueFieldId={this.uniqueFieldId}
               value={value}
@@ -283,6 +289,7 @@ const mapStateToProps = state => {
     mediaPaths: state.mediaLibrary.get('controlMedia'),
     isFetching: state.search.get('isFetching'),
     queryHits: state.search.get('queryHits'),
+    config: state.config,
     collection,
     entry,
     isLoadingAsset,

--- a/packages/netlify-cms-core/src/components/Editor/EditorControlPane/Widget.js
+++ b/packages/netlify-cms-core/src/components/Editor/EditorControlPane/Widget.js
@@ -219,6 +219,9 @@ export default class Widget extends Component {
   render() {
     const {
       controlComponent,
+      entry,
+      collection,
+      config,
       field,
       value,
       mediaPaths,
@@ -257,6 +260,9 @@ export default class Widget extends Component {
       t,
     } = this.props;
     return React.createElement(controlComponent, {
+      entry,
+      collection,
+      config,
       field,
       value,
       mediaPaths,


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines.

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first two fields are mandatory:
-->

**Summary**

Pass down `entry`, `collection` and `config` properties to the control widget. 

This allows control widgets to inspect and act on whole entry data and collection or configuration values. 
A specific use case for this feature is the creation of a slug widget which updates according to some other fields.

<!--
Explain the **motivation** for making this change.
What existing problem does the pull request solve?
-->

**Test plan**
I don't think a test plan is needed since it's relative straight forward.
<!--
Demonstrate the code is solid.
Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.
-->

**A picture of a cute animal (not mandatory but encouraged)**
