### PR TITLE
chore: fix renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,5 @@
 {
   "extends": ["github>netlify/renovate-config:default"],
-  "semanticCommits": true
+  "ignorePresets": [":prHourlyLimit2"],
+  "semanticCommits": true,
 }


### PR DESCRIPTION
We've been missing a lot of renovate PRs lately.
Looks like we're hitting the 2 PRs per hour limit set by `config:base` (search log for `Reached PR creation limit or per run commits limit`):
https://app.renovatebot.com/dashboard#github/netlify/netlify-cms/183508836
This ignores that preset (keeps the overall 20 open PRs limit).
