### PR TITLE
feat: pattern validation on input event

### DIFF
--- a/packages/netlify-cms-core/src/components/Editor/Editor.js
+++ b/packages/netlify-cms-core/src/components/Editor/Editor.js
@@ -214,6 +214,7 @@ export class Editor extends React.Component {
   handleChangeDraftField = (field, value, metadata) => {
     const entries = [this.props.unPublishedEntry, this.props.publishedEntry].filter(Boolean);
     this.props.changeDraftField(field, value, metadata, entries);
+    this.editorInterfaceRef.handleOnChange();
   };
 
   handleChangeStatus = newStatusName => {
@@ -431,6 +432,7 @@ export class Editor extends React.Component {
         onLogoutClick={logoutUser}
         deployPreview={deployPreview}
         loadDeployPreview={opts => loadDeployPreview(collection, slug, entry, isPublished, opts)}
+        ref={e => (this.editorInterfaceRef = e)}
       />
     );
   }

--- a/packages/netlify-cms-core/src/components/Editor/EditorInterface.js
+++ b/packages/netlify-cms-core/src/components/Editor/EditorInterface.js
@@ -132,6 +132,10 @@ class EditorInterface extends Component {
     this.setState({ showEventBlocker: false });
   };
 
+  handleOnChange = () => {
+    this.controlPaneRef.validate();
+  };
+
   handleOnPersist = (opts = {}) => {
     const { createNew = false, duplicate = false } = opts;
     this.controlPaneRef.validate();


### PR DESCRIPTION
Addresses #3744 

**Summary**
The validation of the `pattern` regexp eventually attached to a string field is currently triggered when the user save an entry. Instead, if `pattern` validation is triggered `onChange`, the UX would be enhanced and would help user to make necessary corrections to satisfy `pattern` prior to saving itself.

To create this functionality, `handleOnChange` function is created inside `EditorInterface` component.
`
handleOnChange = () => {
    this.controlPaneRef.validate();
};
`
Above function is called inside `handleChangeDraftField` function inside `Editor.js` file which is triggered when `onChange` is invoked.

**Test plan**
`yarn test` was run to verify all testcases passed.

**Non mandatory cute animal**
![kitten](https://user-images.githubusercontent.com/10570968/82820817-8164d580-9ec0-11ea-8e33-66a69a0a727c.jpg)
