### PR TITLE
feat: reorganizing the NetlifyCMS Docs navigation

### DIFF
--- a/website/content/docs/add-to-your-site.md
+++ b/website/content/docs/add-to-your-site.md
@@ -1,7 +1,7 @@
 ---
 title: Add to Your Site
 weight: 20
-group: start
+group: intro
 ---
 
 You can adapt Netlify CMS to a wide variety of projects. It works with any content written in markdown, JSON, YAML, or TOML files, stored in a repo on [GitHub](https://github.com/), [GitLab](https://about.gitlab.com/), or [Bitbucket](https://bitbucket.org). You can also create your own custom backend.

--- a/website/content/docs/backends-overview.md
+++ b/website/content/docs/backends-overview.md
@@ -1,7 +1,7 @@
 ---
 title: Overview
 weight: 1
-group: backends
+group: accounts
 ---
 
 A backend is JavaScript code that allows Netlify CMS to communicate with a service that stores content - typically a Git host like GitHub or GitLab. It provides functions that Netlify CMS can use to do things like read and update files using API's provided by the service.

--- a/website/content/docs/beta-features.md
+++ b/website/content/docs/beta-features.md
@@ -1,7 +1,7 @@
 ---
 title: Beta Features!
 weight: 200
-group: config
+group: configuration
 ---
 
 We run new functionality in an open beta format from time to time. That means that this functionality is totally available for use, and we _think_ it might be ready for primetime, but it could break or change without notice.

--- a/website/content/docs/beta-features.md
+++ b/website/content/docs/beta-features.md
@@ -1,7 +1,7 @@
 ---
 title: Beta Features!
 weight: 200
-group: reference
+group: config
 ---
 
 We run new functionality in an open beta format from time to time. That means that this functionality is totally available for use, and we _think_ it might be ready for primetime, but it could break or change without notice.

--- a/website/content/docs/bitbucket-backend.md
+++ b/website/content/docs/bitbucket-backend.md
@@ -1,7 +1,7 @@
 ---
 title: Bitbucket
-group: backends
 weight: 20
+group: accounts
 ---
 For repositories stored on Bitbucket, the `bitbucket` backend allows CMS users to log in directly with their Bitbucket account. Note that all users must have write access to your content repository for this to work.
 

--- a/website/content/docs/collection-types.md
+++ b/website/content/docs/collection-types.md
@@ -1,6 +1,6 @@
 ---
 title: Collection Types
-group: start
+group: intro
 weight: 27
 ---
 All editable content types are defined in the `collections` field of your `config.yml` file, and display in the left sidebar of the Content page of the editor UI.

--- a/website/content/docs/collection-types.md
+++ b/website/content/docs/collection-types.md
@@ -1,7 +1,8 @@
 ---
 title: Collection Types
-group: intro
+group: collections
 weight: 27
+
 ---
 All editable content types are defined in the `collections` field of your `config.yml` file, and display in the left sidebar of the Content page of the editor UI.
 

--- a/website/content/docs/configuration-options.md
+++ b/website/content/docs/configuration-options.md
@@ -1,6 +1,6 @@
 ---
 title: Configuration Options
-group: config
+group: configuration
 weight: 23
 ---
 

--- a/website/content/docs/configuration-options.md
+++ b/website/content/docs/configuration-options.md
@@ -1,6 +1,6 @@
 ---
 title: Configuration Options
-group: reference
+group: config
 weight: 23
 ---
 

--- a/website/content/docs/custom-widgets.md
+++ b/website/content/docs/custom-widgets.md
@@ -1,7 +1,7 @@
 ---
 title: Creating Custom Widgets
 weight: 35
-group: customization
+group: fields
 ---
 
 The NetlifyCMS exposes a `window.CMS` global object that you can use to register custom widgets, previews, and editor plugins. The same object is also the default export if you import Netify CMS as an npm module. The available widget extension methods are:

--- a/website/content/docs/deploy-preview-links.md
+++ b/website/content/docs/deploy-preview-links.md
@@ -1,6 +1,6 @@
 ---
 title: Deploy Preview Links
-group: features
+group: workflow
 weight: 10
 ---
 When using the editorial workflow, content editors can create and save content without publishing it

--- a/website/content/docs/examples.md
+++ b/website/content/docs/examples.md
@@ -1,6 +1,6 @@
 ---
 title: Examples
-group: start
+group: intro
 weight: 110
 ---
 

--- a/website/content/docs/examples.md
+++ b/website/content/docs/examples.md
@@ -1,7 +1,8 @@
 ---
 title: Examples
-group: intro
+group: contributing
 weight: 110
+
 ---
 
 Do you have a great, open source example? Submit a pull request to this page!

--- a/website/content/docs/external-oauth-clients.md
+++ b/website/content/docs/external-oauth-clients.md
@@ -1,7 +1,7 @@
 ---
 title: External OAuth Clients
 weight: 40
-group: backends
+group: accounts
 ---
 
 If you would like to facilitate your own OAuth authentication rather than use Netlify's service or implicit grant, you can use one of the community-maintained projects below. Feel free to hit the "Edit this page" button if you'd like to add yours!

--- a/website/content/docs/git-gateway-backend.md
+++ b/website/content/docs/git-gateway-backend.md
@@ -1,7 +1,7 @@
 ---
 title: Git Gateway
 weight: 10
-group: backends
+group: accounts
 ---
 
 [Git Gateway](https://github.com/netlify/git-gateway) is a Netlify open source project that allows you to add editors to your site CMS without giving them direct write access to your GitHub or GitLab repository. (For Bitbucket repositories, use the [Bitbucket backend](#bitbucket-backend) instead.)

--- a/website/content/docs/github-backend.md
+++ b/website/content/docs/github-backend.md
@@ -1,7 +1,7 @@
 ---
 title: GitHub
 weight: 20
-group: backends
+group: accounts
 ---
 
 For repositories stored on GitHub, the `github` backend allows CMS users to log in directly with their GitHub account. Note that all users must have push access to your content repository for this to work.

--- a/website/content/docs/gitlab-backend.md
+++ b/website/content/docs/gitlab-backend.md
@@ -1,7 +1,7 @@
 ---
 title: GitLab
-group: backends
 weight: 20
+group: accounts
 ---
 For repositories stored on GitLab, the `gitlab` backend allows CMS users to log in directly with their GitLab account. Note that all users must have push access to your content repository for this to work.
 

--- a/website/content/docs/intro.md
+++ b/website/content/docs/intro.md
@@ -29,7 +29,7 @@ With this in mind, you can:
 
 If you hook up Netlify CMS to your website, you're basically adding a tool for content editors to make commits to your site repository without touching code or learning Git.
 
-## Find out more
+### Find out more
 
 - Get a feel for the UI in the [demo site](https://cms-demo.netlify.com). (No login required. Click the login button to go straight to the CMS editor UI.)
 - [Start with a template](../start-with-a-template/) to make a Netlify CMS-enabled site of your own.

--- a/website/content/docs/intro.md
+++ b/website/content/docs/intro.md
@@ -1,7 +1,7 @@
 ---
-title: Introduction
+title: Overview
 weight: 1
-group: start
+group: intro
 ---
 
 Netlify CMS is an open source content management system for your Git workflow that enables you to provide editors with a friendly UI and intuitive workflows. You can use it with any static site generator to create faster, more flexible web projects. Content is stored in your Git repository alongside your code for easier versioning, multi-channel publishing, and the option to handle content updates directly in Git.

--- a/website/content/docs/open-authoring.md
+++ b/website/content/docs/open-authoring.md
@@ -1,6 +1,6 @@
 ---
 title: Open Authoring
-group: features
+group: workflow
 ---
 
 **This is a [beta feature](/docs/beta-features#open-authoring).**

--- a/website/content/docs/releases.md
+++ b/website/content/docs/releases.md
@@ -19,11 +19,11 @@ If you are using a package manager like Yarn or NPM, use their standard procedur
 If you are using the CMS through a CDN like Unpkg, then that depends on the version tag you are using. You can find the version tag in the `/admin/index.html` file of your site.
 
 - (Recommended) If you use `^2.0.0`, the CMS does all updates except major versions automatically.
-   - It upgrades to `2.0.1`, `2.1.0`, `2.1.2`.
-   - It does not upgrade to `3.0.0` or higher.
-   - It does not upgrade to beta versions.
+  - It upgrades to `2.0.1`, `2.1.0`, `2.1.2`.
+  - It does not upgrade to `3.0.0` or higher.
+  - It does not upgrade to beta versions.
 
 - If you use `~2.0.0`, the CMS will do only patch updates automatically.
-   - It upgrades `2.0.1`, `2.0.2`.
-   - It does not upgrade to `2.1.0` or higher.
-   - It does not upgrade beta versions.
+  - It upgrades `2.0.1`, `2.0.2`.
+  - It does not upgrade to `2.1.0` or higher.
+  - It does not upgrade beta versions.

--- a/website/content/docs/start-with-a-template.md
+++ b/website/content/docs/start-with-a-template.md
@@ -1,6 +1,6 @@
 ---
 title: Start with a Template
-group: start
+group: intro
 weight: 10
 ---
 You can add Netlify CMS [to an existing site](/docs/add-to-your-site/), but the quickest way to get started is with a template.  Found below, our featured templates deploy a bare-bones site and Netlify CMS to Netlify ([what's the difference, you ask?](../intro/#netlify-cms-vs-netlify)), giving you a fully working CMS-enabled site with just a few clicks.

--- a/website/content/docs/test-backend.md
+++ b/website/content/docs/test-backend.md
@@ -1,7 +1,8 @@
 ---
 title: Test
 weight: 30
-group: backends
+group: accounts
+
 ---
 
 You can use the `test-repo` backend to try out Netlify CMS without connecting to a Git repo. With this backend, you can write and publish content normally, but any changes will disappear when you reload the page. This backend powers the Netlify CMS [demo site](https://cms-demo.netlify.com/).

--- a/website/content/docs/update-the-cms-version.md
+++ b/website/content/docs/update-the-cms-version.md
@@ -1,16 +1,20 @@
 ---
-title: Update the CMS Version
+title: Releases
 weight: 60
 group: intro
 ---
 
+
+
+## Update the CMS Version
+
 The update procedure for your CMS depends upon the method you used to install Netlify CMS.
 
-## Package Manager
+### Package Manager
 
 If you are using a package manager like Yarn or NPM, use their standard procedure to update. This is how both the Hugo and Gatsby starters are set up.
 
-## CDN
+### CDN
 
 If you are using the CMS through a CDN like Unpkg, then that depends on the version tag you are using. You can find the version tag in the `/admin/index.html` file of your site.
 

--- a/website/content/docs/update-the-cms-version.md
+++ b/website/content/docs/update-the-cms-version.md
@@ -1,7 +1,7 @@
 ---
 title: Update the CMS Version
 weight: 60
-group: start
+group: intro
 ---
 
 The update procedure for your CMS depends upon the method you used to install Netlify CMS.

--- a/website/content/docs/widgets.md
+++ b/website/content/docs/widgets.md
@@ -1,7 +1,7 @@
 ---
 title: Widgets
 weight: 30
-group: reference
+group: fields
 ---
 
 Widgets define the data type and interface for entry fields. Netlify CMS comes with several built-in widgets. Click the widget names in the sidebar to jump to specific widget details. We’re always adding new widgets, and you can also [create your own](../custom-widgets)!

--- a/website/site.yml
+++ b/website/site.yml
@@ -4,7 +4,7 @@ menu:
       title: Intro to Netlify CMS
     - name: accounts
       title: Account Settings
-    - name: config
+    - name: configuration
       title: Configuring your Site
     - name: media
       title: Media

--- a/website/site.yml
+++ b/website/site.yml
@@ -1,18 +1,22 @@
 menu:
   docs:
-    - name: start
-      title: Quick Start
-    - name: backends
-      title: Backends
-    - name: features
-      title: Features
-    - name: reference
-      title: Reference
+    - name: intro
+      title: Intro to Netlify CMS
+    - name: accounts
+      title: Account Settings
+    - name: config
+      title: Configuring your Site
     - name: media
       title: Media
+    - name: workflow
+      title: Workflow
+    - name: collections
+      title: Collections
+    - name: fields
+      title: Fields
     - name: guides
-      title: Guides
+      title: Platform Guides
     - name: customization
-      title: Customization
+      title: Customizing Netlify CMS
     - name: contributing
-      title: Contributing
+      title: Community

--- a/website/static/_redirects
+++ b/website/static/_redirects
@@ -7,3 +7,4 @@
 /docs/test-drive                        /docs/start-with-a-template 301
 /docs/quick-start                       /docs/add-to-your-site 301
 /chat                                   https://join.slack.com/t/netlifycms/shared_invite/enQtODE1NTcxODA5Mjg1LTRjYWExM2MyZDJmODA3YmVkMjI2YmQwZDg2ZDUyYTMyM2Y3Zjc1ZTJhNDBkYmMwNjA2ZTkwODY4YjZjNGNlNTE 301
+/docs/update-the-cms-version            /docs/releases 301


### PR DESCRIPTION
Starting in on https://github.com/netlify/netlify-cms/issues/3764
> A proposal for reorganizing the navigation on the NetlifyCMS docs site. The goal is to make it easier for users to find the guidance they need.


