### PR TITLE
renaming and reorg of the navigation

### DIFF
--- a/website/content/docs/add-to-your-site.md
+++ b/website/content/docs/add-to-your-site.md
@@ -1,7 +1,7 @@
 ---
 title: Add to Your Site
 weight: 20
-group: start
+group: intro
 ---
 
 You can adapt Netlify CMS to a wide variety of projects. It works with any content written in markdown, JSON, YAML, or TOML files, stored in a repo on [GitHub](https://github.com/), [GitLab](https://about.gitlab.com/), or [Bitbucket](https://bitbucket.org). You can also create your own custom backend.

--- a/website/content/docs/backends-overview.md
+++ b/website/content/docs/backends-overview.md
@@ -1,7 +1,7 @@
 ---
 title: Overview
 weight: 1
-group: backends
+group: account
 ---
 
 A backend is JavaScript code that allows Netlify CMS to communicate with a service that stores content - typically a Git host like GitHub or GitLab. It provides functions that Netlify CMS can use to do things like read and update files using API's provided by the service.

--- a/website/content/docs/beta-features.md
+++ b/website/content/docs/beta-features.md
@@ -1,7 +1,7 @@
 ---
 title: Beta Features!
 weight: 200
-group: reference
+group: config
 ---
 
 We run new functionality in an open beta format from time to time. That means that this functionality is totally available for use, and we _think_ it might be ready for primetime, but it could break or change without notice.

--- a/website/content/docs/bitbucket-backend.md
+++ b/website/content/docs/bitbucket-backend.md
@@ -1,7 +1,7 @@
 ---
 title: Bitbucket
 weight: 20
-group: backends
+group: account
 ---
 
 For repositories stored on Bitbucket, the `bitbucket` backend allows CMS users to log in directly with their Bitbucket account. Note that all users must have write access to your content repository for this to work.

--- a/website/content/docs/collection-types.md
+++ b/website/content/docs/collection-types.md
@@ -1,6 +1,6 @@
 ---
 title: Collection Types
-group: start
+group: intro
 weight: 27
 ---
 All editable content types are defined in the `collections` field of your `config.yml` file, and display in the left sidebar of the Content page of the editor UI.

--- a/website/content/docs/configuration-options.md
+++ b/website/content/docs/configuration-options.md
@@ -1,6 +1,6 @@
 ---
 title: Configuration Options
-group: reference
+group: config
 weight: 23
 ---
 

--- a/website/content/docs/custom-widgets.md
+++ b/website/content/docs/custom-widgets.md
@@ -1,7 +1,7 @@
 ---
 title: Creating Custom Widgets
 weight: 35
-group: customization
+group: customizing
 ---
 
 The NetlifyCMS exposes a `window.CMS` global object that you can use to register custom widgets, previews, and editor plugins. The same object is also the default export if you import Netify CMS as an npm module. The available widget extension methods are:

--- a/website/content/docs/customization.md
+++ b/website/content/docs/customization.md
@@ -1,7 +1,7 @@
 ---
 title: Creating Custom Previews
 weight: 50
-group: customization
+group: customizing
 ---
 
 The NetlifyCMS exposes a `window.CMS` global object that you can use to register custom widgets, previews and editor plugins. The available customization methods are:

--- a/website/content/docs/deploy-preview-links.md
+++ b/website/content/docs/deploy-preview-links.md
@@ -1,6 +1,6 @@
 ---
 title: Deploy Preview Links
-group: features
+group: workflow
 weight: 10
 ---
 

--- a/website/content/docs/examples.md
+++ b/website/content/docs/examples.md
@@ -1,6 +1,6 @@
 ---
 title: Examples
-group: start
+group: intro
 weight: 110
 ---
 

--- a/website/content/docs/external-oauth-clients.md
+++ b/website/content/docs/external-oauth-clients.md
@@ -1,7 +1,7 @@
 ---
 title: External OAuth Clients
 weight: 40
-group: backends
+group: account
 ---
 
 If you would like to facilitate your own OAuth authentication rather than use Netlify's service or implicit grant, you can use one of the community-maintained projects below. Feel free to hit the "Edit this page" button if you'd like to add yours!

--- a/website/content/docs/git-gateway-backend.md
+++ b/website/content/docs/git-gateway-backend.md
@@ -1,7 +1,7 @@
 ---
 title: Git Gateway
 weight: 10
-group: backends
+group: account
 ---
 
 [Git Gateway](https://github.com/netlify/git-gateway) is a Netlify open source project that allows you to add editors to your site CMS without giving them direct write access to your GitHub or GitLab repository. (For Bitbucket repositories, use the [Bitbucket backend](#bitbucket-backend) instead.)

--- a/website/content/docs/github-backend.md
+++ b/website/content/docs/github-backend.md
@@ -1,7 +1,7 @@
 ---
 title: GitHub
 weight: 20
-group: backends
+group: account
 ---
 
 For repositories stored on GitHub, the `github` backend allows CMS users to log in directly with their GitHub account. Note that all users must have push access to your content repository for this to work.

--- a/website/content/docs/gitlab-backend.md
+++ b/website/content/docs/gitlab-backend.md
@@ -1,7 +1,7 @@
 ---
 title: GitLab
 weight: 20
-group: backends
+group: account
 ---
 
 For repositories stored on GitLab, the `gitlab` backend allows CMS users to log in directly with their GitLab account. Note that all users must have push access to your content repository for this to work.

--- a/website/content/docs/intro.md
+++ b/website/content/docs/intro.md
@@ -1,7 +1,7 @@
 ---
 title: Introduction
 weight: 1
-group: start
+group: intro
 ---
 
 Netlify CMS is an open source content management system for your Git workflow that enables you to provide editors with a friendly UI and intuitive workflows. You can use it with any static site generator to create faster, more flexible web projects. Content is stored in your Git repository alongside your code for easier versioning, multi-channel publishing, and the option to handle content updates directly in Git.

--- a/website/content/docs/open-authoring.md
+++ b/website/content/docs/open-authoring.md
@@ -1,6 +1,6 @@
 ---
 title: Open Authoring
-group: features
+group: workflow
 ---
 
 **This is a [beta feature](/docs/beta-features#open-authoring).**

--- a/website/content/docs/start-with-a-template.md
+++ b/website/content/docs/start-with-a-template.md
@@ -1,6 +1,6 @@
 ---
 title: Start with a Template
-group: start
+group: intro
 weight: 10
 ---
 You can add Netlify CMS [to an existing site](/docs/add-to-your-site/), but the quickest way to get started is with a template.  Found below, our featured templates deploy a bare-bones site and Netlify CMS to Netlify ([what's the difference, you ask?](../intro/#netlify-cms-vs-netlify)), giving you a fully working CMS-enabled site with just a few clicks.

--- a/website/content/docs/test-backend.md
+++ b/website/content/docs/test-backend.md
@@ -1,7 +1,7 @@
 ---
 title: Test
 weight: 30
-group: backends
+group: account
 ---
 
 You can use the `test-repo` backend to try out Netlify CMS without connecting to a Git repo. With this backend, you can write and publish content normally, but any changes will disappear when you reload the page. This backend powers the Netlify CMS [demo site](https://cms-demo.netlify.com/).

--- a/website/content/docs/update-the-cms-version.md
+++ b/website/content/docs/update-the-cms-version.md
@@ -1,7 +1,7 @@
 ---
 title: Update the CMS Version
 weight: 60
-group: start
+group: intro
 ---
 
 The update procedure for your CMS depends upon the method you used to install Netlify CMS.

--- a/website/content/docs/widgets.md
+++ b/website/content/docs/widgets.md
@@ -1,7 +1,7 @@
 ---
 title: Widgets
 weight: 30
-group: reference
+group: fields
 ---
 
 Widgets define the data type and interface for entry fields. Netlify CMS comes with several built-in widgets. Click the widget names in the sidebar to jump to specific widget details. We’re always adding new widgets, and you can also [create your own](../custom-widgets)!

--- a/website/content/docs/widgets/boolean.md
+++ b/website/content/docs/widgets/boolean.md
@@ -1,6 +1,7 @@
 ---
 title: boolean
 label: "Boolean"
+group: fields
 ---
 
 The boolean widget translates a toggle switch input to a true/false value.

--- a/website/content/docs/widgets/code.md
+++ b/website/content/docs/widgets/code.md
@@ -1,6 +1,7 @@
 ---
 title: code
 label: 'Code'
+group: fields
 ---
 
 The code widget provides a code editor (powered by [Codemirror](https://codemirror.net)) with optional syntax awareness. Can output the raw code value or an object with the selected language and the raw code value.

--- a/website/site.yml
+++ b/website/site.yml
@@ -1,15 +1,17 @@
 menu:
   docs:
-    - name: start
-      title: Quick Start
-    - name: backends
-      title: Backends
-    - name: features
-      title: Features
-    - name: reference
-      title: Reference
+    - name: intro
+      title: Intro to Netlify CMS
+    - name: account
+      title: Account Settings
+    - name: config
+      title: Configuring your Site
     - name: media
       title: Media
+    - name: workflow
+      title: Workflow
+    - name: fields
+      title: Fields
     - name: guides
       title: Guides
     - name: customization


### PR DESCRIPTION
via https://github.com/netlify/netlify-cms/issues/3764

---

a proposal for reorganizing the navigation on the NetlifyCMS docs site. The goal is to make it easier for users to find the guidance they need.
