### PR TITLE
Fix: handle token expiry

### DIFF
--- a/packages/netlify-cms-backend-bitbucket/src/AuthenticationPage.js
+++ b/packages/netlify-cms-backend-bitbucket/src/AuthenticationPage.js
@@ -23,14 +23,15 @@ export default class BitbucketAuthenticationPage extends React.Component {
   state = {};
 
   componentDidMount() {
-    const {
-      auth_type: authType = '',
-      base_url = 'https://bitbucket.org',
-      auth_endpoint = 'site/oauth2/authorize',
-      app_id = '',
-    } = this.props.config.backend;
+    const { auth_type: authType = '' } = this.props.config.backend;
 
     if (authType === 'implicit') {
+      const {
+        base_url = 'https://bitbucket.org',
+        auth_endpoint = 'site/oauth2/authorize',
+        app_id = '',
+      } = this.props.config.backend;
+
       this.auth = new ImplicitAuthenticator({
         base_url,
         auth_endpoint,

--- a/packages/netlify-cms-backend-bitbucket/src/implementation.ts
+++ b/packages/netlify-cms-backend-bitbucket/src/implementation.ts
@@ -111,6 +111,16 @@ export default class BitbucketBackend implements Implementation {
     return true;
   }
 
+  async status() {
+    const auth =
+      (await this.api
+        ?.user()
+        .then(user => !!user)
+        .catch(() => false)) || false;
+
+    return { auth };
+  }
+
   authComponent() {
     return AuthenticationPage;
   }

--- a/packages/netlify-cms-backend-git-gateway/src/implementation.ts
+++ b/packages/netlify-cms-backend-git-gateway/src/implementation.ts
@@ -168,8 +168,16 @@ export default class GitGateway implements Implementation {
     return true;
   }
 
-  status() {
-    return this.backend!.status();
+  async status() {
+    const auth =
+      (await this.tokenPromise?.()
+        .then(token => !!token)
+        .catch(e => {
+          console.warn('Failed getting Identity token', e);
+          return false;
+        })) || false;
+
+    return { auth };
   }
 
   async getAuthClient() {

--- a/packages/netlify-cms-backend-github/src/API.ts
+++ b/packages/netlify-cms-backend-github/src/API.ts
@@ -202,9 +202,13 @@ export default class API {
 
   user(): Promise<{ name: string; login: string }> {
     if (!this._userPromise) {
-      this._userPromise = this.request('/user') as Promise<GitHubUser>;
+      this._userPromise = this.getUser();
     }
     return this._userPromise;
+  }
+
+  getUser() {
+    return this.request('/user') as Promise<GitHubUser>;
   }
 
   async hasWriteAccess() {

--- a/packages/netlify-cms-backend-github/src/implementation.tsx
+++ b/packages/netlify-cms-backend-github/src/implementation.tsx
@@ -111,6 +111,16 @@ export default class GitHub implements Implementation {
     return true;
   }
 
+  async status() {
+    const auth =
+      (await this.api
+        ?.user()
+        .then(user => !!user)
+        .catch(() => false)) || false;
+
+    return { auth };
+  }
+
   authComponent() {
     const wrappedAuthenticationPage = (props: Record<string, unknown>) => (
       <AuthenticationPage {...props} backend={this} />

--- a/packages/netlify-cms-backend-github/src/implementation.tsx
+++ b/packages/netlify-cms-backend-github/src/implementation.tsx
@@ -114,9 +114,12 @@ export default class GitHub implements Implementation {
   async status() {
     const auth =
       (await this.api
-        ?.user()
+        ?.getUser()
         .then(user => !!user)
-        .catch(() => false)) || false;
+        .catch(e => {
+          console.warn('Failed getting GitHub user', e);
+          return false;
+        })) || false;
 
     return { auth };
   }

--- a/packages/netlify-cms-backend-gitlab/src/implementation.ts
+++ b/packages/netlify-cms-backend-gitlab/src/implementation.ts
@@ -87,6 +87,16 @@ export default class GitLab implements Implementation {
     return true;
   }
 
+  async status() {
+    const auth =
+      (await this.api
+        ?.user()
+        .then(user => !!user)
+        .catch(() => false)) || false;
+
+    return { auth };
+  }
+
   authComponent() {
     return AuthenticationPage;
   }

--- a/packages/netlify-cms-backend-gitlab/src/implementation.ts
+++ b/packages/netlify-cms-backend-gitlab/src/implementation.ts
@@ -92,7 +92,10 @@ export default class GitLab implements Implementation {
       (await this.api
         ?.user()
         .then(user => !!user)
-        .catch(() => false)) || false;
+        .catch(e => {
+          console.warn('Failed getting GitLab user', e);
+          return false;
+        })) || false;
 
     return { auth };
   }

--- a/packages/netlify-cms-backend-proxy/src/implementation.ts
+++ b/packages/netlify-cms-backend-proxy/src/implementation.ts
@@ -63,6 +63,10 @@ export default class ProxyBackend implements Implementation {
     return false;
   }
 
+  status() {
+    return Promise.resolve({ auth: true });
+  }
+
   authComponent() {
     return AuthenticationPage;
   }

--- a/packages/netlify-cms-backend-test/src/implementation.ts
+++ b/packages/netlify-cms-backend-test/src/implementation.ts
@@ -101,6 +101,10 @@ export default class TestBackend implements Implementation {
     return false;
   }
 
+  status() {
+    return Promise.resolve({ auth: true });
+  }
+
   authComponent() {
     return AuthenticationPage;
   }

--- a/packages/netlify-cms-core/src/actions/auth.js
+++ b/packages/netlify-cms-core/src/actions/auth.js
@@ -1,7 +1,7 @@
 import { actions as notifActions } from 'redux-notifications';
 import { currentBackend } from 'coreSrc/backend';
 
-const { notifSend } = notifActions;
+const { notifSend, notifClear } = notifActions;
 
 export const AUTH_REQUEST = 'AUTH_REQUEST';
 export const AUTH_SUCCESS = 'AUTH_SUCCESS';
@@ -111,6 +111,7 @@ export function logoutUser() {
     const backend = currentBackend(state.config);
     Promise.resolve(backend.logout()).then(() => {
       dispatch(logout());
+      dispatch(notifClear());
     });
   };
 }

--- a/packages/netlify-cms-core/src/actions/status.ts
+++ b/packages/netlify-cms-core/src/actions/status.ts
@@ -1,0 +1,42 @@
+import { State } from '../types/redux';
+import { currentBackend } from '../backend';
+import { ThunkDispatch } from 'redux-thunk';
+import { AnyAction } from 'redux';
+
+export const STATUS_REQUEST = 'STATUS_REQUEST';
+export const STATUS_SUCCESS = 'STATUS_SUCCESS';
+export const STATUS_FAILURE = 'STATUS_FAILURE';
+
+export function statusRequest() {
+  return {
+    type: STATUS_REQUEST,
+  };
+}
+
+export function statusSuccess(status: { auth: boolean }) {
+  return {
+    type: STATUS_SUCCESS,
+    payload: { status },
+  };
+}
+
+export function statusFailure(error: Error) {
+  return {
+    type: STATUS_FAILURE,
+    error,
+  };
+}
+
+export function checkBackendStatus() {
+  return async (dispatch: ThunkDispatch<State, {}, AnyAction>, getState: () => State) => {
+    try {
+      dispatch(statusRequest());
+      const state = getState();
+      const backend = currentBackend(state.config);
+      const status = await backend.status();
+      dispatch(statusSuccess(status));
+    } catch (error) {
+      dispatch(statusFailure(error));
+    }
+  };
+}

--- a/packages/netlify-cms-core/src/actions/status.ts
+++ b/packages/netlify-cms-core/src/actions/status.ts
@@ -2,6 +2,9 @@ import { State } from '../types/redux';
 import { currentBackend } from '../backend';
 import { ThunkDispatch } from 'redux-thunk';
 import { AnyAction } from 'redux';
+import { actions as notifActions } from 'redux-notifications';
+
+const { notifSend } = notifActions;
 
 export const STATUS_REQUEST = 'STATUS_REQUEST';
 export const STATUS_SUCCESS = 'STATUS_SUCCESS';
@@ -30,10 +33,31 @@ export function statusFailure(error: Error) {
 export function checkBackendStatus() {
   return async (dispatch: ThunkDispatch<State, {}, AnyAction>, getState: () => State) => {
     try {
-      dispatch(statusRequest());
       const state = getState();
+      if (state.status.get('isFetching') === true) {
+        return;
+      }
+
+      dispatch(statusRequest());
       const backend = currentBackend(state.config);
       const status = await backend.status();
+
+      const authError = status.auth === false;
+      if (authError) {
+        const key = 'ui.toast.onLoggedOut';
+        const existingNotification = state.notifs.find(n => n.message?.key === key);
+        if (!existingNotification) {
+          dispatch(
+            notifSend({
+              message: {
+                key: 'ui.toast.onLoggedOut',
+              },
+              kind: 'danger',
+            }),
+          );
+        }
+      }
+
       dispatch(statusSuccess(status));
     } catch (error) {
       dispatch(statusFailure(error));

--- a/packages/netlify-cms-core/src/backend.ts
+++ b/packages/netlify-cms-core/src/backend.ts
@@ -179,6 +179,11 @@ export class Backend {
     }
   }
 
+  async status() {
+    const status = await this.implementation!.status();
+    return status;
+  }
+
   currentUser() {
     if (this.user) {
       return this.user;

--- a/packages/netlify-cms-core/src/backend.ts
+++ b/packages/netlify-cms-core/src/backend.ts
@@ -180,7 +180,17 @@ export class Backend {
   }
 
   async status() {
-    const status = await this.implementation!.status();
+    const attempts = 3;
+    let status: { auth: boolean } = { auth: false };
+    for (let i = 1; i <= attempts; i++) {
+      status = await this.implementation!.status();
+      // return on first success
+      if (Object.values(status).every(s => s === true)) {
+        return status;
+      } else {
+        await new Promise(resolve => setTimeout(resolve, i * 1000));
+      }
+    }
     return status;
   }
 
@@ -227,13 +237,17 @@ export class Backend {
     });
   }
 
-  logout() {
-    return Promise.resolve(this.implementation.logout()).then(() => {
+  async logout() {
+    try {
+      await this.implementation.logout();
+    } catch (e) {
+      console.warn('Error during logout', e.message);
+    } finally {
       this.user = null;
       if (this.authStore) {
         this.authStore.logout();
       }
-    });
+    }
   }
 
   getToken = () => this.implementation.getToken();

--- a/packages/netlify-cms-core/src/components/App/Header.js
+++ b/packages/netlify-cms-core/src/components/App/Header.js
@@ -17,6 +17,8 @@ import {
   zIndex,
 } from 'netlify-cms-ui-default';
 import SettingsDropdown from 'UI/SettingsDropdown';
+import { connect } from 'react-redux';
+import { checkBackendStatus } from '../../actions/status';
 
 const styles = {
   buttonActive: css`
@@ -122,6 +124,18 @@ class Header extends React.Component {
     t: PropTypes.func.isRequired,
   };
 
+  intervalId;
+
+  componentDidMount() {
+    this.intervalId = setInterval(() => {
+      this.props.checkBackendStatus();
+    }, 10000);
+  }
+
+  componentWillUnmount() {
+    clearInterval(this.intervalId);
+  }
+
   handleCreatePostClick = collectionName => {
     const { onCreateEntryClick } = this.props;
     if (onCreateEntryClick) {
@@ -211,4 +225,10 @@ class Header extends React.Component {
   }
 }
 
-export default translate()(Header);
+function mapStateToProps() {
+  return {};
+}
+
+const mapDispatchToProps = { checkBackendStatus };
+
+export default connect(mapStateToProps, mapDispatchToProps)(translate()(Header));

--- a/packages/netlify-cms-core/src/components/App/Header.js
+++ b/packages/netlify-cms-core/src/components/App/Header.js
@@ -129,7 +129,7 @@ class Header extends React.Component {
   componentDidMount() {
     this.intervalId = setInterval(() => {
       this.props.checkBackendStatus();
-    }, 10000);
+    }, 5 * 60 * 1000);
   }
 
   componentWillUnmount() {

--- a/packages/netlify-cms-core/src/components/App/Header.js
+++ b/packages/netlify-cms-core/src/components/App/Header.js
@@ -122,6 +122,7 @@ class Header extends React.Component {
     displayUrl: PropTypes.string,
     isTestRepo: PropTypes.bool,
     t: PropTypes.func.isRequired,
+    checkBackendStatus: PropTypes.func.isRequired,
   };
 
   intervalId;
@@ -129,7 +130,7 @@ class Header extends React.Component {
   componentDidMount() {
     this.intervalId = setInterval(() => {
       this.props.checkBackendStatus();
-    }, 5 * 60 * 1000);
+    }, 60 * 1000);
   }
 
   componentWillUnmount() {
@@ -225,10 +226,8 @@ class Header extends React.Component {
   }
 }
 
-function mapStateToProps() {
-  return {};
-}
+const mapDispatchToProps = {
+  checkBackendStatus,
+};
 
-const mapDispatchToProps = { checkBackendStatus };
-
-export default connect(mapStateToProps, mapDispatchToProps)(translate()(Header));
+export default connect(null, mapDispatchToProps)(translate()(Header));

--- a/packages/netlify-cms-core/src/components/App/Header.js
+++ b/packages/netlify-cms-core/src/components/App/Header.js
@@ -130,7 +130,7 @@ class Header extends React.Component {
   componentDidMount() {
     this.intervalId = setInterval(() => {
       this.props.checkBackendStatus();
-    }, 60 * 1000);
+    }, 5 * 60 * 1000);
   }
 
   componentWillUnmount() {

--- a/packages/netlify-cms-core/src/reducers/globalUI.js
+++ b/packages/netlify-cms-core/src/reducers/globalUI.js
@@ -1,7 +1,12 @@
 import { Map } from 'immutable';
 import { USE_OPEN_AUTHORING } from 'Actions/auth';
 
-const LOADING_IGNORE_LIST = ['DEPLOY_PREVIEW'];
+const LOADING_IGNORE_LIST = [
+  'DEPLOY_PREVIEW',
+  'STATUS_REQUEST',
+  'STATUS_SUCCESS',
+  'STATUS_FAILURE',
+];
 
 const ignoreWhenLoading = action => LOADING_IGNORE_LIST.some(type => action.type.includes(type));
 

--- a/packages/netlify-cms-core/src/reducers/index.ts
+++ b/packages/netlify-cms-core/src/reducers/index.ts
@@ -11,6 +11,7 @@ import medias from './medias';
 import mediaLibrary from './mediaLibrary';
 import deploys, * as fromDeploys from './deploys';
 import globalUI from './globalUI';
+import status from './status';
 import { Status } from '../constants/publishModes';
 import { State, Collection } from '../types/redux';
 
@@ -28,6 +29,7 @@ const reducers = {
   mediaLibrary,
   deploys,
   globalUI,
+  status,
 };
 
 export default reducers;

--- a/packages/netlify-cms-core/src/reducers/status.ts
+++ b/packages/netlify-cms-core/src/reducers/status.ts
@@ -1,0 +1,18 @@
+import { Map } from 'immutable';
+import { AnyAction } from 'redux';
+import { STATUS_SUCCESS } from '../actions/status';
+
+export interface EntriesAction extends AnyAction {
+  payload: { status: { auth: boolean } };
+}
+
+const status = (state = Map(), action: EntriesAction) => {
+  switch (action.type) {
+    case STATUS_SUCCESS:
+      return Map(action.payload.status);
+    default:
+      return state;
+  }
+};
+
+export default status;

--- a/packages/netlify-cms-core/src/reducers/status.ts
+++ b/packages/netlify-cms-core/src/reducers/status.ts
@@ -1,18 +1,33 @@
-import { Map } from 'immutable';
+import { Map, fromJS } from 'immutable';
 import { AnyAction } from 'redux';
-import { STATUS_SUCCESS } from '../actions/status';
+import { STATUS_REQUEST, STATUS_SUCCESS, STATUS_FAILURE } from '../actions/status';
+import { Status } from '../types/redux';
 
 export interface EntriesAction extends AnyAction {
-  payload: { status: { auth: boolean } };
+  payload: { status: { auth: boolean }; error?: Error };
 }
 
 const status = (state = Map(), action: EntriesAction) => {
   switch (action.type) {
+    case STATUS_REQUEST:
+      return state.set('isFetching', true);
     case STATUS_SUCCESS:
-      return Map(action.payload.status);
+      return state.withMutations(map => {
+        map.set('isFetching', false);
+        map.set('status', fromJS(action.payload.status));
+      });
+    case STATUS_FAILURE:
+      return state.withMutations(map => {
+        map.set('isFetching', false);
+        map.set('error', action.payload.error);
+      });
     default:
       return state;
   }
+};
+
+export const selectStatus = (status: Status) => {
+  return status.get('status')?.toJS() || {};
 };
 
 export default status;

--- a/packages/netlify-cms-core/src/types/redux.ts
+++ b/packages/netlify-cms-core/src/types/redux.ts
@@ -241,6 +241,11 @@ export type Search = StaticallyTypedRecord<{
 
 export type Cursors = StaticallyTypedRecord<{}>;
 
+export type Status = StaticallyTypedRecord<{
+  isFetching: boolean;
+  status: StaticallyTypedRecord<{ auth: boolean }>;
+}>;
+
 export interface State {
   config: Config;
   cursors: Cursors;
@@ -253,6 +258,8 @@ export interface State {
   medias: Medias;
   mediaLibrary: MediaLibrary;
   search: Search;
+  notifs: { message: { key: string }; kind: string; id: number }[];
+  status: Status;
 }
 
 export interface MediasAction extends Action<string> {

--- a/packages/netlify-cms-lib-util/src/AccessTokenError.ts
+++ b/packages/netlify-cms-lib-util/src/AccessTokenError.ts
@@ -1,0 +1,11 @@
+export const ACCESS_TOKEN_ERROR = 'ACCESS_TOKEN_ERROR';
+
+export default class AccessTokenError extends Error {
+  message: string;
+
+  constructor(message: string) {
+    super(message);
+    this.message = message;
+    this.name = ACCESS_TOKEN_ERROR;
+  }
+}

--- a/packages/netlify-cms-lib-util/src/implementation.ts
+++ b/packages/netlify-cms-lib-util/src/implementation.ts
@@ -139,6 +139,7 @@ export interface Implementation {
   ) => Promise<{ entries: ImplementationEntry[]; cursor: Cursor }>;
 
   isGitBackend?: () => boolean;
+  status: () => Promise<{ auth: boolean }>;
 }
 
 const MAX_CONCURRENT_DOWNLOADS = 10;

--- a/packages/netlify-cms-lib-util/src/implementation.ts
+++ b/packages/netlify-cms-lib-util/src/implementation.ts
@@ -84,6 +84,8 @@ export type Config = {
     large_media_url?: string;
     use_large_media_transforms_in_media_library?: boolean;
     proxy_url?: string;
+    auth_type?: string;
+    app_id?: string;
   };
   media_folder: string;
   base_url?: string;

--- a/packages/netlify-cms-lib-util/src/index.ts
+++ b/packages/netlify-cms-lib-util/src/index.ts
@@ -1,6 +1,7 @@
 import APIError from './APIError';
 import Cursor, { CURSOR_COMPATIBILITY_SYMBOL } from './Cursor';
 import EditorialWorkflowError, { EDITORIAL_WORKFLOW_ERROR } from './EditorialWorkflowError';
+import AccessTokenError from './AccessTokenError';
 import localForage from './localForage';
 import { isAbsolutePath, basename, fileExtensionWithSeparator, fileExtension } from './path';
 import { onlySuccessfulPromises, flowAsync, then } from './promise';
@@ -138,6 +139,7 @@ export const NetlifyCmsLibUtil = {
   blobToFileObj,
   requestWithBackoff,
   allEntriesByFolder,
+  AccessTokenError,
 };
 export {
   APIError,
@@ -192,4 +194,5 @@ export {
   blobToFileObj,
   requestWithBackoff,
   allEntriesByFolder,
+  AccessTokenError,
 };

--- a/packages/netlify-cms-locales/src/en/index.js
+++ b/packages/netlify-cms-locales/src/en/index.js
@@ -223,6 +223,7 @@ const en = {
       entryUpdated: 'Entry status updated',
       onDeleteUnpublishedChanges: 'Unpublished changes deleted',
       onFailToAuth: '%{details}',
+      onLoggedOut: 'You have been logged out, please back up any data and login again',
     },
   },
   workflow: {


### PR DESCRIPTION
Fixes https://github.com/netlify/netlify-cms/issues/3779 (shows a relevant message as we can't refresh a Bitbucket implicit token: https://developer.atlassian.com/cloud/bitbucket/oauth-2/#refresh-tokens)

Fixes https://github.com/netlify/netlify-cms/issues/941

Related https://github.com/netlify/gotrue-js/pull/83

Token expiry can happen in the following cases:

- **Web Application Flow** - Revoking OAuth app from the relevant GitHub/GitLab/Bitbucket interface. Relevant config is:
```yaml
backend:
  name: github/gitlab/bitbucket
```
- **GoTrue/Netlify Identity** - token expires every hour, but auto refreshed by identity widget/gotrue-js. That can fails when the refresh token is no longer valid. That can happen when a user logs in via a different browser window and then goes back to the original window. See https://github.com/netlify/netlify-cms/issues/941#issuecomment-635265078 and https://github.com/netlify/netlify-identity-widget/issues/142#issuecomment-395894548.
Relevant config is:
```yaml
backend:
  name: git-gateway
```
- **Bitbucket implicit grant** - invalidates after 1 hour and [can't be refreshed](https://developer.atlassian.com/cloud/bitbucket/oauth-2/#refresh-tokens).
Relevant config is:
```yaml
backend:
  name: bitbucket
  repo: owner/repo
  auth_type: implicit
  app_id: 'Bitbucket OAuth Consumer key'
```
- **Bitbucket Web Application Flow** - invalidates after 1 hour and auto refreshed by the CMS.
Relevant config is:
```yaml
backend:
  name: bitbucket
  repo: owner/repo
```
- **GitLab implicit grant** - not sure, from the example in the docs it seems it expires in 1 hour - did not experience that issue: https://docs.gitlab.com/ee/api/oauth2.html#implicit-grant-flow, and the example in the response seems wrong: `http://myapp.com/oauth/redirect#access_token=ABCDExyz123&state=YOUR_UNIQUE_STATE_HASH&token_type=bearer&expires_in=3600`
The response when doing implicit auth doesn't have an `expires_in` argument.
Relevant config is:
```yaml
backend:
  name: gitlab
  repo: owner/repo
  auth_type: implicit
  app_id: 'GitLab Application ID'
```

### Solution
- Periodically check that the user is logged in and show a sticky notification error until the user logs out.

Also relevant to https://github.com/netlify/netlify-cms/issues/3334