### PR TITLE
Fix: handle branch names conflicts

### DIFF
--- a/packages/netlify-cms-backend-github/src/GraphQLAPI.ts
+++ b/packages/netlify-cms-backend-github/src/GraphQLAPI.ts
@@ -14,8 +14,9 @@ import {
   DEFAULT_PR_BODY,
   branchFromContentKey,
   CMS_BRANCH_PREFIX,
+  throwOnConflictingBranches,
 } from 'netlify-cms-lib-util';
-import { trim } from 'lodash';
+import { trim, trimStart } from 'lodash';
 import introspectionQueryResultData from './fragmentTypes';
 import API, { Config, BlobArgs, API_NAME, PullRequestState, MOCK_PULL_REQUEST } from './API';
 import * as queries from './queries';
@@ -134,10 +135,21 @@ export default class GraphQLAPI extends API {
     });
   }
 
-  mutate(options: MutationOptions<OperationVariables>) {
-    return this.client.mutate(options).catch(error => {
+  async mutate(options: MutationOptions<OperationVariables>) {
+    try {
+      const result = await this.client.mutate(options);
+      return result;
+    } catch (error) {
+      const errors = error.graphQLErrors;
+      if (Array.isArray(errors) && errors.some(e => e.message === 'Ref cannot be created.')) {
+        const refName = options?.variables?.createRefInput?.name || '';
+        const branchName = trimStart(refName, 'refs/heads/');
+        if (branchName) {
+          await throwOnConflictingBranches(branchName, name => this.getBranch(name), API_NAME);
+        }
+      }
       throw new APIError(error.message, 500, 'GitHub');
-    });
+    }
   }
 
   async hasWriteAccess() {

--- a/packages/netlify-cms-lib-util/src/index.ts
+++ b/packages/netlify-cms-lib-util/src/index.ts
@@ -49,6 +49,7 @@ import {
   FetchError as FE,
   ApiRequest as AR,
   requestWithBackoff,
+  throwOnConflictingBranches,
 } from './API';
 import {
   CMS_BRANCH_PREFIX,
@@ -140,6 +141,7 @@ export const NetlifyCmsLibUtil = {
   requestWithBackoff,
   allEntriesByFolder,
   AccessTokenError,
+  throwOnConflictingBranches,
 };
 export {
   APIError,
@@ -195,4 +197,5 @@ export {
   requestWithBackoff,
   allEntriesByFolder,
   AccessTokenError,
+  throwOnConflictingBranches,
 };


### PR DESCRIPTION
Related to:
https://github.com/netlify/netlify-cms/issues/1693
https://github.com/netlify/netlify-cms/issues/2827

Handles errors originating from branch conflicts (existing `cms` branches).