### PR TITLE
feat: allow author login/name to work in commit message templates #3793

### DIFF
--- a/packages/netlify-cms-core/src/lib/__tests__/formatters.spec.js
+++ b/packages/netlify-cms-core/src/lib/__tests__/formatters.spec.js
@@ -116,13 +116,13 @@ describe('formatters', () => {
     it('should use empty values if "authorLogin" and "authorName" are missing in commit message', () => {
       config.getIn.mockReturnValueOnce(
         Map({
-          update: '{{author-login}} - {{author-name}}: {{message}}',
+          update: '{{author-login}} - {{author-name}}: Create {{collection}} “{{slug}}”',
         }),
       );
 
       expect(
         commitMessageFormatter(
-          'create',
+          'update',
           config,
           {
             slug: 'doc-slug',
@@ -137,7 +137,7 @@ describe('formatters', () => {
     it('should return custom update message with author information', () => {
       config.getIn.mockReturnValueOnce(
         Map({
-          update: '{{author-login}} - {{author-name}}: {{message}}',
+          create: '{{author-login}} - {{author-name}}: Create {{collection}} “{{slug}}”',
         }),
       );
 

--- a/packages/netlify-cms-core/src/lib/__tests__/formatters.spec.js
+++ b/packages/netlify-cms-core/src/lib/__tests__/formatters.spec.js
@@ -134,7 +134,7 @@ describe('formatters', () => {
       ).toEqual(' - : Create Collection “doc-slug”');
     });
 
-    it('should return custom update message with author information', () => {
+    it('should return custom create message with author information', () => {
       config.getIn.mockReturnValueOnce(
         Map({
           create: '{{author-login}} - {{author-name}}: Create {{collection}} “{{slug}}”',

--- a/packages/netlify-cms-core/src/lib/__tests__/formatters.spec.js
+++ b/packages/netlify-cms-core/src/lib/__tests__/formatters.spec.js
@@ -113,6 +113,50 @@ describe('formatters', () => {
       ).toEqual('Custom commit message');
     });
 
+    it('should use empty values if "authorLogin" and "authorName" are missing in commit message', () => {
+      config.getIn.mockReturnValueOnce(
+        Map({
+          update: '{{author-login}} - {{author-name}}: {{message}}',
+        }),
+      );
+
+      expect(
+        commitMessageFormatter(
+          'create',
+          config,
+          {
+            slug: 'doc-slug',
+            path: 'file-path',
+            collection,
+          },
+          true,
+        ),
+      ).toEqual(' - : Create Collection “doc-slug”');
+    });
+
+    it('should return custom update message with author information', () => {
+      config.getIn.mockReturnValueOnce(
+        Map({
+          update: '{{author-login}} - {{author-name}}: {{message}}',
+        }),
+      );
+
+      expect(
+        commitMessageFormatter(
+          'create',
+          config,
+          {
+            slug: 'doc-slug',
+            path: 'file-path',
+            collection,
+            authorLogin: 'user-login',
+            authorName: 'Test User',
+          },
+          true,
+        ),
+      ).toEqual('user-login - Test User: Create Collection “doc-slug”');
+    });
+
     it('should return custom open authoring message', () => {
       config.getIn.mockReturnValueOnce(
         Map({

--- a/packages/netlify-cms-core/src/lib/formatters.ts
+++ b/packages/netlify-cms-core/src/lib/formatters.ts
@@ -57,6 +57,10 @@ export const commitMessageFormatter = (
         return path || '';
       case 'collection':
         return collection ? collection.get('label_singular') || collection.get('label') : '';
+      case 'author-login':
+        return authorLogin || '';
+      case 'author-name':
+        return authorName || '';
       default:
         console.warn(`Ignoring unknown variable “${variable}” in commit message template.`);
         return '';

--- a/website/content/docs/beta-features.md
+++ b/website/content/docs/beta-features.md
@@ -349,14 +349,14 @@ backend:
 
 Netlify CMS generates the following commit types:
 
-| Commit type     | When is it triggered?                    | Available template tags                  |
-| --------------- | ---------------------------------------- | ---------------------------------------- |
-| `create`        | A new entry is created                   | `slug`, `path`, `collection`             |
-| `update`        | An existing entry is changed             | `slug`, `path`, `collection`             |
-| `delete`        | An exising entry is deleted              | `slug`, `path`, `collection`             |
-| `uploadMedia`   | A media file is uploaded                 | `path`                                   |
-| `deleteMedia`   | A media file is deleted                  | `path`                                   |
-| `openAuthoring` | A commit is made via a forked repository | `message`, `author-login`, `author-name` |
+| Commit type     | When is it triggered?                    | Available template tags                                     |
+| --------------- | ---------------------------------------- | ----------------------------------------------------------- |
+| `create`        | A new entry is created                   | `slug`, `path`, `collection`, `author-login`, `author-name` |
+| `update`        | An existing entry is changed             | `slug`, `path`, `collection`, `author-login`, `author-name` |
+| `delete`        | An exising entry is deleted              | `slug`, `path`, `collection`, `author-login`, `author-name` |
+| `uploadMedia`   | A media file is uploaded                 | `path`, `author-login`, `author-name`                       |
+| `deleteMedia`   | A media file is deleted                  | `path`, `author-login`, `author-name`                       |
+| `openAuthoring` | A commit is made via a forked repository | `message`, `author-login`, `author-name`                    |
 
 Template tags produce the following output:
 


### PR DESCRIPTION
**Summary**
Fixes https://github.com/netlify/netlify-cms/issues/3793

author-name and author-login are already passed to the template, so we might as well expose them to the commit messages even if openAuthoring is false.

**Test plan**

Existing tests pass.
