### PR TITLE
fix(editor): proper length check for history when going back in editor

### DIFF
--- a/packages/netlify-cms-core/src/components/Editor/EditorToolbar.js
+++ b/packages/netlify-cms-core/src/components/Editor/EditorToolbar.js
@@ -570,7 +570,7 @@ class EditorToolbar extends React.Component {
       <ToolbarContainer>
         <ToolbarSectionBackLink
           onClick={() => {
-            if (history.length > 0) {
+            if (history.length > 2) {
               history.goBack();
             } else {
               history.push(`/collections/${collection.get('name')}`);


### PR DESCRIPTION
Fixes https://github.com/netlify/netlify-cms/issues/3951

Using `history. goBack` was introduced in #3716 in order to preserve the URL state (and collection filter state) when exiting the editor.

The current `history.length` doesn't work when the CMS is opened from another page using a link with `target="_blank"`.

Also see https://stackoverflow.com/questions/3588315/how-to-check-if-the-user-can-go-back-in-browser-history-or-not#answer-36645802