### PR TITLE
feat: add backend status down indicator

### DIFF
--- a/packages/netlify-cms-backend-github/src/implementation.tsx
+++ b/packages/netlify-cms-backend-github/src/implementation.tsx
@@ -43,7 +43,8 @@ type ApiFile = { id: string; type: string; name: string; path: string; size: num
 
 const { fetchWithTimeout: fetch } = unsentRequest;
 
-const GITHUB_STATUS_ENDPOINT = 'https://kctbh9vrtdwd.statuspage.io/api/v2/components.json';
+const STATUS_PAGE = 'https://www.githubstatus.com';
+const GITHUB_STATUS_ENDPOINT = `${STATUS_PAGE}/api/v2/components.json`;
 const GITHUB_OPERATIONAL_UNITS = ['API Requests', 'Issues, Pull Requests, Projects'];
 type GitHubStatusComponent = {
   id: string;
@@ -136,16 +137,20 @@ export default class GitHub implements Implementation {
         return true;
       });
 
-    const auth =
-      (await this.api
-        ?.getUser()
-        .then(user => !!user)
-        .catch(e => {
-          console.warn('Failed getting GitHub user', e);
-          return false;
-        })) || false;
+    let auth = false;
+    // no need to check auth if api is down
+    if (api) {
+      auth =
+        (await this.api
+          ?.getUser()
+          .then(user => !!user)
+          .catch(e => {
+            console.warn('Failed getting GitHub user', e);
+            return false;
+          })) || false;
+    }
 
-    return { auth, api };
+    return { auth: { status: auth }, api: { status: api, statusPage: STATUS_PAGE } };
   }
 
   authComponent() {

--- a/packages/netlify-cms-backend-gitlab/src/implementation.ts
+++ b/packages/netlify-cms-backend-gitlab/src/implementation.ts
@@ -97,7 +97,7 @@ export default class GitLab implements Implementation {
           return false;
         })) || false;
 
-    return { auth };
+    return { auth, api: true };
   }
 
   authComponent() {

--- a/packages/netlify-cms-backend-gitlab/src/implementation.ts
+++ b/packages/netlify-cms-backend-gitlab/src/implementation.ts
@@ -97,7 +97,7 @@ export default class GitLab implements Implementation {
           return false;
         })) || false;
 
-    return { auth, api: true };
+    return { auth: { status: auth }, api: { status: true, statusPage: '' } };
   }
 
   authComponent() {

--- a/packages/netlify-cms-backend-proxy/src/implementation.ts
+++ b/packages/netlify-cms-backend-proxy/src/implementation.ts
@@ -64,7 +64,7 @@ export default class ProxyBackend implements Implementation {
   }
 
   status() {
-    return Promise.resolve({ auth: true, api: true });
+    return Promise.resolve({ auth: { status: true }, api: { status: true, statusPage: '' } });
   }
 
   authComponent() {

--- a/packages/netlify-cms-backend-proxy/src/implementation.ts
+++ b/packages/netlify-cms-backend-proxy/src/implementation.ts
@@ -64,7 +64,7 @@ export default class ProxyBackend implements Implementation {
   }
 
   status() {
-    return Promise.resolve({ auth: true });
+    return Promise.resolve({ auth: true, api: true });
   }
 
   authComponent() {

--- a/packages/netlify-cms-backend-test/src/implementation.ts
+++ b/packages/netlify-cms-backend-test/src/implementation.ts
@@ -102,7 +102,7 @@ export default class TestBackend implements Implementation {
   }
 
   status() {
-    return Promise.resolve({ auth: true });
+    return Promise.resolve({ auth: true, api: true });
   }
 
   authComponent() {

--- a/packages/netlify-cms-backend-test/src/implementation.ts
+++ b/packages/netlify-cms-backend-test/src/implementation.ts
@@ -102,7 +102,7 @@ export default class TestBackend implements Implementation {
   }
 
   status() {
-    return Promise.resolve({ auth: true, api: true });
+    return Promise.resolve({ auth: { status: true }, api: { status: true, statusPage: '' } });
   }
 
   authComponent() {

--- a/packages/netlify-cms-core/src/actions/status.ts
+++ b/packages/netlify-cms-core/src/actions/status.ts
@@ -16,7 +16,10 @@ export function statusRequest() {
   };
 }
 
-export function statusSuccess(status: { auth: boolean; api: boolean }) {
+export function statusSuccess(status: {
+  auth: { status: boolean };
+  api: { status: boolean; statusPage: string };
+}) {
   return {
     type: STATUS_SUCCESS,
     payload: { status },
@@ -26,7 +29,7 @@ export function statusSuccess(status: { auth: boolean; api: boolean }) {
 export function statusFailure(error: Error) {
   return {
     type: STATUS_FAILURE,
-    error,
+    payload: { error },
   };
 }
 
@@ -45,11 +48,12 @@ export function checkBackendStatus() {
       const backendDownKey = 'ui.toast.onBackendDown';
       const previousBackendDownNotifs = state.notifs.filter(n => n.message?.key === backendDownKey);
 
-      if (status.api === false) {
+      if (status.api.status === false) {
         if (previousBackendDownNotifs.length === 0) {
           dispatch(
             notifSend({
               message: {
+                details: status.api.statusPage,
                 key: 'ui.toast.onBackendDown',
               },
               kind: 'danger',
@@ -57,14 +61,14 @@ export function checkBackendStatus() {
           );
         }
         return dispatch(statusSuccess(status));
-      } else if (status.api === true && previousBackendDownNotifs.length > 0) {
+      } else if (status.api.status === true && previousBackendDownNotifs.length > 0) {
         // If backend is up, clear all the danger messages
         previousBackendDownNotifs.forEach(notif => {
           dispatch(notifDismiss(notif.id));
         });
       }
 
-      const authError = status.auth === false;
+      const authError = status.auth.status === false;
       if (authError) {
         const key = 'ui.toast.onLoggedOut';
         const existingNotification = state.notifs.find(n => n.message?.key === key);

--- a/packages/netlify-cms-core/src/actions/status.ts
+++ b/packages/netlify-cms-core/src/actions/status.ts
@@ -4,7 +4,7 @@ import { ThunkDispatch } from 'redux-thunk';
 import { AnyAction } from 'redux';
 import { actions as notifActions } from 'redux-notifications';
 
-const { notifSend } = notifActions;
+const { notifSend, notifDismiss } = notifActions;
 
 export const STATUS_REQUEST = 'STATUS_REQUEST';
 export const STATUS_SUCCESS = 'STATUS_SUCCESS';
@@ -16,7 +16,7 @@ export function statusRequest() {
   };
 }
 
-export function statusSuccess(status: { auth: boolean }) {
+export function statusSuccess(status: { auth: boolean; api: boolean }) {
   return {
     type: STATUS_SUCCESS,
     payload: { status },
@@ -41,6 +41,28 @@ export function checkBackendStatus() {
       dispatch(statusRequest());
       const backend = currentBackend(state.config);
       const status = await backend.status();
+
+      const backendDownKey = 'ui.toast.onBackendDown';
+      const previousBackendDownNotifs = state.notifs.filter(n => n.message?.key === backendDownKey);
+
+      if (status.api === false) {
+        if (previousBackendDownNotifs.length === 0) {
+          dispatch(
+            notifSend({
+              message: {
+                key: 'ui.toast.onBackendDown',
+              },
+              kind: 'danger',
+            }),
+          );
+        }
+        return dispatch(statusSuccess(status));
+      } else if (status.api === true && previousBackendDownNotifs.length > 0) {
+        // If backend is up, clear all the danger messages
+        previousBackendDownNotifs.forEach(notif => {
+          dispatch(notifDismiss(notif.id));
+        });
+      }
 
       const authError = status.auth === false;
       if (authError) {

--- a/packages/netlify-cms-core/src/backend.ts
+++ b/packages/netlify-cms-core/src/backend.ts
@@ -181,7 +181,7 @@ export class Backend {
 
   async status() {
     const attempts = 3;
-    let status: { auth: boolean } = { auth: false };
+    let status: { auth: boolean; api: boolean } = { auth: false, api: false };
     for (let i = 1; i <= attempts; i++) {
       status = await this.implementation!.status();
       // return on first success

--- a/packages/netlify-cms-core/src/backend.ts
+++ b/packages/netlify-cms-core/src/backend.ts
@@ -181,11 +181,17 @@ export class Backend {
 
   async status() {
     const attempts = 3;
-    let status: { auth: boolean; api: boolean } = { auth: false, api: false };
+    let status: {
+      auth: { status: boolean };
+      api: { status: boolean; statusPage: string };
+    } = {
+      auth: { status: false },
+      api: { status: false, statusPage: '' },
+    };
     for (let i = 1; i <= attempts; i++) {
       status = await this.implementation!.status();
       // return on first success
-      if (Object.values(status).every(s => s === true)) {
+      if (Object.values(status).every(s => s.status === true)) {
         return status;
       } else {
         await new Promise(resolve => setTimeout(resolve, i * 1000));

--- a/packages/netlify-cms-core/src/reducers/status.ts
+++ b/packages/netlify-cms-core/src/reducers/status.ts
@@ -4,7 +4,7 @@ import { STATUS_REQUEST, STATUS_SUCCESS, STATUS_FAILURE } from '../actions/statu
 import { Status } from '../types/redux';
 
 export interface EntriesAction extends AnyAction {
-  payload: { status: { auth: boolean }; error?: Error };
+  payload: { status: { auth: boolean; api: boolean }; error?: Error };
 }
 
 const status = (state = Map(), action: EntriesAction) => {

--- a/packages/netlify-cms-core/src/reducers/status.ts
+++ b/packages/netlify-cms-core/src/reducers/status.ts
@@ -3,11 +3,14 @@ import { AnyAction } from 'redux';
 import { STATUS_REQUEST, STATUS_SUCCESS, STATUS_FAILURE } from '../actions/status';
 import { Status } from '../types/redux';
 
-export interface EntriesAction extends AnyAction {
-  payload: { status: { auth: boolean; api: boolean }; error?: Error };
+interface StatusAction extends AnyAction {
+  payload: {
+    status: { auth: { status: boolean }; api: { status: boolean; statusPage: string } };
+    error?: Error;
+  };
 }
 
-const status = (state = Map(), action: EntriesAction) => {
+const status = (state = Map(), action: StatusAction) => {
   switch (action.type) {
     case STATUS_REQUEST:
       return state.set('isFetching', true);

--- a/packages/netlify-cms-lib-util/src/implementation.ts
+++ b/packages/netlify-cms-lib-util/src/implementation.ts
@@ -141,7 +141,10 @@ export interface Implementation {
   ) => Promise<{ entries: ImplementationEntry[]; cursor: Cursor }>;
 
   isGitBackend?: () => boolean;
-  status: () => Promise<{ auth: boolean; api: boolean }>;
+  status: () => Promise<{
+    auth: { status: boolean };
+    api: { status: boolean; statusPage: string };
+  }>;
 }
 
 const MAX_CONCURRENT_DOWNLOADS = 10;

--- a/packages/netlify-cms-lib-util/src/implementation.ts
+++ b/packages/netlify-cms-lib-util/src/implementation.ts
@@ -141,7 +141,7 @@ export interface Implementation {
   ) => Promise<{ entries: ImplementationEntry[]; cursor: Cursor }>;
 
   isGitBackend?: () => boolean;
-  status: () => Promise<{ auth: boolean }>;
+  status: () => Promise<{ auth: boolean; api: boolean }>;
 }
 
 const MAX_CONCURRENT_DOWNLOADS = 10;

--- a/packages/netlify-cms-lib-util/src/unsentRequest.js
+++ b/packages/netlify-cms-lib-util/src/unsentRequest.js
@@ -12,7 +12,7 @@ const isAbortControllerSupported = () => {
 
 const timeout = 60;
 const fetchWithTimeout = (input, init) => {
-  if (init.signal || !isAbortControllerSupported()) {
+  if ((init && init.signal) || !isAbortControllerSupported()) {
     return fetch(input, init);
   }
   const controller = new AbortController();

--- a/packages/netlify-cms-locales/src/en/index.js
+++ b/packages/netlify-cms-locales/src/en/index.js
@@ -224,7 +224,8 @@ const en = {
       onDeleteUnpublishedChanges: 'Unpublished changes deleted',
       onFailToAuth: '%{details}',
       onLoggedOut: 'You have been logged out, please back up any data and login again',
-      onBackendDown: 'The backend service is experiencing an outage. Proceed with caution.',
+      onBackendDown:
+        'The backend service is experiencing an outage. See %{details} for more information',
     },
   },
   workflow: {

--- a/packages/netlify-cms-locales/src/en/index.js
+++ b/packages/netlify-cms-locales/src/en/index.js
@@ -224,6 +224,7 @@ const en = {
       onDeleteUnpublishedChanges: 'Unpublished changes deleted',
       onFailToAuth: '%{details}',
       onLoggedOut: 'You have been logged out, please back up any data and login again',
+      onBackendDown: 'The backend service is experiencing an outage. Proceed with caution.',
     },
   },
   workflow: {


### PR DESCRIPTION
**Summary**
Closes https://github.com/netlify/netlify-cms/issues/3334

Note: i18n needed for new key `ui.toast.onBackendDown`

**Test plan**
Tested on development environment:
- [x] `yarn test` pass
- [X] BitBucket, GitHub, and Netlify Git gateway status pages
- [X] Send notification when one or more of the required components for the provider are not `operational`
- [X] Does not send more than one backend down notification
- [X]  Does not send the Auth is down message if backend is down (https://github.com/netlify/netlify-cms/pull/3847/commits/59b17ab0ef7018780cf9b576f32b48513d89a82e) ... assuming auth would not be available if the backend is down..
- [X] Dismisses the notification when backend check is successful

Ran `yarn lint`

<img width="1503" alt="image" src="https://user-images.githubusercontent.com/28766663/84442445-a456ef80-ac0b-11ea-950b-b166cc8a76a2.png">




**A picture of a cute animal (not mandatory but encouraged)**
![image](https://user-images.githubusercontent.com/28766663/84447304-a4f48380-ac15-11ea-8edb-9c91e2444ab3.png)

