### PR TITLE
feat: make lists empty by default

### DIFF
--- a/packages/netlify-cms-core/src/actions/__tests__/entries.spec.js
+++ b/packages/netlify-cms-core/src/actions/__tests__/entries.spec.js
@@ -125,7 +125,7 @@ describe('entries', () => {
     });
   });
   describe('createEmptyDraftData', () => {
-    it('should set default value for list field widget', () => {
+    it('should set an empty list for list field widget', () => {
       const fields = fromJS([
         {
           name: 'images',
@@ -133,10 +133,10 @@ describe('entries', () => {
           field: { name: 'url', widget: 'text', default: 'https://image.png' },
         },
       ]);
-      expect(createEmptyDraftData(fields)).toEqual({ images: ['https://image.png'] });
+      expect(createEmptyDraftData(fields)).toEqual({ images: [] });
     });
 
-    it('should set default values for list fields widget', () => {
+    it('should set an empty list for list fields widget', () => {
       const fields = fromJS([
         {
           name: 'images',
@@ -147,12 +147,10 @@ describe('entries', () => {
           ],
         },
       ]);
-      expect(createEmptyDraftData(fields)).toEqual({
-        images: [{ title: 'default image', url: 'https://image.png' }],
-      });
+      expect(createEmptyDraftData(fields)).toEqual({ images: [] });
     });
 
-    it('should not set empty value for list fields widget', () => {
+    it('should set an empty list for list fields widget', () => {
       const fields = fromJS([
         {
           name: 'images',
@@ -163,7 +161,7 @@ describe('entries', () => {
           ],
         },
       ]);
-      expect(createEmptyDraftData(fields)).toEqual({});
+      expect(createEmptyDraftData(fields)).toEqual({ images: [] });
     });
 
     it('should set default value for object field widget', () => {

--- a/packages/netlify-cms-core/src/actions/__tests__/entries.spec.js
+++ b/packages/netlify-cms-core/src/actions/__tests__/entries.spec.js
@@ -136,34 +136,6 @@ describe('entries', () => {
       expect(createEmptyDraftData(fields)).toEqual({ images: [] });
     });
 
-    it('should set an empty list for list fields widget', () => {
-      const fields = fromJS([
-        {
-          name: 'images',
-          widget: 'list',
-          fields: [
-            { name: 'title', widget: 'text', default: 'default image' },
-            { name: 'url', widget: 'text', default: 'https://image.png' },
-          ],
-        },
-      ]);
-      expect(createEmptyDraftData(fields)).toEqual({ images: [] });
-    });
-
-    it('should set an empty list for list fields widget', () => {
-      const fields = fromJS([
-        {
-          name: 'images',
-          widget: 'list',
-          fields: [
-            { name: 'title', widget: 'text' },
-            { name: 'url', widget: 'text' },
-          ],
-        },
-      ]);
-      expect(createEmptyDraftData(fields)).toEqual({ images: [] });
-    });
-
     it('should set default value for object field widget', () => {
       const fields = fromJS([
         {

--- a/packages/netlify-cms-core/src/actions/entries.ts
+++ b/packages/netlify-cms-core/src/actions/entries.ts
@@ -653,23 +653,19 @@ export function createEmptyDraftData(fields: EntryFields, withNameKey = true) {
       const isEmptyDefaultValue = (val: unknown) => [[{}], {}].some(e => isEqual(val, e));
 
       if (List.isList(subfields)) {
-        const subDefaultValue = list
-          ? [createEmptyDraftData(subfields as EntryFields)]
+        const subDefaultValue = list ? []
           : createEmptyDraftData(subfields as EntryFields);
         if (!isEmptyDefaultValue(subDefaultValue)) {
           acc[name] = subDefaultValue;
         }
-        return acc;
       }
 
       if (Map.isMap(subfields)) {
-        const subDefaultValue = list
-          ? [createEmptyDraftData(List([subfields as EntryField]), false)]
+        const subDefaultValue = list ? []
           : createEmptyDraftData(List([subfields as EntryField]));
         if (!isEmptyDefaultValue(subDefaultValue)) {
           acc[name] = subDefaultValue;
         }
-        return acc;
       }
 
       if (defaultValue !== null) {

--- a/packages/netlify-cms-core/src/actions/entries.ts
+++ b/packages/netlify-cms-core/src/actions/entries.ts
@@ -653,16 +653,14 @@ export function createEmptyDraftData(fields: EntryFields, withNameKey = true) {
       const isEmptyDefaultValue = (val: unknown) => [[{}], {}].some(e => isEqual(val, e));
 
       if (List.isList(subfields)) {
-        const subDefaultValue = list ? []
-          : createEmptyDraftData(subfields as EntryFields);
+        const subDefaultValue = list ? [] : createEmptyDraftData(subfields as EntryFields);
         if (!isEmptyDefaultValue(subDefaultValue)) {
           acc[name] = subDefaultValue;
         }
       }
 
       if (Map.isMap(subfields)) {
-        const subDefaultValue = list ? []
-          : createEmptyDraftData(List([subfields as EntryField]));
+        const subDefaultValue = list ? [] : createEmptyDraftData(List([subfields as EntryField]));
         if (!isEmptyDefaultValue(subDefaultValue)) {
           acc[name] = subDefaultValue;
         }


### PR DESCRIPTION
closes #3534

**Summary**

I think list should be empty by default.
That's actually what happens for typedList (because it relies on `types` and not `field` or `fields`).

**A picture of a cute animal (not mandatory but encouraged)**
![!https://www.sciencemag.org/sites/default/files/styles/article_main_image_-_1280w__no_aspect_/public/cs_0315N_Pangolin_2.jpg?itok=hv3HRiOE](https://www.sciencemag.org/sites/default/files/styles/article_main_image_-_1280w__no_aspect_/public/cs_0315N_Pangolin_2.jpg?itok=hv3HRiOE)