### PR TITLE
feat(relation-widget): Allow the relation widget to target file collections

### DIFF
--- a/dev-test/config.yml
+++ b/dev-test/config.yml
@@ -34,6 +34,14 @@ collections: # A list of collections the CMS should be able to edit
         tagname: ''
 
       - { label: 'Body', name: 'body', widget: 'markdown', hint: 'Main content goes here.' }
+      - label: Categories
+        name: categories
+        widget: relation
+        collection: 'settings.general.categories'
+        valueField: id
+        displayFields: description
+        multiple: true
+
     meta:
       - { label: 'SEO Description', name: 'description', widget: 'text' }
 
@@ -76,6 +84,10 @@ collections: # A list of collections the CMS should be able to edit
                   class: 'thumb',
                   required: false,
                 }
+
+          - label: 'Post Categories'
+            name: categories
+            widget: list
 
       - name: 'authors'
         label: 'Authors'

--- a/dev-test/index.html
+++ b/dev-test/index.html
@@ -36,7 +36,7 @@
     },
     _data: {
       "settings.json": {
-        content: '{"site_title": "CMS Demo"}'
+        content: '{"site_title": "CMS Demo", "categories": ["Business", "Politics", "Tech", "Science", "Health"]}'
       },
       "authors.yml": {
         content: 'authors:\n  - name: Mathias\n    description: Co-founder @ Netlify\n  - name: Chris\n    description: Co-founder @ Netlify\n'

--- a/packages/netlify-cms-widget-relation/src/RelationControl.js
+++ b/packages/netlify-cms-widget-relation/src/RelationControl.js
@@ -151,10 +151,10 @@ export default class RelationControl extends React.Component {
   loadFileOptions = debounce((term, callback) => {
     const { field, loadEntry } = this.props;
     const target = field.get('collection');
-    const [ collection, fileName, fieldName ] = target.split('.')
+    const [collection, fileName, fieldName] = target.split('.');
 
     loadEntry(collection, fileName).then(({ data }) => {
-      let options = data[fieldName] || []
+      let options = data[fieldName] || [];
 
       // handle simple array of string (from a simple list)
       if (options.every(item => typeof item === 'string')) {
@@ -162,20 +162,20 @@ export default class RelationControl extends React.Component {
           data: item,
           value: item,
           label: item,
-        }))
+        }));
       } else {
         // handle object list
-        const hits = options.map(item => ({ data: item }))
-        options = this.parseHitOptions(hits)
+        const hits = options.map(item => ({ data: item }));
+        options = this.parseHitOptions(hits);
       }
 
       if (!this.allOptions) {
-        this.allOptions = options
-      };
+        this.allOptions = options;
+      }
 
       callback(options);
-    })
-  }, 500)
+    });
+  }, 500);
 
   loadOptions = debounce((term, callback) => {
     const { field, query, forID } = this.props;
@@ -183,7 +183,7 @@ export default class RelationControl extends React.Component {
     const searchFields = field.get('searchFields');
     const optionsLength = field.get('optionsLength') || 20;
     const searchFieldsArray = List.isList(searchFields) ? searchFields.toJS() : [searchFields];
-    
+
     query(forID, collection, searchFieldsArray, term).then(({ payload }) => {
       let options =
         payload.response && payload.response.hits

--- a/packages/netlify-cms-widget-relation/src/RelationControl.js
+++ b/packages/netlify-cms-widget-relation/src/RelationControl.js
@@ -165,7 +165,8 @@ export default class RelationControl extends React.Component {
         }))
       } else {
         // handle object list
-        options = this.parseHitOptions(data[fieldName])
+        const hits = options.map(item => ({ data: item }))
+        options = this.parseHitOptions(hits)
       }
 
       if (!this.allOptions) {

--- a/packages/netlify-cms-widget-relation/src/RelationControl.js
+++ b/packages/netlify-cms-widget-relation/src/RelationControl.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import ImmutablePropTypes from 'react-immutable-proptypes';
 import { Async as AsyncSelect } from 'react-select';
-import { find, isEmpty, last, debounce } from 'lodash';
+import { find, isEmpty, last, debounce, get } from 'lodash';
 import { List, Map, fromJS } from 'immutable';
 import { reactSelectStyles } from 'netlify-cms-ui-default';
 import { stringTemplate } from 'netlify-cms-lib-widgets';
@@ -151,10 +151,10 @@ export default class RelationControl extends React.Component {
   loadFileOptions = debounce((term, callback) => {
     const { field, loadEntry } = this.props;
     const target = field.get('collection');
-    const [collection, fileName, fieldName] = target.split('.');
+    const [collection, fileName, ...fieldName] = target.split('.');
 
     loadEntry(collection, fileName).then(({ data }) => {
-      let options = data[fieldName] || [];
+      let options = get(data, fieldName, []);
 
       // handle simple array of string (from a simple list)
       if (options.every(item => typeof item === 'string')) {

--- a/packages/netlify-cms-widget-relation/src/__tests__/relation.spec.js
+++ b/packages/netlify-cms-widget-relation/src/__tests__/relation.spec.js
@@ -113,20 +113,26 @@ class RelationController extends React.Component {
   });
 
   loadEntry = jest.fn(() => {
-    return Promise.resolve({ data: {
-      simpleList: ['cat-one', 'cat-two', 'cat-three'],
-      objectList: [{
-        id: 'a',
-        name: 'name-A',
-      }, {
-        id: 'b',
-        name: 'name-B',
-      }, {
-        id: 'c',
-        name: 'name-C',
-      }]
-    } })
-  })
+    return Promise.resolve({
+      data: {
+        simpleList: ['cat-one', 'cat-two', 'cat-three'],
+        objectList: [
+          {
+            id: 'a',
+            name: 'name-A',
+          },
+          {
+            id: 'b',
+            name: 'name-B',
+          },
+          {
+            id: 'c',
+            name: 'name-C',
+          },
+        ],
+      },
+    });
+  });
 
   render() {
     return this.props.children({
@@ -148,7 +154,12 @@ function setup({ field, value }) {
   const helpers = render(
     <RelationController value={value}>
       {({ handleOnChange, value, query, queryHits, setQueryHits, loadEntry }) => {
-        renderArgs = { value, onChangeSpy: handleOnChange, setQueryHitsSpy: setQueryHits, loadEntrySpy: loadEntry };
+        renderArgs = {
+          value,
+          onChangeSpy: handleOnChange,
+          setQueryHitsSpy: setQueryHits,
+          loadEntrySpy: loadEntry,
+        };
         return (
           <RelationControl
             field={field}
@@ -339,7 +350,6 @@ describe('Relation widget', () => {
   });
 
   describe('with file collection', () => {
-    
     const simpleListFieldConfig = {
       name: 'post',
       collection: 'file.fileName.simpleList',
@@ -353,15 +363,15 @@ describe('Relation widget', () => {
     };
 
     it('should list content of a simple list', async () => {
-        const field = fromJS(simpleListFieldConfig);
-        const { getAllByText, input } = setup({ field });
-        fireEvent.keyDown(input, { key: 'ArrowDown' });
-    
-        await wait(() => {
-          expect(getAllByText(/cat/)).toHaveLength(3);
-        });
+      const field = fromJS(simpleListFieldConfig);
+      const { getAllByText, input } = setup({ field });
+      fireEvent.keyDown(input, { key: 'ArrowDown' });
+
+      await wait(() => {
+        expect(getAllByText(/cat/)).toHaveLength(3);
+      });
     });
-    
+
     it('should list the displayFields', async () => {
       const field = fromJS(objectListFieldConfig);
       const { getAllByText, input } = setup({ field });
@@ -369,7 +379,7 @@ describe('Relation widget', () => {
 
       await wait(() => {
         expect(getAllByText(/name/)).toHaveLength(3);
-      })
-    })
+      });
+    });
   });
 });

--- a/packages/netlify-cms-widget-relation/src/__tests__/relation.spec.js
+++ b/packages/netlify-cms-widget-relation/src/__tests__/relation.spec.js
@@ -112,6 +112,12 @@ class RelationController extends React.Component {
     return Promise.resolve({ payload: { response: { hits: queryHits } } });
   });
 
+  loadEntry = jest.fn(() => {
+    return Promise.resolve({ data: {
+      categories: ['cat-one', 'cat-two', 'cat-three'],
+    } })
+  })
+
   render() {
     return this.props.children({
       value: this.state.value,
@@ -119,6 +125,7 @@ class RelationController extends React.Component {
       query: this.query,
       queryHits: this.state.queryHits,
       setQueryHits: this.setQueryHits,
+      loadEntry: this.loadEntry,
     });
   }
 }
@@ -130,7 +137,7 @@ function setup({ field, value }) {
 
   const helpers = render(
     <RelationController value={value}>
-      {({ handleOnChange, value, query, queryHits, setQueryHits }) => {
+      {({ handleOnChange, value, query, queryHits, setQueryHits, loadEntry }) => {
         renderArgs = { value, onChangeSpy: handleOnChange, setQueryHitsSpy: setQueryHits };
         return (
           <RelationControl
@@ -138,6 +145,7 @@ function setup({ field, value }) {
             value={value}
             query={query}
             queryHits={queryHits}
+            loadEntry={loadEntry}
             onChange={handleOnChange}
             forID="relation-field"
             classNameWrapper=""
@@ -318,5 +326,26 @@ describe('Relation widget', () => {
         expect(onChangeSpy).toHaveBeenCalledWith(value, metadata2);
       });
     });
+  });
+
+  describe('with file collection', () => {
+    
+    const fileFieldConfig = {
+      name: 'post',
+      collection: 'posts',
+      displayFields: ['title', 'slug'],
+      searchFields: ['title', 'body'],
+      valueField: 'title',
+    };
+
+    it('should list the correct options', async () => {
+        const field = fromJS(fileFieldConfig);
+        const { getAllByText, input } = setup({ field });
+        fireEvent.keyDown(input, { key: 'ArrowDown' });
+    
+        await wait(() => {
+          expect(getAllByText(/cat/)).toHaveLength(3);
+        });
+    })
   });
 });

--- a/packages/netlify-cms-widget-relation/src/__tests__/relation.spec.js
+++ b/packages/netlify-cms-widget-relation/src/__tests__/relation.spec.js
@@ -114,7 +114,17 @@ class RelationController extends React.Component {
 
   loadEntry = jest.fn(() => {
     return Promise.resolve({ data: {
-      categories: ['cat-one', 'cat-two', 'cat-three'],
+      simpleList: ['cat-one', 'cat-two', 'cat-three'],
+      objectList: [{
+        id: 'a',
+        name: 'name-A',
+      }, {
+        id: 'b',
+        name: 'name-B',
+      }, {
+        id: 'c',
+        name: 'name-C',
+      }]
     } })
   })
 
@@ -138,7 +148,7 @@ function setup({ field, value }) {
   const helpers = render(
     <RelationController value={value}>
       {({ handleOnChange, value, query, queryHits, setQueryHits, loadEntry }) => {
-        renderArgs = { value, onChangeSpy: handleOnChange, setQueryHitsSpy: setQueryHits };
+        renderArgs = { value, onChangeSpy: handleOnChange, setQueryHitsSpy: setQueryHits, loadEntrySpy: loadEntry };
         return (
           <RelationControl
             field={field}
@@ -330,22 +340,36 @@ describe('Relation widget', () => {
 
   describe('with file collection', () => {
     
-    const fileFieldConfig = {
+    const simpleListFieldConfig = {
       name: 'post',
-      collection: 'posts',
-      displayFields: ['title', 'slug'],
-      searchFields: ['title', 'body'],
-      valueField: 'title',
+      collection: 'file.fileName.simpleList',
     };
 
-    it('should list the correct options', async () => {
-        const field = fromJS(fileFieldConfig);
+    const objectListFieldConfig = {
+      name: 'post',
+      collection: 'file.fileName.objectList',
+      displayFields: 'name',
+      valueField: 'id',
+    };
+
+    it('should list content of a simple list', async () => {
+        const field = fromJS(simpleListFieldConfig);
         const { getAllByText, input } = setup({ field });
         fireEvent.keyDown(input, { key: 'ArrowDown' });
     
         await wait(() => {
           expect(getAllByText(/cat/)).toHaveLength(3);
         });
+    });
+    
+    it('should list the displayFields', async () => {
+      const field = fromJS(objectListFieldConfig);
+      const { getAllByText, input } = setup({ field });
+      fireEvent.keyDown(input, { key: 'ArrowDown' });
+
+      await wait(() => {
+        expect(getAllByText(/name/)).toHaveLength(3);
+      })
     })
   });
 });

--- a/packages/netlify-cms-widget-relation/src/__tests__/relation.spec.js
+++ b/packages/netlify-cms-widget-relation/src/__tests__/relation.spec.js
@@ -130,6 +130,12 @@ class RelationController extends React.Component {
             name: 'name-C',
           },
         ],
+        nestedList: {
+          nested: Array.from({ length: 3 }, (_, id) => ({
+            id,
+            name: `nested-${id}`,
+          })),
+        },
       },
     });
   });
@@ -379,6 +385,19 @@ describe('Relation widget', () => {
 
       await wait(() => {
         expect(getAllByText(/name/)).toHaveLength(3);
+      });
+    });
+
+    it('should access list nested', async () => {
+      const field = fromJS({
+        ...objectListFieldConfig,
+        collection: 'file.fileName.nestedList.nested',
+      });
+      const { getAllByText, input } = setup({ field });
+      fireEvent.keyDown(input, { key: 'ArrowDown' });
+
+      await wait(() => {
+        expect(getAllByText(/nested/)).toHaveLength(3);
       });
     });
   });


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines.

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first two fields are mandatory:
-->

**Summary**

Hello everyone! This PR is a WIP and is meant to facilitate discussion, no hurt feeling if it's rejected.

A few challenges when targeting a file collection:
- Beside the collection name, the widget will also need the file name, and the name of a field in that file (which is very likely a list widget.)
- The widget needs to know if it's dealing with a file collection, a folder collection, or its own entry.
- The widget have to be able to handle a simple array of string and potentially an array of object with different shape (in case of an array produced by a typed list widget).

For the first two, I think we could use dot notation in collection name:

```yml
# folder collection
- label: Featured Posts
  name: featuredPosts
  widget: relation
  collection: posts

# file collection
- label: Categories
  name: categories
  widget: relation
  # [collection].[fileName].[fieldName]
  collection: "settings.post.categories"
```

If `collection` contains dots, use `query` as usual; otherwise use `loadEntry`. Later on, when a user want to target a list widget in the same entry as the relation widget, I think it should be smart and use the new `entry` props.

Also, I found that query's results are stored in `queryHits`. I wonder if `loadEntry` results should be stored in a similar manner?

Please let me know if this is a valid approach!

**Test plan**

I've written 2 basic tests that covers a simple list &  a list of items with the same object shape. Will need a few more.

<!--
Demonstrate the code is solid.
Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.
-->

closes #800 
