### PR TITLE
Revert "chore: fix PR labeler for forked PRs"

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -5,25 +5,26 @@ on:
 
 jobs:
   label-pr:
+    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false
     runs-on: ubuntu-latest
     steps:
       - uses: erezrokah/pr-labeler-action@v1.0.0
         if: startsWith(github.event.pull_request.title, 'fix')
         with:
-          token: '${{ secrets.PR_LABELER_TOKEN }}'
+          token: '${{ secrets.GITHUB_TOKEN }}'
           label: 'type: bug'
       - uses: erezrokah/pr-labeler-action@v1.0.0
         if: startsWith(github.event.pull_request.title, 'chore')
         with:
-          token: '${{ secrets.PR_LABELER_TOKEN }}'
+          token: '${{ secrets.GITHUB_TOKEN }}'
           label: 'type: chore'
       - uses: erezrokah/pr-labeler-action@v1.0.0
         if: startsWith(github.event.pull_request.title, 'feat')
         with:
-          token: '${{ secrets.PR_LABELER_TOKEN }}'
+          token: '${{ secrets.GITHUB_TOKEN }}'
           label: 'type: feature'
       - uses: erezrokah/pr-labeler-action@v1.0.0
         if: startsWith(github.event.pull_request.title, 'security')
         with:
-          token: '${{ secrets.PR_LABELER_TOKEN }}'
+          token: '${{ secrets.GITHUB_TOKEN }}'
           label: 'type: security'


### PR DESCRIPTION
This reverts commit cd79ea70243bd175489d7fb92ed50d3b620e969a (https://github.com/netlify/netlify-cms/pull/3902)

Secrets are not passed to builds from forks, so we can't use this approach.
We need to use a Netlify Function

