### PR TITLE
docs: replace outdated command

### DIFF
--- a/website/content/docs/nuxt.md
+++ b/website/content/docs/nuxt.md
@@ -99,7 +99,7 @@ git push -u origin master
 
 ### Deploying With Netlify
 
-Now you can go ahead and deploy to Netlify. Go to your Netlify dashboard and click **[New site from Git](https://app.netlify.com/start)**. Select the repo you just created. Under **Basic build settings**, you can set the build command to  `npm run build && npm run export` . Set the publish directory to `dist`. Click **Deploy site** to get the process going.
+Now you can go ahead and deploy to Netlify. Go to your Netlify dashboard and click **[New site from Git](https://app.netlify.com/start)**. Select the repo you just created. Under **Basic build settings**, you can set the build command to  `npm run generate` . Set the publish directory to `dist`. Click **Deploy site** to get the process going.
 
 ### Authenticating with Netlify Identity
 


### PR DESCRIPTION
**Summary**

Nuxt 2.14 deprecates the `nuxt build && nuxt export` in favor of `nuxt generate` as you can read [here](https://nuxtjs.org/blog/nuxt-static-improvements#using-in-your-projects).

![image](https://user-images.githubusercontent.com/11526389/89654566-22acd680-d8c9-11ea-95cb-b4eb78e1dc29.png)

**Additional thoughts**:

In the docs, you are talking about the npm script, that probably does not match with the nuxt script. Should this be explained in order to avoid issues with persons that do not use to deal with npm scripts?