### PR TITLE
test(e2e): update chrome flags

### DIFF
--- a/cypress/plugins/index.js
+++ b/cypress/plugins/index.js
@@ -178,15 +178,7 @@ module.exports = async (on, config) => {
 
   on('before:browser:launch', (browser = {}, launchOptions) => {
     if (browser.name === 'chrome') {
-      // to allows usage of a mock proxy
-      launchOptions.args.push('--ignore-certificate-errors');
-      launchOptions.args.push('-–disable-gpu');
-      if (browser.isHeaded) {
-        launchOptions.args.push('--window-size=1200,1200');
-      } else {
-        launchOptions.args.push('--window-size=1200,1077');
-      }
-
+      launchOptions.args.push('--disable-dev-shm-usage');
       return launchOptions;
     }
   });


### PR DESCRIPTION
Removed flags are now added by cypress by default.
`--disable-dev-shm-usage` adds better compatibility for running inside a docker container.