### PR TITLE
feat: add preDeployPreview hook

### DIFF
--- a/packages/netlify-cms-core/src/actions/deploys.js
+++ b/packages/netlify-cms-core/src/actions/deploys.js
@@ -62,7 +62,7 @@ export function loadDeployPreview(collection, slug, entry, published, opts) {
        * unpublished entries.
        */
       const deploy = published
-        ? backend.getDeploy(collection, slug, entry)
+        ? await backend.getDeploy(collection, slug, entry)
         : await backend.getDeployPreview(collection, slug, entry, opts);
       if (deploy) {
         return dispatch(deployPreviewLoaded(collection, slug, deploy));

--- a/packages/netlify-cms-core/src/backend.ts
+++ b/packages/netlify-cms-core/src/backend.ts
@@ -791,6 +791,11 @@ export class Backend {
     }
     const hookEntry: DeployPreviewUrl = fromJS({
       url: previewUrlFormatter(baseUrl, collection, slug, this.config.get('slug'), entry),
+      collection,
+      baseUrl,
+      slug,
+      slugConfig: this.config.get('slug'),
+      entry,
     });
 
     const modifiedData = await this.invokePreDeployPreviewEvent(hookEntry);
@@ -846,6 +851,11 @@ export class Backend {
        * Create a URL using the collection `preview_path`, if provided.
        */
       url: previewUrlFormatter(deployPreview.url, collection, slug, this.config.get('slug'), entry),
+      collection,
+      baseUrl: deployPreview.url,
+      slug,
+      slugConfig: this.config.get('slug'),
+      entry,
     });
     const modifiedData = await this.invokePreDeployPreviewEvent(hookEntry);
     const finalEntry = (modifiedData && hookEntry.set('url', modifiedData)) || hookEntry;

--- a/packages/netlify-cms-core/src/lib/__tests__/registry.spec.js
+++ b/packages/netlify-cms-core/src/lib/__tests__/registry.spec.js
@@ -52,6 +52,7 @@ describe('registry', () => {
       'postUnpublish',
       'preSave',
       'postSave',
+      'preDeployPreview',
     ];
 
     describe('registerEventListener', () => {

--- a/packages/netlify-cms-core/src/lib/registry.js
+++ b/packages/netlify-cms-core/src/lib/registry.js
@@ -10,6 +10,7 @@ const allowedEvents = [
   'postUnpublish',
   'preSave',
   'postSave',
+  'preDeployPreview',
 ];
 const eventHandlers = {};
 allowedEvents.forEach(e => {

--- a/packages/netlify-cms-core/src/types/redux.ts
+++ b/packages/netlify-cms-core/src/types/redux.ts
@@ -77,7 +77,14 @@ export type Entries = StaticallyTypedRecord<{
   filter: Filter;
 }>;
 
-export type DeployPreviewUrl = StaticallyTypedRecord<{ url: string }>;
+export type DeployPreviewUrl = StaticallyTypedRecord<{
+  url: string;
+  collection: Collection;
+  baseUrl: string;
+  slug: string;
+  slugConfig: SlugConfig;
+  entry: EntryMap;
+}>;
 
 export type Deploys = StaticallyTypedRecord<{}>;
 

--- a/packages/netlify-cms-core/src/types/redux.ts
+++ b/packages/netlify-cms-core/src/types/redux.ts
@@ -77,6 +77,8 @@ export type Entries = StaticallyTypedRecord<{
   filter: Filter;
 }>;
 
+export type DeployPreviewUrl = StaticallyTypedRecord<{ url: string }>;
+
 export type Deploys = StaticallyTypedRecord<{}>;
 
 export type EditorialWorkflow = StaticallyTypedRecord<{

--- a/website/content/docs/beta-features.md
+++ b/website/content/docs/beta-features.md
@@ -401,7 +401,7 @@ CMS.registerEventListener({
 });
 ```
 
-Supported events are `prePublish`, `postPublish`, `preUnpublish`, `postUnepublish`, `preSave`, `postSave` and `preDeployPreview`. The `preSave` and `preDeployPreview` hook can be used to modify the entry data like so:
+Supported events are `prePublish`, `postPublish`, `preUnpublish`, `postUnepublish`, `preSave`, `postSave` and `preDeployPreview`. The `preSave` and `preDeployPreview` hooks can be used to modify the entry data like so:
 
 ```javascript
 CMS.registerEventListener({

--- a/website/content/docs/beta-features.md
+++ b/website/content/docs/beta-features.md
@@ -401,13 +401,22 @@ CMS.registerEventListener({
 });
 ```
 
-Supported events are `prePublish`, `postPublish`, `preUnpublish`, `postUnpublish`, `preSave` and `postSave`. The `preSave` hook can be used to modify the entry data like so:
+Supported events are `prePublish`, `postPublish`, `preUnpublish`, `postUnepublish`, `preSave`, `postSave` and `preDeployPreview`. The `preSave` and `preDeployPreview` hook can be used to modify the entry data like so:
 
 ```javascript
 CMS.registerEventListener({
   name: 'preSave',
   handler: ({ entry }) => {
     return entry.get('data').set('title', 'new title');
+  },
+});
+```
+
+```javascript
+CMS.registerEventListener({
+  name: 'preSave',
+  handler: ({ deploy }) => {
+    return deploy.get('url') + ".liveview"
   },
 });
 ```


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines.

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first two fields are mandatory:
-->
Close #3964

**Summary**

Allow better preview url customization
The base url was not editable with the config

**Test plan**

Tested with a local build, working fine :

Code used : 
```js
CMS.registerEventListener({
  name: 'preDeployPreview',
  handler: ({ deploy, ...all }) => {
    console.log(deploy.get('url'), all)
    return 'https://reddit.com'
  },
})
```
<!--
Demonstrate the code is solid.
Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.
-->

**A picture of a cute animal (not mandatory but encouraged)**

![image](https://user-images.githubusercontent.com/12765875/86145629-7290c480-baf7-11ea-9253-7ecbe9e2bb73.png)


