### PR TITLE
header ui update closes #3263

### DIFF
--- a/packages/netlify-cms-ui-default/src/AppBar/AppBar.jsx
+++ b/packages/netlify-cms-ui-default/src/AppBar/AppBar.jsx
@@ -1,6 +1,5 @@
 import React, { useState, useEffect } from 'react';
 import styled from '@emotion/styled';
-import LogoTile from '../LogoTile';
 import Icon from '../Icon';
 import Card from '../Card';
 import { IconButton } from '../Button';
@@ -80,12 +79,10 @@ const AppBar = ({ renderStart, renderEnd, renderActions }) => {
 
   return (
     <AppBarWrap>
-      {isMobile ? (
+      {isMobile && (
         <ActionsWrap noBorder>
           <IconButton icon="arrow-left" />
         </ActionsWrap>
-      ) : (
-        <LogoTile />
       )}
       <StartWrap>
         <TitleWrap>

--- a/packages/netlify-cms-ui-default/src/SearchBar/SearchBar.jsx
+++ b/packages/netlify-cms-ui-default/src/SearchBar/SearchBar.jsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import styled from '@emotion/styled';
+import Icon from '../Icon';
+
+const SearchContainer = styled.div`
+  display: flex;
+  align-items: center;
+  position: relative;
+  width: 100%;
+  min-width: 200px;
+
+  svg {
+    position: absolute;
+    left: 6px;
+    z-index: 2;
+    height: 100%;
+    display: flex;
+    align-items: center;
+    pointer-events: none;
+  }
+`;
+
+const EndWrap = styled.div`
+  position: absolute;
+  right: 6px;
+  z-index: 2;
+`;
+
+const SearchInput = styled.input`
+  color: ${({ theme }) => theme.color.highEmphasis};
+  background-color: ${({ theme }) => theme.color.surfaceHighlight};
+  border-radius: 6px;
+  font-size: 14px;
+  padding: 10px 6px 10px 32px;
+  width: 100%;
+  z-index: 1;
+  border: 0;
+  caret-color: ${({ theme }) => theme.color.primary['900']};
+
+  &::placeholder {
+    color: ${({ theme }) => theme.color.disabled};
+  }
+
+  &:focus {
+    outline: none;
+    box-shadow: inset 0 0 0 2px ${({ theme }) => theme.color.primary['900']};
+  }
+`;
+
+const SearchBar = ({ placeholder, renderEnd, onChange }) => {
+  return (
+    <SearchContainer>
+      <Icon name="search" />
+      <SearchInput placeholder={placeholder} onChange={onChange} />
+      <EndWrap>{renderEnd && renderEnd()}</EndWrap>
+    </SearchContainer>
+  );
+};
+
+export default SearchBar;

--- a/packages/netlify-cms-ui-default/src/SearchBar/index.js
+++ b/packages/netlify-cms-ui-default/src/SearchBar/index.js
@@ -1,0 +1,1 @@
+export { default } from './SearchBar';

--- a/packages/netlify-cms-ui-default/src/SearchBar/story.jsx
+++ b/packages/netlify-cms-ui-default/src/SearchBar/story.jsx
@@ -1,0 +1,70 @@
+import React, { useState } from 'react';
+import { text, boolean } from '@storybook/addon-knobs';
+import styled from '@emotion/styled';
+import SearchBar from './SearchBar';
+import { Menu, MenuItem } from '../Menu';
+import { Button } from '../Button';
+
+export default {
+  title: 'Components/SearchBar',
+};
+
+export const _SearchBar = () => {
+  const renderEnd = boolean('renderEnd', false);
+  const placeholder = text('placeholder', 'Search');
+  return (
+    <SearchWrap>
+      <SearchBar
+        placeholder={placeholder}
+        renderEnd={renderEnd ? () => <EndContent /> : null}
+        onChange={e => console.log(e.target.value)}
+      />
+    </SearchWrap>
+  );
+};
+
+_SearchBar.story = {
+  name: 'SearchBar',
+};
+
+const SearchWrap = styled.div`
+  width: 33%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+`;
+
+const EndContent = () => {
+  const [categoryMenuAnchorEl, setCategoryMenuAnchorEl] = useState(null);
+  const [selectedCategory, setSelectedCategory] = useState('Posts');
+  const categories = ['Posts', 'Media', 'Pages', 'Products', 'Authors', 'Everywhere'];
+  function handleClose() {
+    setCategoryMenuAnchorEl(null);
+  }
+  return (
+    <>
+      <Button size="sm" hasMenu onClick={e => setCategoryMenuAnchorEl(e.currentTarget)}>
+        {selectedCategory}
+      </Button>
+      <Menu
+        anchorEl={categoryMenuAnchorEl}
+        open={!!categoryMenuAnchorEl}
+        onClose={() => setCategoryMenuAnchorEl(null)}
+        anchorOrigin={{ y: 'bottom', x: 'right' }}
+      >
+        {categories.map(category => (
+          <MenuItem
+            key={category}
+            selected={selectedCategory === category}
+            onClick={() => {
+              setSelectedCategory(category);
+              handleClose();
+            }}
+          >
+            {category}
+          </MenuItem>
+        ))}
+      </Menu>
+    </>
+  );
+};


### PR DESCRIPTION
**Summary**
Commit 1:
Removes the `LogoTile` from the `AppBar`

Commit 2:
Adds a `SearchBar` component with an optional `renderEnd` parameter.
The design was inherited from existing `CollectionSearch` component and extended.

**Test plan**
Snapshot of the newly added component with `renderEnd` enabled

<img width="1159" alt="Screen Shot 2020-06-19 at 4 31 09 PM" src="https://user-images.githubusercontent.com/51631122/85126150-819b8b00-b24a-11ea-8002-500fae801f3e.png">

**Note**
Some changes on the `AppBar` component are pending and will be done soon.
