### PR TITLE
fix(date): allow default value to Date field

### DIFF
--- a/packages/netlify-cms-widget-date/src/DateControl.js
+++ b/packages/netlify-cms-widget-date/src/DateControl.js
@@ -50,7 +50,14 @@ export default class DateControl extends React.Component {
     };
   }
 
+  getDefaultValue() {
+    const { field } = this.props;
+    const defaultValue = field.get('default');
+    return defaultValue;
+  }
+
   formats = this.getFormats();
+  defaultValue = this.getDefaultValue();
 
   componentDidMount() {
     warnDeprecated();
@@ -62,7 +69,7 @@ export default class DateControl extends React.Component {
      */
     if (!value && value !== '') {
       setTimeout(() => {
-        this.handleChange(new Date());
+        this.handleChange(this.defaultValue === undefined ? new Date() : this.defaultValue);
       }, 0);
     }
   }


### PR DESCRIPTION

**Summary**

Default value for the Date widget are not taken into account
https://www.netlifycms.org/docs/widgets/#date

**Test plan**
I duplicated the code from the Datetime widget :sweat_smile: 

**A picture of a cute animal (not mandatory but encouraged)**
![Wombat](http://2.bp.blogspot.com/-hUyNGSzt7YQ/TZ3dcfX1H3I/AAAAAAAACK0/tkH0oGbHzPg/s1600/wombat.jpg)