### PR TITLE
fix: missing List import to netlify-cms-core index.d.ts

### DIFF
--- a/packages/netlify-cms-core/index.d.ts
+++ b/packages/netlify-cms-core/index.d.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 declare module 'netlify-cms-core' {
   import React, { ComponentType } from 'react';
-  import { Map } from 'immutable';
+  import { List, Map } from 'immutable';
 
   export type CmsBackendType = 'git-gateway' | 'github' | 'gitlab' | 'bitbucket' | 'test-repo';
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines.

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first two fields are mandatory:
-->

**Summary**
A project with `netlify-cms-core@2.28.0` as a dependency fails to compile due to the `List` import being missing.

![Screenshot 2020-06-01 at 20 23 53](https://user-images.githubusercontent.com/6690208/83447004-a076e080-a447-11ea-8683-b589beb38dc5.png)

This PR adds the missing dependency.

**Test plan**

Should have been caught by `type-check`, but seems to have been missed because of the `"skipLibCheck": true` option. However, enabling this brings about some other errors.
