### PR TITLE
Fix: relation widget performance

### DIFF
--- a/packages/netlify-cms-core/src/__tests__/backend.spec.js
+++ b/packages/netlify-cms-core/src/__tests__/backend.spec.js
@@ -822,7 +822,10 @@ describe('Backend', () => {
           data: {
             field: {
               nested: {
-                list: [{ id: 1, name: '1' }, undefined, undefined, { id: 4, name: '4' }],
+                list: [
+                  { id: 1, name: '1' },
+                  { id: 4, name: '4' },
+                ],
               },
             },
             list: [1, 2],
@@ -888,10 +891,50 @@ describe('Backend', () => {
           data: {
             field: {
               nested: {
-                list: [{ id: 1, name: '1' }, undefined, undefined, { id: 4, name: '4' }],
+                list: [
+                  { id: 1, name: '1' },
+                  { id: 4, name: '4' },
+                ],
               },
             },
-            list: [undefined, 2],
+            list: [2],
+          },
+        },
+      ]);
+    });
+
+    it('should merge entries and keep sort by entry index', () => {
+      const expanded = [
+        {
+          data: {
+            list: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12],
+          },
+          field: 'list.5',
+        },
+        {
+          data: {
+            list: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12],
+          },
+          field: 'list.0',
+        },
+        {
+          data: {
+            list: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12],
+          },
+          field: 'list.11',
+        },
+        {
+          data: {
+            list: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12],
+          },
+          field: 'list.1',
+        },
+      ];
+
+      expect(mergeExpandedEntries(expanded)).toEqual([
+        {
+          data: {
+            list: [5, 0, 11, 1],
           },
         },
       ]);

--- a/packages/netlify-cms-lib-widgets/package.json
+++ b/packages/netlify-cms-lib-widgets/package.json
@@ -18,6 +18,7 @@
   },
   "peerDependencies": {
     "immutable": "^3.7.6",
+    "lodash": "^4.17.11",
     "moment": "^2.24.0"
   }
 }

--- a/packages/netlify-cms-lib-widgets/src/__tests__/stringTemplate.spec.js
+++ b/packages/netlify-cms-lib-widgets/src/__tests__/stringTemplate.spec.js
@@ -4,6 +4,7 @@ import {
   compileStringTemplate,
   parseDateFromEntry,
   extractTemplateVars,
+  expandPath,
 } from '../stringTemplate';
 describe('stringTemplate', () => {
   describe('keyToPathArray', () => {
@@ -105,6 +106,68 @@ describe('stringTemplate', () => {
       expect(
         compileStringTemplate('{{slug}}', date, 'slug', fromJS({}), value => value.toUpperCase()),
       ).toBe('SLUG');
+    });
+  });
+
+  describe('expandPath', () => {
+    it('should expand wildcard paths', () => {
+      const data = {
+        categories: [
+          {
+            name: 'category 1',
+          },
+          {
+            name: 'category 2',
+          },
+        ],
+      };
+
+      expect(expandPath({ data, path: 'categories.*.name' })).toEqual([
+        'categories.0.name',
+        'categories.1.name',
+      ]);
+    });
+
+    it('should handle wildcard at the end of the path', () => {
+      const data = {
+        nested: {
+          otherNested: {
+            list: [
+              {
+                title: 'title 1',
+                nestedList: [{ description: 'description 1' }, { description: 'description 2' }],
+              },
+              {
+                title: 'title 2',
+                nestedList: [{ description: 'description 2' }, { description: 'description 2' }],
+              },
+            ],
+          },
+        },
+      };
+
+      expect(expandPath({ data, path: 'nested.otherNested.list.*.nestedList.*' })).toEqual([
+        'nested.otherNested.list.0.nestedList.0',
+        'nested.otherNested.list.0.nestedList.1',
+        'nested.otherNested.list.1.nestedList.0',
+        'nested.otherNested.list.1.nestedList.1',
+      ]);
+    });
+
+    it('should handle non wildcard index', () => {
+      const data = {
+        categories: [
+          {
+            name: 'category 1',
+          },
+          {
+            name: 'category 2',
+          },
+        ],
+      };
+      const path = 'categories.0.name';
+
+      expect(expandPath({ data, path })).toEqual(['categories.0.name']);
     });
   });
 });

--- a/packages/netlify-cms-widget-relation/package.json
+++ b/packages/netlify-cms-widget-relation/package.json
@@ -22,7 +22,8 @@
     "build:esm": "cross-env NODE_ENV=esm babel src --out-dir dist/esm --ignore \"**/__tests__\" --root-mode upward"
   },
   "dependencies": {
-    "react-select": "^2.4.2"
+    "react-select": "^2.4.2",
+    "react-window": "^1.8.5"
   },
   "peerDependencies": {
     "@emotion/core": "^10.0.9",

--- a/packages/netlify-cms-widget-relation/src/RelationControl.js
+++ b/packages/netlify-cms-widget-relation/src/RelationControl.js
@@ -124,7 +124,6 @@ export default class RelationControl extends React.Component {
           },
         }) ||
         {};
-
       onChange(fromJS(value), metadata);
     } else {
       value = optionToString(selectedOption);
@@ -176,9 +175,9 @@ export default class RelationControl extends React.Component {
     const { field, query, forID } = this.props;
     const collection = field.get('collection');
     const searchFields = field.get('searchFields');
+    const optionsLength = field.get('optionsLength') || 20;
     const searchFieldsArray = List.isList(searchFields) ? searchFields.toJS() : [searchFields];
     const file = field.get('file');
-    const optionsLength = field.get('optionsLength') || 20;
 
     query(forID, collection, searchFieldsArray, term, file, optionsLength).then(({ payload }) => {
       const hits = payload.response?.hits || [];

--- a/packages/netlify-cms-widget-relation/src/RelationControl.js
+++ b/packages/netlify-cms-widget-relation/src/RelationControl.js
@@ -172,12 +172,19 @@ export default class RelationControl extends React.Component {
   };
 
   loadOptions = debounce((term, callback) => {
-    const { field, query, forID } = this.props;
+    const { field, query, forID, value } = this.props;
     const collection = field.get('collection');
     const searchFields = field.get('searchFields');
     const optionsLength = field.get('optionsLength') || 20;
-    const searchFieldsArray = List.isList(searchFields) ? searchFields.toJS() : [searchFields];
+    let searchFieldsArray = List.isList(searchFields) ? searchFields.toJS() : [searchFields];
     const file = field.get('file');
+
+    // if the field has a previous value perform the initial search based on the value field
+    // this is needed since search results are limited to optionsLength
+    if (!this.didInitialSearch && value && !term) {
+      searchFieldsArray = [field.get('valueField')];
+      term = value;
+    }
 
     query(forID, collection, searchFieldsArray, term, file, optionsLength).then(({ payload }) => {
       const hits = payload.response?.hits || [];

--- a/packages/netlify-cms-widget-relation/src/RelationControl.js
+++ b/packages/netlify-cms-widget-relation/src/RelationControl.js
@@ -6,6 +6,28 @@ import { find, isEmpty, last, debounce, get, trimEnd } from 'lodash';
 import { List, Map, fromJS } from 'immutable';
 import { reactSelectStyles } from 'netlify-cms-ui-default';
 import { stringTemplate } from 'netlify-cms-lib-widgets';
+import { FixedSizeList } from 'react-window';
+
+const Option = ({ index, style, data }) => <div style={style}>{data.options[index]}</div>;
+
+const MenuList = props => {
+  const rows = props.children;
+  if (rows.length === 0) {
+    return;
+  }
+  return (
+    <FixedSizeList
+      style={{ width: '100%' }}
+      width={300}
+      height={300}
+      itemCount={rows.length}
+      itemSize={30}
+      itemData={{ options: rows }}
+    >
+      {Option}
+    </FixedSizeList>
+  );
+};
 
 function optionToString(option) {
   return option && option.value ? option.value : '';
@@ -186,7 +208,9 @@ export default class RelationControl extends React.Component {
     const file = field.get('file');
 
     const queryPromise = file
-      ? query(forID, collection, ['slug'], file)
+      ? this.props
+          .loadEntry(collection, file)
+          .then(entry => ({ payload: { response: { hits: [entry] } } }))
       : query(forID, collection, searchFieldsArray, term);
 
     queryPromise.then(({ payload }) => {
@@ -230,6 +254,7 @@ export default class RelationControl extends React.Component {
 
     return (
       <AsyncSelect
+        components={{ MenuList }}
         value={selectedValue}
         inputId={forID}
         defaultOptions

--- a/packages/netlify-cms-widget-relation/src/RelationControl.js
+++ b/packages/netlify-cms-widget-relation/src/RelationControl.js
@@ -174,14 +174,14 @@ export default class RelationControl extends React.Component {
     return value;
   };
 
-  parseHitOptions = hits => {
+  parseHitOptions = (hits, limit = Number.MAX_SAFE_INTEGER) => {
     const { field } = this.props;
     const valueField = field.get('valueField');
     const displayField = field.get('displayFields') || List([field.get('valueField')]);
 
     const options = hits.reduce((acc, hit) => {
       const valuesPaths = expandPath({ data: hit.data, path: valueField });
-      for (let i = 0; i < valuesPaths.length; i++) {
+      for (let i = 0; i < valuesPaths.length && acc.length < limit; i++) {
         const label = displayField
           .toJS()
           .map(key => {
@@ -214,17 +214,14 @@ export default class RelationControl extends React.Component {
       : query(forID, collection, searchFieldsArray, term);
 
     queryPromise.then(({ payload }) => {
-      let options =
+      const limit = term ? Number.MIN_SAFE_INTEGER : optionsLength;
+      const options =
         payload.response && payload.response.hits
-          ? this.parseHitOptions(payload.response.hits)
+          ? this.parseHitOptions(payload.response.hits, limit)
           : [];
 
       if (!this.allOptions && !term) {
         this.allOptions = options;
-      }
-
-      if (!term) {
-        options = options.slice(0, optionsLength);
       }
 
       callback(options);

--- a/packages/netlify-cms-widget-relation/src/__tests__/relation.spec.js
+++ b/packages/netlify-cms-widget-relation/src/__tests__/relation.spec.js
@@ -3,7 +3,13 @@ import { fromJS, Map } from 'immutable';
 import { last } from 'lodash';
 import { render, fireEvent, wait } from '@testing-library/react';
 import { NetlifyCmsWidgetRelation } from '../';
-import { expandPath } from '../RelationControl';
+
+jest.mock('react-window', () => {
+  const FixedSizeList = props => props.itemData.options;
+  return {
+    FixedSizeList,
+  };
+});
 
 const RelationControl = NetlifyCmsWidgetRelation.controlComponent;
 
@@ -128,36 +134,51 @@ class RelationController extends React.Component {
     queryHits: Map(),
   };
 
+  mounted = false;
+
+  componentDidMount() {
+    this.mounted = true;
+  }
+
+  componentWillUnmount() {
+    this.mounted = false;
+  }
+
   handleOnChange = jest.fn(value => {
     this.setState({ ...this.state, value });
   });
 
   setQueryHits = jest.fn(hits => {
-    const queryHits = Map().set('relation-field', hits);
-    this.setState({ ...this.state, queryHits });
+    if (this.mounted) {
+      const queryHits = Map().set('relation-field', hits);
+      this.setState({ ...this.state, queryHits });
+    }
   });
 
   query = jest.fn((...args) => {
     const queryHits = generateHits(25);
 
-    if (args[1] === 'numbers_collection') {
-      return Promise.resolve({ payload: { response: { hits: numberFieldsHits } } });
-    } else if (last(args) === 'nested_file') {
-      return Promise.resolve({ payload: { response: { hits: nestedFileCollectionHits } } });
-    } else if (last(args) === 'simple_file') {
-      return Promise.resolve({ payload: { response: { hits: simpleFileCollectionHits } } });
-    } else if (last(args) === 'YAML') {
-      return Promise.resolve({ payload: { response: { hits: [last(queryHits)] } } });
-    } else if (last(args) === 'Nested') {
-      return Promise.resolve({
-        payload: { response: { hits: [queryHits[queryHits.length - 2]] } },
-      });
-    } else if (last(args) === 'Deeply nested') {
-      return Promise.resolve({
-        payload: { response: { hits: [queryHits[queryHits.length - 3]] } },
-      });
+    const [, collection, , term, file, optionsLength] = args;
+    let hits = queryHits;
+    if (collection === 'numbers_collection') {
+      hits = numberFieldsHits;
+    } else if (file === 'nested_file') {
+      hits = nestedFileCollectionHits;
+    } else if (file === 'simple_file') {
+      hits = simpleFileCollectionHits;
+    } else if (term === 'YAML') {
+      hits = [last(queryHits)];
+    } else if (term === 'Nested') {
+      hits = [queryHits[queryHits.length - 2]];
+    } else if (term === 'Deeply nested') {
+      hits = [queryHits[queryHits.length - 3]];
     }
-    return Promise.resolve({ payload: { response: { hits: queryHits } } });
+
+    hits = hits.slice(0, optionsLength);
+
+    this.setQueryHits(hits);
+
+    return Promise.resolve({ payload: { response: { hits } } });
   });
 
   render() {
@@ -207,68 +228,6 @@ function setup({ field, value }) {
     input,
   };
 }
-
-describe('expandPath', () => {
-  it('should expand wildcard paths', () => {
-    const data = {
-      categories: [
-        {
-          name: 'category 1',
-        },
-        {
-          name: 'category 2',
-        },
-      ],
-    };
-
-    expect(expandPath({ data, path: 'categories.*.name' })).toEqual([
-      'categories.0.name',
-      'categories.1.name',
-    ]);
-  });
-
-  it('should handle wildcard at the end of the path', () => {
-    const data = {
-      nested: {
-        otherNested: {
-          list: [
-            {
-              title: 'title 1',
-              nestedList: [{ description: 'description 1' }, { description: 'description 2' }],
-            },
-            {
-              title: 'title 2',
-              nestedList: [{ description: 'description 2' }, { description: 'description 2' }],
-            },
-          ],
-        },
-      },
-    };
-
-    expect(expandPath({ data, path: 'nested.otherNested.list.*.nestedList.*' })).toEqual([
-      'nested.otherNested.list.0.nestedList.0',
-      'nested.otherNested.list.0.nestedList.1',
-      'nested.otherNested.list.1.nestedList.0',
-      'nested.otherNested.list.1.nestedList.1',
-    ]);
-  });
-
-  it('should handle non wildcard index', () => {
-    const data = {
-      categories: [
-        {
-          name: 'category 1',
-        },
-        {
-          name: 'category 2',
-        },
-      ],
-    };
-    const path = 'categories.0.name';
-
-    expect(expandPath({ data, path })).toEqual(['categories.0.name']);
-  });
-});
 
 describe('Relation widget', () => {
   it('should list the first 20 option hits on initial load', async () => {
@@ -439,11 +398,11 @@ describe('Relation widget', () => {
         fireEvent.click(getByText('Post # 1 post-number-1'));
         fireEvent.keyDown(input, { key: 'ArrowDown' });
         fireEvent.click(getByText('Post # 2 post-number-2'));
-
-        expect(onChangeSpy).toHaveBeenCalledTimes(2);
-        expect(onChangeSpy).toHaveBeenCalledWith(fromJS(['Post # 1']), metadata1);
-        expect(onChangeSpy).toHaveBeenCalledWith(fromJS(['Post # 1', 'Post # 2']), metadata2);
       });
+
+      expect(onChangeSpy).toHaveBeenCalledTimes(2);
+      expect(onChangeSpy).toHaveBeenCalledWith(fromJS(['Post # 1']), metadata1);
+      expect(onChangeSpy).toHaveBeenCalledWith(fromJS(['Post # 1', 'Post # 2']), metadata2);
     });
 
     it('should update metadata for initial preview', async () => {

--- a/packages/netlify-cms-widget-relation/src/__tests__/relation.spec.js
+++ b/packages/netlify-cms-widget-relation/src/__tests__/relation.spec.js
@@ -398,11 +398,11 @@ describe('Relation widget', () => {
         fireEvent.click(getByText('Post # 1 post-number-1'));
         fireEvent.keyDown(input, { key: 'ArrowDown' });
         fireEvent.click(getByText('Post # 2 post-number-2'));
-      });
 
-      expect(onChangeSpy).toHaveBeenCalledTimes(2);
-      expect(onChangeSpy).toHaveBeenCalledWith(fromJS(['Post # 1']), metadata1);
-      expect(onChangeSpy).toHaveBeenCalledWith(fromJS(['Post # 1', 'Post # 2']), metadata2);
+        expect(onChangeSpy).toHaveBeenCalledTimes(2);
+        expect(onChangeSpy).toHaveBeenCalledWith(fromJS(['Post # 1']), metadata1);
+        expect(onChangeSpy).toHaveBeenCalledWith(fromJS(['Post # 1', 'Post # 2']), metadata2);
+      });
     });
 
     it('should update metadata for initial preview', async () => {


### PR DESCRIPTION
Fixes https://github.com/netlify/netlify-cms/issues/3810
Fixes https://github.com/netlify/netlify-cms/issues/3908

1. Fixes the search for file collections by using `expandPath` inside `backend.ts` (moved to a shared lib).
2. Virtualises the select dropdown.
3. Passes options length as a limit to `backend.ts` to avoid saving all results in the redux store.