### PR TITLE
fix(backup): synchronize calls to localForage

### DIFF
--- a/packages/netlify-cms-core/src/__tests__/backend.spec.js
+++ b/packages/netlify-cms-core/src/__tests__/backend.spec.js
@@ -114,7 +114,9 @@ describe('Backend', () => {
   });
 
   describe('getLocalDraftBackup', () => {
-    const { localForage } = require('netlify-cms-lib-util');
+    const { localForage, asyncLock } = require('netlify-cms-lib-util');
+
+    asyncLock.mockImplementation(() => ({ acquire: jest.fn(), release: jest.fn() }));
 
     beforeEach(() => {
       jest.clearAllMocks();


### PR DESCRIPTION
Make sure calls to `persistLocalDraftBackup` and `deleteLocalDraftBackup` are executed in-order 

Fixes an issue with the backup pop showing up in the following scenario:
1. Open https://cms-demo.netlify.com/#/collections/posts/new
2. Quickly exit the editor.
3. Click on `New post`
4. See that the backup pop up is shown.
![backup](https://user-images.githubusercontent.com/26760571/85220874-bc6f0180-b3b7-11ea-92f4-2b1dec229023.gif)
