### PR TITLE
fix: datetime format not correct

### DIFF
--- a/packages/netlify-cms-widget-datetime/src/DateTimeControl.js
+++ b/packages/netlify-cms-widget-datetime/src/DateTimeControl.js
@@ -65,6 +65,10 @@ export default class DateTimeControl extends React.Component {
       setTimeout(() => {
         this.handleChange(this.defaultValue === undefined ? new Date() : this.defaultValue);
       }, 0);
+    } else {
+      setTimeout(() => {
+        this.handleChange(value);
+      }, 0);
     }
   }
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines.

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first two fields are mandatory:
-->
fixes #3702 

**Summary**

<!--
Explain the **motivation** for making this change.
What existing problem does the pull request solve?
-->

The value of datetime widget doesn't get formatted when it mounts. So if you edit posts without modifying values in datetime widget, the values will save without format.

**Test plan**

<!--
Demonstrate the code is solid.
Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.
-->
I don't know how to test it. 
But in the development server, it corrects the preview of the datetime widget.

![Screenshot_2020-06-05 Netlify CMS Development Test](https://user-images.githubusercontent.com/8216525/83804758-37aa9500-a6e1-11ea-82b2-66eb714a5e5c.png)


**A picture of a cute animal (not mandatory but encouraged)**

![Serval Cat](https://user-images.githubusercontent.com/8216525/83805222-0e3e3900-a6e2-11ea-912e-73dd67355f42.jpg)
