### PR TITLE
fix(proxy-server): change request logging level to debug

### DIFF
--- a/packages/netlify-cms-proxy-server/src/middlewares/common/index.ts
+++ b/packages/netlify-cms-proxy-server/src/middlewares/common/index.ts
@@ -11,7 +11,7 @@ export const registerCommonMiddlewares = (app: express.Express, options: Options
   const { logger } = options;
   const stream = {
     write: (message: string) => {
-      logger.info(String(message).trim());
+      logger.debug(String(message).trim());
     },
   };
   app.use(morgan('combined', { stream }));


### PR DESCRIPTION
Current default is too verbose.
This is configurable via `LOG_LEVEL` env variable.