### PR TITLE
feat: improve search to target single collections

### DIFF
--- a/cypress/integration/search_suggestion_spec.js
+++ b/cypress/integration/search_suggestion_spec.js
@@ -1,0 +1,78 @@
+import { login } from '../utils/steps';
+
+const search = (term, collection) => {
+  cy.get('[class*=SearchInput]').clear({ force: true });
+  cy.get('[class*=SearchInput]').type(term, { force: true });
+  cy.get('[class*=SuggestionsContainer]').within(() => {
+    cy.contains(collection).click();
+  });
+};
+
+const assertSearchHeading = title => {
+  cy.get('[class*=SearchResultHeading]').should('have.text', title);
+};
+
+const assertSearchResult = (text, collection) => {
+  cy.get('[class*=ListCardLink]').within(() => {
+    if (collection) {
+      cy.contains('h2', collection);
+    }
+    cy.contains('h2', text);
+  });
+};
+
+const assertNotInSearch = text => {
+  cy.get('[class*=ListCardLink]').within(() => {
+    cy.contains('h2', text).should('not.exist');
+  });
+};
+
+describe('Search Suggestion', () => {
+  before(() => {
+    Cypress.config('defaultCommandTimeout', 4000);
+    cy.task('setupBackend', { backend: 'test' });
+  });
+
+  after(() => {
+    cy.task('teardownBackend', { backend: 'test' });
+  });
+
+  beforeEach(() => {
+    login();
+  });
+
+  it('can search in all collections', () => {
+    search('this', 'All Collections');
+
+    assertSearchHeading('Search Results for "this"');
+
+    assertSearchResult('This is post # 20', 'Posts');
+    assertSearchResult('This is a TOML front matter post', 'Posts');
+    assertSearchResult('This is a JSON front matter post', 'Posts');
+    assertSearchResult('This is a YAML front matter post', 'Posts');
+    assertSearchResult('This FAQ item # 5', 'FAQ');
+  });
+
+  it('can search in posts collection', () => {
+    search('this', 'Posts');
+
+    assertSearchHeading('Search Results for "this" in Posts');
+
+    assertSearchResult('This is post # 20');
+    assertSearchResult('This is a TOML front matter post');
+    assertSearchResult('This is a JSON front matter post');
+    assertSearchResult('This is a YAML front matter post');
+
+    assertNotInSearch('This FAQ item # 5');
+  });
+
+  it('can search in faq collection', () => {
+    search('this', 'FAQ');
+
+    assertSearchHeading('Search Results for "this" in FAQ');
+
+    assertSearchResult('This FAQ item # 5');
+
+    assertNotInSearch('This is post # 20');
+  });
+});

--- a/packages/netlify-cms-core/src/actions/collections.js
+++ b/packages/netlify-cms-core/src/actions/collections.js
@@ -1,8 +1,12 @@
 import history from 'Routing/history';
 import { getCollectionUrl, getNewEntryUrl } from 'Lib/urlHelper';
 
-export function searchCollections(query) {
-  history.push(`/search/${query}`);
+export function searchCollections(query, collection) {
+  if (collection) {
+    history.push(`/collections/${collection}/search/${query}`);
+  } else {
+    history.push(`/search/${query}`);
+  }
 }
 
 export function showCollection(collectionName) {

--- a/packages/netlify-cms-core/src/components/App/App.js
+++ b/packages/netlify-cms-core/src/components/App/App.js
@@ -200,6 +200,12 @@ class App extends React.Component {
           <Switch>
             <Redirect exact from="/" to={defaultPath} />
             <Redirect exact from="/search/" to={defaultPath} />
+            <RouteInCollection
+              exact
+              collections={collections}
+              path="/collections/:name/search/"
+              render={({ match }) => <Redirect to={`/collections/${match.params.name}`} />}
+            />
             <Redirect
               // This happens on Identity + Invite Only + External Provider email not matching
               // the registered user
@@ -222,6 +228,11 @@ class App extends React.Component {
               path="/collections/:name/entries/*"
               collections={collections}
               render={props => <Editor {...props} />}
+            />
+            <RouteInCollection
+              path="/collections/:name/search/:searchTerm"
+              collections={collections}
+              render={props => <Collection {...props} isSearchResults isSingleSearchResult />}
             />
             <Route
               path="/search/:searchTerm"

--- a/packages/netlify-cms-core/src/components/Collection/Collection.js
+++ b/packages/netlify-cms-core/src/components/Collection/Collection.js
@@ -15,6 +15,7 @@ import { sortByField } from 'Actions/entries';
 import { selectSortableFields } from 'Reducers/collections';
 import { selectEntriesSort } from 'Reducers/entries';
 import { VIEW_STYLE_LIST } from 'Constants/collectionViews';
+import { components } from 'netlify-cms-ui-default/src/styles';
 
 const CollectionContainer = styled.div`
   margin: ${lengths.pageMargin};
@@ -22,6 +23,15 @@ const CollectionContainer = styled.div`
 
 const CollectionMain = styled.main`
   padding-left: 280px;
+`;
+
+const SearchResultContainer = styled.div`
+  ${components.cardTop};
+  margin-bottom: 22px;
+`;
+
+const SearchResultHeading = styled.h1`
+  ${components.cardTopHeading};
 `;
 
 class Collection extends React.Component {
@@ -68,17 +78,33 @@ class Collection extends React.Component {
       collections,
       collectionName,
       isSearchResults,
+      isSingleSearchResult,
       searchTerm,
       sortableFields,
       onSortClick,
       sort,
+      t,
     } = this.props;
     const newEntryUrl = collection.get('create') ? getNewEntryUrl(collectionName) : '';
+
+    const searchResultKey =
+      'collection.collectionTop.searchResults' + (isSingleSearchResult ? 'InCollection' : '');
+
     return (
       <CollectionContainer>
-        <Sidebar collections={collections} collection={collection} searchTerm={searchTerm} />
+        <Sidebar
+          collections={collections}
+          collection={(!isSearchResults || isSingleSearchResult) && collection}
+          searchTerm={searchTerm}
+        />
         <CollectionMain>
-          {isSearchResults ? null : (
+          {isSearchResults ? (
+            <SearchResultContainer>
+              <SearchResultHeading>
+                {t(searchResultKey, { searchTerm, collection: collection.get('label') })}
+              </SearchResultHeading>
+            </SearchResultContainer>
+          ) : (
             <>
               <CollectionTop collection={collection} newEntryUrl={newEntryUrl} />
               <CollectionControls

--- a/packages/netlify-cms-core/src/components/Collection/Collection.js
+++ b/packages/netlify-cms-core/src/components/Collection/Collection.js
@@ -29,6 +29,7 @@ class Collection extends React.Component {
     searchTerm: PropTypes.string,
     collectionName: PropTypes.string,
     isSearchResults: PropTypes.bool,
+    isSingleSearchResult: PropTypes.bool,
     collection: ImmutablePropTypes.map.isRequired,
     collections: ImmutablePropTypes.orderedMap.isRequired,
     sortableFields: PropTypes.array,
@@ -46,8 +47,13 @@ class Collection extends React.Component {
   };
 
   renderEntriesSearch = () => {
-    const { searchTerm, collections } = this.props;
-    return <EntriesSearch collections={collections} searchTerm={searchTerm} />;
+    const { searchTerm, collections, collection, isSingleSearchResult } = this.props;
+    return (
+      <EntriesSearch
+        collections={isSingleSearchResult ? collections.filter(c => c === collection) : collections}
+        searchTerm={searchTerm}
+      />
+    );
   };
 
   handleChangeViewStyle = viewStyle => {
@@ -70,7 +76,7 @@ class Collection extends React.Component {
     const newEntryUrl = collection.get('create') ? getNewEntryUrl(collectionName) : '';
     return (
       <CollectionContainer>
-        <Sidebar collections={collections} searchTerm={searchTerm} />
+        <Sidebar collections={collections} collection={collection} searchTerm={searchTerm} />
         <CollectionMain>
           {isSearchResults ? null : (
             <>

--- a/packages/netlify-cms-core/src/components/Collection/Collection.js
+++ b/packages/netlify-cms-core/src/components/Collection/Collection.js
@@ -4,7 +4,7 @@ import ImmutablePropTypes from 'react-immutable-proptypes';
 import styled from '@emotion/styled';
 import { connect } from 'react-redux';
 import { translate } from 'react-polyglot';
-import { lengths } from 'netlify-cms-ui-default';
+import { lengths, components } from 'netlify-cms-ui-default';
 import { getNewEntryUrl } from 'Lib/urlHelper';
 import Sidebar from './Sidebar';
 import CollectionTop from './CollectionTop';
@@ -15,7 +15,6 @@ import { sortByField } from 'Actions/entries';
 import { selectSortableFields } from 'Reducers/collections';
 import { selectEntriesSort } from 'Reducers/entries';
 import { VIEW_STYLE_LIST } from 'Constants/collectionViews';
-import { components } from 'netlify-cms-ui-default/src/styles';
 
 const CollectionContainer = styled.div`
   margin: ${lengths.pageMargin};

--- a/packages/netlify-cms-core/src/components/Collection/CollectionSearch.js
+++ b/packages/netlify-cms-core/src/components/Collection/CollectionSearch.js
@@ -99,18 +99,19 @@ class CollectionSearch extends React.Component {
     query: this.props.searchTerm,
     suggestionsVisible: false,
     // default to the currently selected
-    selectedCollectionIdx: this.props.collection
-      ? this.props.collections.keySeq().indexOf(this.props.collection.get('name'))
-      : -1,
+    selectedCollectionIdx: this.getSelectedSelectionBasedOnProps(),
   };
 
   componentDidUpdate(prevProps) {
     if (prevProps.collection !== this.props.collection) {
-      const selectedCollectionIdx = this.props.collection
-        ? this.props.collections.keySeq().indexOf(this.props.collection.get('name'))
-        : -1;
+      const selectedCollectionIdx = this.getSelectedSelectionBasedOnProps();
       this.setState({ selectedCollectionIdx });
     }
+  }
+
+  getSelectedSelectionBasedOnProps() {
+    const { collection, collections } = this.props;
+    return collection ? collections.keySeq().indexOf(collection.get('name')) : -1;
   }
 
   toggleSuggestions(visible) {

--- a/packages/netlify-cms-core/src/components/Collection/CollectionSearch.js
+++ b/packages/netlify-cms-core/src/components/Collection/CollectionSearch.js
@@ -1,0 +1,237 @@
+import React from 'react';
+import styled from '@emotion/styled';
+import { colorsRaw, colors, Icon, lengths, zIndex } from 'netlify-cms-ui-default';
+import { translate } from 'react-polyglot';
+import PropTypes from 'prop-types';
+import ImmutablePropTypes from 'react-immutable-proptypes';
+
+const SearchContainer = styled.div`
+  margin: 0 12px;
+  position: relative;
+
+  ${Icon} {
+    position: absolute;
+    top: 0;
+    left: 6px;
+    z-index: ${zIndex.zIndex2};
+    height: 100%;
+    display: flex;
+    align-items: center;
+    pointer-events: none;
+  }
+`;
+
+const InputContainer = styled.div`
+  display: flex;
+  align-items: center;
+  position: relative;
+`;
+
+const SearchInput = styled.input`
+  background-color: #eff0f4;
+  border-radius: ${lengths.borderRadius};
+  font-size: 14px;
+  padding: 10px 6px 10px 32px;
+  width: 100%;
+  position: relative;
+  z-index: ${zIndex.zIndex1};
+
+  &:focus {
+    outline: none;
+    box-shadow: inset 0 0 0 2px ${colorsRaw.blue};
+  }
+`;
+
+const SuggestionsContainer = styled.div`
+  position: relative;
+  width: 100%;
+`;
+
+const Suggestions = styled.ul`
+  position: absolute;
+  top: 6px;
+  left: 0px;
+  right: 0px;
+  padding: 10px 0;
+  margin: 0;
+  list-style: none;
+  background-color: #fff;
+  border-radius: ${lengths.borderRadius};
+  border: 1px solid ${colors.textFieldBorder};
+  z-index: ${zIndex.zIndex1};
+`;
+
+const SuggestionHeader = styled.li`
+  padding: 0px 6px 6px 32px;
+  font-size: 12px;
+  color: ${colors.text};
+`;
+
+const SuggestionItem = styled.li(
+  ({ isActive }) => `
+  color: ${isActive ? colors.active : colorsRaw.grayDark};
+  background-color: ${isActive ? colors.activeBackground : 'inherit'};
+  padding: 6px 6px 6px 32px;
+  cursor: pointer;
+  position: relative;
+  
+  &:hover {
+    color: ${colors.active};
+    background-color: ${colors.activeBackground};
+  }
+`,
+);
+
+const SuggestionDivider = styled.div`
+  width: 100%;
+`;
+
+class CollectionSearch extends React.Component {
+  static propTypes = {
+    collections: ImmutablePropTypes.orderedMap.isRequired,
+    collection: ImmutablePropTypes.map,
+    searchTerm: PropTypes.string.isRequired,
+    onSubmit: PropTypes.func.isRequired,
+    t: PropTypes.func.isRequired,
+  };
+
+  state = {
+    query: this.props.searchTerm,
+    suggestionsVisible: false,
+    // default to the currently selected
+    selectedCollectionIdx: this.props.collection
+      ? this.props.collections.keySeq().indexOf(this.props.collection.get('name'))
+      : -1,
+  };
+
+  componentDidUpdate(prevProps) {
+    if (prevProps.collection !== this.props.collection) {
+      const selectedCollectionIdx = this.props.collection
+        ? this.props.collections.keySeq().indexOf(this.props.collection.get('name'))
+        : -1;
+      this.setState({ selectedCollectionIdx });
+    }
+  }
+
+  toggleSuggestions(visible) {
+    this.setState({ suggestionsVisible: visible });
+  }
+
+  selectNextSuggestion() {
+    const { collections } = this.props;
+    const { selectedCollectionIdx } = this.state;
+    this.setState({
+      selectedCollectionIdx: Math.min(selectedCollectionIdx + 1, collections.size - 1),
+    });
+  }
+
+  selectPreviousSuggestion() {
+    const { selectedCollectionIdx } = this.state;
+    this.setState({
+      selectedCollectionIdx: Math.max(selectedCollectionIdx - 1, -1),
+    });
+  }
+
+  resetSelectedSuggestion() {
+    this.setState({
+      selectedCollectionIdx: -1,
+    });
+  }
+
+  submitSearch = () => {
+    const { onSubmit, collections } = this.props;
+    const { selectedCollectionIdx, query } = this.state;
+
+    this.toggleSuggestions(false);
+    if (selectedCollectionIdx !== -1) {
+      onSubmit(query, collections.toIndexedSeq().getIn([selectedCollectionIdx, 'name']));
+    } else {
+      onSubmit(query);
+    }
+  };
+
+  handleKeyDown = event => {
+    const { suggestionsVisible } = this.state;
+
+    if (event.key === 'Enter') {
+      this.submitSearch();
+    }
+
+    if (suggestionsVisible) {
+      // allow closing of suggestions with escape key
+      if (event.key === 'Escape') {
+        this.toggleSuggestions(false);
+      }
+
+      if (event.key === 'ArrowDown') {
+        this.selectNextSuggestion();
+        event.preventDefault();
+      } else if (event.key === 'ArrowUp') {
+        this.selectPreviousSuggestion();
+        event.preventDefault();
+      }
+    }
+  };
+
+  handleQueryChange = query => {
+    this.setState({ query });
+    this.toggleSuggestions(query !== '');
+    if (query === '') {
+      this.resetSelectedSuggestion();
+    }
+  };
+
+  handleSuggestionClick = (event, idx) => {
+    this.setState({ selectedCollectionIdx: idx }, this.submitSearch);
+    event.preventDefault();
+  };
+
+  render() {
+    const { collections, t } = this.props;
+    const { suggestionsVisible, selectedCollectionIdx, query } = this.state;
+    return (
+      <SearchContainer
+        onBlur={() => this.toggleSuggestions(false)}
+        onFocus={() => this.toggleSuggestions(query !== '')}
+      >
+        <InputContainer>
+          <Icon type="search" />
+          <SearchInput
+            onChange={e => this.handleQueryChange(e.target.value)}
+            onKeyDown={this.handleKeyDown}
+            onClick={() => this.toggleSuggestions(true)}
+            placeholder={t('collection.sidebar.searchAll')}
+            value={query}
+          />
+        </InputContainer>
+        {suggestionsVisible && (
+          <SuggestionsContainer>
+            <Suggestions>
+              <SuggestionHeader>{t('collection.sidebar.searchIn')}</SuggestionHeader>
+              <SuggestionItem
+                isActive={selectedCollectionIdx === -1}
+                onClick={e => this.handleSuggestionClick(e, -1)}
+                onMouseDown={e => e.preventDefault()}
+              >
+                {t('collection.sidebar.allCollections')}
+              </SuggestionItem>
+              <SuggestionDivider />
+              {collections.toIndexedSeq().map((collection, idx) => (
+                <SuggestionItem
+                  key={idx}
+                  isActive={idx === selectedCollectionIdx}
+                  onClick={e => this.handleSuggestionClick(e, idx)}
+                  onMouseDown={e => e.preventDefault()}
+                >
+                  {collection.get('label')}
+                </SuggestionItem>
+              ))}
+            </Suggestions>
+          </SuggestionsContainer>
+        )}
+      </SearchContainer>
+    );
+  }
+}
+
+export default translate()(CollectionSearch);

--- a/packages/netlify-cms-core/src/components/Collection/Entries/EntryListing.js
+++ b/packages/netlify-cms-core/src/components/Collection/Entries/EntryListing.js
@@ -54,10 +54,11 @@ export default class EntryListing extends React.Component {
 
   renderCardsForMultipleCollections = () => {
     const { collections, entries } = this.props;
+    const isSingleCollectionInList = collections.size === 1;
     return entries.map((entry, idx) => {
       const collectionName = entry.get('collection');
       const collection = collections.find(coll => coll.get('name') === collectionName);
-      const collectionLabel = collection.get('label');
+      const collectionLabel = !isSingleCollectionInList && collection.get('label');
       const inferedFields = this.inferFields(collection);
       const entryCardProps = { collection, entry, inferedFields, collectionLabel };
       return <EntryCard {...entryCardProps} key={idx} />;

--- a/packages/netlify-cms-core/src/components/Collection/Sidebar.js
+++ b/packages/netlify-cms-core/src/components/Collection/Sidebar.js
@@ -67,7 +67,7 @@ const SidebarNavLink = styled(NavLink)`
 class Sidebar extends React.Component {
   static propTypes = {
     collections: ImmutablePropTypes.orderedMap.isRequired,
-    collection: ImmutablePropTypes.map.isRequired,
+    collection: ImmutablePropTypes.map,
     searchTerm: PropTypes.string,
     t: PropTypes.func.isRequired,
   };

--- a/packages/netlify-cms-core/src/components/Collection/Sidebar.js
+++ b/packages/netlify-cms-core/src/components/Collection/Sidebar.js
@@ -5,8 +5,9 @@ import styled from '@emotion/styled';
 import { css } from '@emotion/core';
 import { translate } from 'react-polyglot';
 import { NavLink } from 'react-router-dom';
-import { Icon, components, colors, colorsRaw, lengths, zIndex } from 'netlify-cms-ui-default';
+import { Icon, components, colors } from 'netlify-cms-ui-default';
 import { searchCollections } from 'Actions/collections';
+import CollectionSearch from './CollectionSearch';
 
 const styles = {
   sidebarNavLinkActive: css`
@@ -22,7 +23,8 @@ const SidebarContainer = styled.aside`
   padding: 8px 0 12px;
   position: fixed;
   max-height: calc(100vh - 112px);
-  overflow: auto;
+  display: flex;
+  flex-direction: column;
 `;
 
 const SidebarHeading = styled.h2`
@@ -33,42 +35,10 @@ const SidebarHeading = styled.h2`
   color: ${colors.textLead};
 `;
 
-const SearchContainer = styled.div`
-  display: flex;
-  align-items: center;
-  margin: 0 12px;
-  position: relative;
-
-  ${Icon} {
-    position: absolute;
-    top: 0;
-    left: 6px;
-    z-index: ${zIndex.zIndex2};
-    height: 100%;
-    display: flex;
-    align-items: center;
-    pointer-events: none;
-  }
-`;
-
-const SearchInput = styled.input`
-  background-color: #eff0f4;
-  border-radius: ${lengths.borderRadius};
-  font-size: 14px;
-  padding: 10px 6px 10px 32px;
-  width: 100%;
-  position: relative;
-  z-index: ${zIndex.zIndex1};
-
-  &:focus {
-    outline: none;
-    box-shadow: inset 0 0 0 2px ${colorsRaw.blue};
-  }
-`;
-
 const SidebarNavList = styled.ul`
   margin: 16px 0 0;
   list-style: none;
+  overflow: auto;
 `;
 
 const SidebarNavLink = styled(NavLink)`
@@ -78,6 +48,7 @@ const SidebarNavLink = styled(NavLink)`
   align-items: center;
   padding: 8px 12px;
   border-left: 2px solid #fff;
+  z-index: -1;
 
   ${Icon} {
     margin-right: 8px;
@@ -96,6 +67,7 @@ const SidebarNavLink = styled(NavLink)`
 class Sidebar extends React.Component {
   static propTypes = {
     collections: ImmutablePropTypes.orderedMap.isRequired,
+    collection: ImmutablePropTypes.map.isRequired,
     searchTerm: PropTypes.string,
     t: PropTypes.func.isRequired,
   };
@@ -103,8 +75,6 @@ class Sidebar extends React.Component {
   static defaultProps = {
     searchTerm: '',
   };
-
-  state = { query: this.props.searchTerm };
 
   renderLink = collection => {
     const collectionName = collection.get('name');
@@ -119,21 +89,16 @@ class Sidebar extends React.Component {
   };
 
   render() {
-    const { collections, t } = this.props;
-    const { query } = this.state;
-
+    const { collections, collection, searchTerm, t } = this.props;
     return (
       <SidebarContainer>
         <SidebarHeading>{t('collection.sidebar.collections')}</SidebarHeading>
-        <SearchContainer>
-          <Icon type="search" size="small" />
-          <SearchInput
-            onChange={e => this.setState({ query: e.target.value })}
-            onKeyDown={e => e.key === 'Enter' && searchCollections(query)}
-            placeholder={t('collection.sidebar.searchAll')}
-            value={query}
-          />
-        </SearchContainer>
+        <CollectionSearch
+          searchTerm={searchTerm}
+          collections={collections}
+          collection={collection}
+          onSubmit={(query, collection) => searchCollections(query, collection)}
+        />
         <SidebarNavList>
           {collections
             .toList()

--- a/packages/netlify-cms-core/src/reducers/index.ts
+++ b/packages/netlify-cms-core/src/reducers/index.ts
@@ -44,13 +44,14 @@ export const selectEntries = (state: State, collection: string) =>
 export const selectPublishedSlugs = (state: State, collection: string) =>
   fromEntries.selectPublishedSlugs(state.entries, collection);
 
-export const selectSearchedEntries = (state: State) => {
+export const selectSearchedEntries = (state: State, availableCollections: string[]) => {
   const searchItems = state.search.get('entryIds');
+  // only return search results for actually available collections
   return (
     searchItems &&
-    searchItems.map(({ collection, slug }) =>
-      fromEntries.selectEntry(state.entries, collection, slug),
-    )
+    searchItems
+      .filter(({ collection }) => availableCollections.indexOf(collection) !== -1)
+      .map(({ collection, slug }) => fromEntries.selectEntry(state.entries, collection, slug))
   );
 };
 

--- a/packages/netlify-cms-core/src/reducers/search.js
+++ b/packages/netlify-cms-core/src/reducers/search.js
@@ -12,10 +12,12 @@ let loadedEntries;
 let response;
 let page;
 let searchTerm;
+let searchCollections;
 
 const defaultState = Map({
   isFetching: false,
   term: null,
+  collections: null,
   page: 0,
   entryIds: List([]),
   queryHits: Map({}),
@@ -31,6 +33,7 @@ const entries = (state = defaultState, action) => {
         return state.withMutations(map => {
           map.set('isFetching', true);
           map.set('term', action.payload.searchTerm);
+          map.set('collections', List(action.payload.searchCollections));
           map.set('page', action.payload.page);
         });
       }
@@ -40,6 +43,7 @@ const entries = (state = defaultState, action) => {
       loadedEntries = action.payload.entries;
       page = action.payload.page;
       searchTerm = action.payload.searchTerm;
+      searchCollections = action.payload.searchCollections;
       return state.withMutations(map => {
         const entryIds = List(
           loadedEntries.map(entry => ({ collection: entry.collection, slug: entry.slug })),
@@ -48,6 +52,7 @@ const entries = (state = defaultState, action) => {
         map.set('fetchID', null);
         map.set('page', page);
         map.set('term', searchTerm);
+        map.set('collections', List(searchCollections));
         map.set(
           'entryIds',
           !page || isNaN(page) || page === 0

--- a/packages/netlify-cms-core/src/types/redux.ts
+++ b/packages/netlify-cms-core/src/types/redux.ts
@@ -222,6 +222,7 @@ export type Search = StaticallyTypedRecord<{
   entryIds?: SearchItem[];
   isFetching: boolean;
   term: string | null;
+  collections: List<string> | null;
   page: number;
 }>;
 

--- a/packages/netlify-cms-locales/src/de/index.js
+++ b/packages/netlify-cms-locales/src/de/index.js
@@ -39,8 +39,13 @@ const de = {
       searchIn: 'Suchen in',
     },
     collectionTop: {
+      sortBy: 'Sortieren nach',
       viewAs: 'Anzeigen als',
       newButton: 'Neue(r) %{collectionLabel}',
+      ascending: 'Aufsteigend',
+      descending: 'Absteigend',
+      searchResults: 'Suchergebnisse für "%{searchTerm}"',
+      searchResultsInCollection: 'Suchergebnisse für "%{searchTerm}" in %{collection}',
     },
     entries: {
       loadingEntries: 'Beiträge laden',

--- a/packages/netlify-cms-locales/src/de/index.js
+++ b/packages/netlify-cms-locales/src/de/index.js
@@ -34,7 +34,9 @@ const de = {
   collection: {
     sidebar: {
       collections: 'Inhaltstypen',
+      allCollections: 'Allen Inhaltstypen',
       searchAll: 'Alles durchsuchen',
+      searchIn: 'Suchen in',
     },
     collectionTop: {
       viewAs: 'Anzeigen als',

--- a/packages/netlify-cms-locales/src/en/index.js
+++ b/packages/netlify-cms-locales/src/en/index.js
@@ -34,7 +34,9 @@ const en = {
   collection: {
     sidebar: {
       collections: 'Collections',
+      allCollections: 'All Collections',
       searchAll: 'Search all',
+      searchIn: 'Search in',
     },
     collectionTop: {
       sortBy: 'Sort by',

--- a/packages/netlify-cms-locales/src/en/index.js
+++ b/packages/netlify-cms-locales/src/en/index.js
@@ -44,6 +44,8 @@ const en = {
       newButton: 'New %{collectionLabel}',
       ascending: 'Ascending',
       descending: 'Descending',
+      searchResults: 'Search Results for "%{searchTerm}"',
+      searchResultsInCollection: 'Search Results for "%{searchTerm}" in %{collection}',
     },
     entries: {
       loadingEntries: 'Loading Entries...',


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines.

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first two fields are mandatory:
-->

Closes #3756

**Summary**
This is a direct follow up of my feature request in #3756. 
It turned out it was quite easy to implement.

This PR adds a "suggestion" box (for lack of a better term) that suggests all collections that can be searched. The collections are listed under "Search in" together with an "All Collections" item. The selection in the suggestion box can be navigated with the arrow up and down keys. The currently selected option in the suggestion box is used when the search is submitted or an option is clicked by the user. It's basically how GitHubs search bar works.

The box opens up when the search field is focused for the first time and starts with the current collection selected by default. This changes the default search behavior since now we only search in the current collection and not over all collections with the interaction _type search term_ -> _press "enter"_. This behavior can be achieved by typing the search term and clicking "All Collections".

The suggestion box is closed by unfocusing the search field or pressing the escape key.

It also adds a new `/collection/:name/search/:searchTerm` route that only searches the search term in a specific collection using newly introduces parameters in the redux search action.


![image](https://user-images.githubusercontent.com/4376726/81990675-e823fc80-963f-11ea-81ec-42e4cdae47a5.png)

Things that I would love feedback on: 
- Does it feel natural as to what the default selection is and the showing / hiding of the box?
- Should we give users the possibility to disable the suggestion box?

<!--
Explain the **motivation** for making this change.
What existing problem does the pull request solve?
-->

**Test plan**

<!--
Demonstrate the code is solid.
Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.
-->
Since now a unique search is identified by a search term and search collections I modified and extended the current search unit tests. Now they specifically target different combinations of search terms and collections. Let me know if I should do more in this area.