### PR TITLE
feat: add pickerUtc option to datetime widget

### DIFF
--- a/packages/netlify-cms-widget-datetime/src/DateTimeControl.js
+++ b/packages/netlify-cms-widget-datetime/src/DateTimeControl.js
@@ -44,8 +44,15 @@ export default class DateTimeControl extends React.Component {
     return defaultValue;
   }
 
+  getPickerUtc() {
+    const { field } = this.props;
+    const pickerUtc = field.get('pickerUtc');
+    return pickerUtc;
+  }
+
   formats = this.getFormats();
   defaultValue = this.getDefaultValue();
+  pickerUtc = this.getPickerUtc();
 
   componentDidMount() {
     const { value } = this.props;
@@ -125,6 +132,7 @@ export default class DateTimeControl extends React.Component {
           onFocus={setActiveStyle}
           onBlur={this.onBlur}
           inputProps={{ className: classNameWrapper, id: forID }}
+          utc={this.pickerUtc}
         />
         <div
           css={css`

--- a/website/content/docs/widgets/datetime.md
+++ b/website/content/docs/widgets/datetime.md
@@ -13,6 +13,7 @@ The datetime widget translates a datetime picker to a datetime string.
   - `format`: sets storage format; accepts Moment.js [tokens](https://momentjs.com/docs/#/parsing/string-format/); defaults to raw Date object (if supported by output format)
   - `dateFormat`: sets date display format in UI; boolean or Moment.js [tokens](https://momentjs.com/docs/#/parsing/string-format/). If `true` use default locale format.
   - `timeFormat`: sets time display format in UI; boolean or Moment.js [tokens](https://momentjs.com/docs/#/parsing/string-format/). If `true` use default locale format, `false` hides time-picker.
+  - `pickerUtc`: _(default: `false`)_ when set to `true`, the datetime picker will display times in UTC. When `false`, the datetime picker will display times in the user's local timezone. When using date-only formats, it can be helpful to set this to `true` so users in all timezones will see the same date in the datetime picker.
 - **Example:**
     ```yaml
     - label: "Start time"
@@ -22,4 +23,5 @@ The datetime widget translates a datetime picker to a datetime string.
       dateFormat: "DD.MM.YYYY" # e.g. 24.12.2021
       timeFormat: "HH:mm" # e.g. 21:07
       format: "LLL"
+      pickerUtc: false
     ```


### PR DESCRIPTION
## Summary

I have a field that I would like to contain just a date (with no specific time). When I configure the `datetime` widget with sensible options for a date-only field, dates are stored properly in the saved markdown, but when I load those dates in the UI, I see the date before.

This is happening because the `DateTime` component from the [`react-datetime` library](https://github.com/YouCanBookMe/react-datetime) uses local timezones by default. It loads the date as the start of day UTC and then converts to the local timezone, which is going to be the previous day in any timezone with a negative UTC offset, including all of the Americas.

This change adds a `pickerUtc` option to the `datetime` widget so that users can specify when they would like the `datetime` picker to display times in UTC rather than in the local timezone. This leverages the `utc` option in the [`react-datetime` API](https://github.com/YouCanBookMe/react-datetime#api). By setting this new option to true on date-only fields, users can ensure that everyone sees the same date in the picker regardless of local timezones.

closes https://github.com/netlify/netlify-cms/issues/3640

## Test plan

I tested the new option locally by updating the `date` field in `dev-test/config.yml`. In each of the demos below, I set `timeFormat` to `false` and `format` to `YYYY-MM-DD`.

### No `pickerUtc` specified

![no-option-specified](https://user-images.githubusercontent.com/7942714/81351000-1d48b180-9078-11ea-96c1-62b8faac142b.gif)

### `pickerUtc: false`

![picker-utc-false](https://user-images.githubusercontent.com/7942714/81351016-29347380-9078-11ea-9a0a-1a11c2088dae.gif)

### `pickerUtc: true`

![picker-utc-true](https://user-images.githubusercontent.com/7942714/81351024-2df92780-9078-11ea-9fb1-ad6ab0a9b521.gif)

## A picture of a cute animal (not mandatory but encouraged)

![00100lPORTRAIT_00100_BURST20181123115455657_COVER](https://user-images.githubusercontent.com/7942714/81351439-2dad5c00-9079-11ea-9f52-3a0c423be418.jpg)
