### PR TITLE
fix: don't rely on browser builtin css for CardsGrid margins

### DIFF
--- a/packages/netlify-cms-core/src/components/Collection/Entries/EntryListing.js
+++ b/packages/netlify-cms-core/src/components/Collection/Entries/EntryListing.js
@@ -13,6 +13,8 @@ const CardsGrid = styled.ul`
   flex-flow: row wrap;
   list-style-type: none;
   margin-left: -12px;
+  margin-top: 16px;
+  margin-bottom: 16px;
 `;
 
 export default class EntryListing extends React.Component {


### PR DESCRIPTION
**Summary**

The `CardsGrid` component currently relies on builtin browser CSS for top and bottom margins on `<ul>`. This can be a problem when the page includes a global css reset, so better be explicit. see:

![netlifycms-cardsgrid](https://user-images.githubusercontent.com/20753323/84525030-4265bb00-acdb-11ea-987d-274d09d35ba8.png)

**Test plan**

none
