### PR TITLE
fix: allow setting an empty array as default for complex lists

### DIFF
--- a/packages/netlify-cms-core/src/actions/__tests__/entries.spec.js
+++ b/packages/netlify-cms-core/src/actions/__tests__/entries.spec.js
@@ -125,6 +125,60 @@ describe('entries', () => {
     });
   });
   describe('createEmptyDraftData', () => {
+    it('should allow an empty array as list default for a single field list', () => {
+      const fields = fromJS([
+        {
+          name: 'images',
+          widget: 'list',
+          default: [],
+          field: { name: 'url', widget: 'text' },
+        },
+      ]);
+      expect(createEmptyDraftData(fields)).toEqual({ images: fromJS([]) });
+    });
+
+    it('should allow an empty array as list default for a fields list', () => {
+      const fields = fromJS([
+        {
+          name: 'images',
+          widget: 'list',
+          default: [],
+          fields: [
+            { name: 'title', widget: 'text' },
+            { name: 'url', widget: 'text' },
+          ],
+        },
+      ]);
+      expect(createEmptyDraftData(fields)).toEqual({ images: fromJS([]) });
+    });
+
+    it('should not allow setting a non empty array as a default value for a single field list', () => {
+      const fields = fromJS([
+        {
+          name: 'images',
+          widget: 'list',
+          default: [{ name: 'url' }, { other: 'field' }],
+          field: { name: 'url', widget: 'text' },
+        },
+      ]);
+      expect(createEmptyDraftData(fields)).toEqual({});
+    });
+
+    it('should not allow setting a non empty array as a default value for a fields list', () => {
+      const fields = fromJS([
+        {
+          name: 'images',
+          widget: 'list',
+          default: [{ name: 'url' }, { other: 'field' }],
+          fields: [
+            { name: 'title', widget: 'text' },
+            { name: 'url', widget: 'text' },
+          ],
+        },
+      ]);
+      expect(createEmptyDraftData(fields)).toEqual({});
+    });
+
     it('should set default value for list field widget', () => {
       const fields = fromJS([
         {
@@ -136,11 +190,40 @@ describe('entries', () => {
       expect(createEmptyDraftData(fields)).toEqual({ images: ['https://image.png'] });
     });
 
+    it('should override list default with field default', () => {
+      const fields = fromJS([
+        {
+          name: 'images',
+          widget: 'list',
+          default: [],
+          field: { name: 'url', widget: 'text', default: 'https://image.png' },
+        },
+      ]);
+      expect(createEmptyDraftData(fields)).toEqual({ images: ['https://image.png'] });
+    });
+
     it('should set default values for list fields widget', () => {
       const fields = fromJS([
         {
           name: 'images',
           widget: 'list',
+          fields: [
+            { name: 'title', widget: 'text', default: 'default image' },
+            { name: 'url', widget: 'text', default: 'https://image.png' },
+          ],
+        },
+      ]);
+      expect(createEmptyDraftData(fields)).toEqual({
+        images: [{ title: 'default image', url: 'https://image.png' }],
+      });
+    });
+
+    it('should override list default with fields default', () => {
+      const fields = fromJS([
+        {
+          name: 'images',
+          widget: 'list',
+          default: [],
           fields: [
             { name: 'title', widget: 'text', default: 'default image' },
             { name: 'url', widget: 'text', default: 'https://image.png' },

--- a/packages/netlify-cms-core/src/actions/entries.ts
+++ b/packages/netlify-cms-core/src/actions/entries.ts
@@ -633,15 +633,16 @@ interface DraftEntryData {
     | string
     | null
     | boolean
+    | List<unknown>
     | DraftEntryData
     | DraftEntryData[]
-    | (string | DraftEntryData | boolean)[];
+    | (string | DraftEntryData | boolean | List<unknown>)[];
 }
 
 export function createEmptyDraftData(fields: EntryFields, withNameKey = true) {
   return fields.reduce(
     (
-      reduction: DraftEntryData | string | undefined | boolean,
+      reduction: DraftEntryData | string | undefined | boolean | List<unknown>,
       value: EntryField | undefined | boolean,
     ) => {
       const acc = reduction as DraftEntryData;
@@ -658,6 +659,9 @@ export function createEmptyDraftData(fields: EntryFields, withNameKey = true) {
           : createEmptyDraftData(subfields as EntryFields);
         if (!isEmptyDefaultValue(subDefaultValue)) {
           acc[name] = subDefaultValue;
+        } else if (list && List.isList(defaultValue) && (defaultValue as List<unknown>).isEmpty()) {
+          // allow setting an empty list as a default
+          acc[name] = defaultValue;
         }
         return acc;
       }
@@ -668,6 +672,9 @@ export function createEmptyDraftData(fields: EntryFields, withNameKey = true) {
           : createEmptyDraftData(List([subfields as EntryField]));
         if (!isEmptyDefaultValue(subDefaultValue)) {
           acc[name] = subDefaultValue;
+        } else if (list && List.isList(defaultValue) && (defaultValue as List<unknown>).isEmpty()) {
+          // allow setting an empty list as a default
+          acc[name] = defaultValue;
         }
         return acc;
       }

--- a/packages/netlify-cms-core/src/types/redux.ts
+++ b/packages/netlify-cms-core/src/types/redux.ts
@@ -110,7 +110,7 @@ export type EntryField = StaticallyTypedRecord<{
   types?: List<EntryField>;
   widget: string;
   name: string;
-  default: string | null | boolean;
+  default: string | null | boolean | List<unknown>;
   media_folder?: string;
   public_folder?: string;
   comment?: string;


### PR DESCRIPTION
Fixes https://github.com/netlify/netlify-cms/issues/3534
Replaces https://github.com/netlify/netlify-cms/pull/3675