### PR TITLE
fix: support common backend configuration options from docs in ts types

### DIFF
--- a/packages/netlify-cms-core/index.d.ts
+++ b/packages/netlify-cms-core/index.d.ts
@@ -83,6 +83,12 @@ declare module 'netlify-cms-core' {
     name: CmsBackendType;
     auth_scope?: CmsAuthScope;
     open_authoring?: boolean;
+    repo?: string;
+    branch?: string;
+    api_root?: string;
+    site_domain?: string;
+    base_url?: string;
+    auth_endpoint?: string;
   }
 
   export interface CmsSlug {


### PR DESCRIPTION

**Summary**
Related to #2926 for TS support, the current types do not permit the common options for backend configuration from the [docs](https://netlifycms.org/docs/backends-overview). I'm using a non-master branch and using typescript for configuration.

**Test plan**
Verified I can add repo/branch for my project without TS compiler errors. If there are more specific tests for these type definitions I'll gladly add them.
