### PR TITLE
chore: fix publish action

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Publish Netlify CMS
         uses: erezrokah/2fa-with-slack-action@v1.0.0
         env:
-          PUSH_TOKEN: ${{ secrets.PUSH_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.PUSH_TOKEN }}
           NPM_TOKEN: ${{secrets.NPM_TOKEN}}
           SLACK_TOKEN: ${{secrets.SLACK_TOKEN}}
           CONVERSATION_ID: ${{secrets.CONVERSATION_ID}}


### PR DESCRIPTION
We should pass a `GITHUB_TOKEN` to the 2fa publish action