### PR TITLE
fix: fix headings dropdown width

### DIFF
--- a/packages/netlify-cms-widget-markdown/src/MarkdownControl/Toolbar.js
+++ b/packages/netlify-cms-widget-markdown/src/MarkdownControl/Toolbar.js
@@ -170,6 +170,7 @@ export default class Toolbar extends React.Component {
           {Object.keys(headingOptions).some(isVisible) && (
             <ToolbarDropdownWrapper>
               <Dropdown
+                dropdownWidth="max-content"
                 dropdownTopOverlap="36px"
                 renderButton={() => (
                   <DropdownButton>


### PR DESCRIPTION
**Summary**

on Firefox, the "Headings" dropdown in the richtext editor toolbar does not display with correct width (it's fine on chrome).

see e.g. https://cms-demo.netlify.com/#/collections/posts/entries/2020-6-16-post-number-20

firefox:
![firefox](https://user-images.githubusercontent.com/20753323/84650523-b5a04480-af08-11ea-8fe9-e14b8721f57f.png)

chrome:
![chrome](https://user-images.githubusercontent.com/20753323/84650528-bafd8f00-af08-11ea-9508-37634641bb3f.png)
