### PR TITLE
chore: disable labeler on forked PRs

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -5,6 +5,7 @@ on:
 
 jobs:
   label-pr:
+    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false
     runs-on: ubuntu-latest
     steps:
       - uses: erezrokah/pr-labeler-action@v1.0.0


### PR DESCRIPTION
See https://github.com/netlify/netlify-cms/runs/690718297?check_suite_focus=true#step:4:1
The PR labeler fails on forked PRs (makes sense due to permissions issues)