### PR TITLE
fix: default entries in grid view

### DIFF
--- a/packages/netlify-cms-core/src/components/Collection/Collection.js
+++ b/packages/netlify-cms-core/src/components/Collection/Collection.js
@@ -14,7 +14,7 @@ import CollectionControls from './CollectionControls';
 import { sortByField, filterByField } from '../../actions/entries';
 import { selectSortableFields, selectViewFilters } from '../../reducers/collections';
 import { selectEntriesSort, selectEntriesFilter } from '../../reducers/entries';
-import { VIEW_STYLE_LIST } from '../../constants/collectionViews';
+import { VIEW_STYLE_GRID } from '../../constants/collectionViews';
 
 const CollectionContainer = styled.div`
   margin: ${lengths.pageMargin};
@@ -47,7 +47,7 @@ export class Collection extends React.Component {
   };
 
   state = {
-    viewStyle: VIEW_STYLE_LIST,
+    viewStyle: VIEW_STYLE_GRID,
   };
 
   renderEntriesCollection = () => {

--- a/packages/netlify-cms-core/src/components/Collection/Entries/EntryCard.js
+++ b/packages/netlify-cms-core/src/components/Collection/Entries/EntryCard.js
@@ -90,7 +90,7 @@ const EntryCard = ({
   image,
   imageField,
   collectionLabel,
-  viewStyle = VIEW_STYLE_LIST,
+  viewStyle = VIEW_STYLE_GRID,
   getAsset,
 }) => {
   if (viewStyle === VIEW_STYLE_LIST) {

--- a/packages/netlify-cms-core/src/components/Collection/__tests__/__snapshots__/Collection.spec.js.snap
+++ b/packages/netlify-cms-core/src/components/Collection/__tests__/__snapshots__/Collection.spec.js.snap
@@ -30,12 +30,12 @@ exports[`Collection should render connected component 1`] = `
         filter="Map {}"
         sortablefields=""
         viewfilters=""
-        viewstyle="VIEW_STYLE_LIST"
+        viewstyle="VIEW_STYLE_GRID"
       />
       <mock-entries-collection
         collection="Map { \\"name\\": \\"pages\\", \\"sortableFields\\": List [], \\"view_filters\\": List [] }"
         filterterm=""
-        viewstyle="VIEW_STYLE_LIST"
+        viewstyle="VIEW_STYLE_GRID"
       />
     </main>
   </div>
@@ -67,11 +67,11 @@ exports[`Collection should render with collection with create url 1`] = `
         newentryurl="/collections/pages/new"
       />
       <mock-collection-controls
-        viewstyle="VIEW_STYLE_LIST"
+        viewstyle="VIEW_STYLE_GRID"
       />
       <mock-entries-collection
         collection="Map { \\"name\\": \\"pages\\", \\"sortableFields\\": List [], \\"view_filters\\": List [], \\"create\\": true }"
-        viewstyle="VIEW_STYLE_LIST"
+        viewstyle="VIEW_STYLE_GRID"
       />
     </main>
   </div>
@@ -104,12 +104,12 @@ exports[`Collection should render with collection with create url and path 1`] =
         newentryurl="/collections/pages/new?path=dir1/dir2"
       />
       <mock-collection-controls
-        viewstyle="VIEW_STYLE_LIST"
+        viewstyle="VIEW_STYLE_GRID"
       />
       <mock-entries-collection
         collection="Map { \\"name\\": \\"pages\\", \\"sortableFields\\": List [], \\"view_filters\\": List [], \\"create\\": true }"
         filterterm="dir1/dir2"
-        viewstyle="VIEW_STYLE_LIST"
+        viewstyle="VIEW_STYLE_GRID"
       />
     </main>
   </div>
@@ -141,11 +141,11 @@ exports[`Collection should render with collection without create url 1`] = `
         newentryurl=""
       />
       <mock-collection-controls
-        viewstyle="VIEW_STYLE_LIST"
+        viewstyle="VIEW_STYLE_GRID"
       />
       <mock-entries-collection
         collection="Map { \\"name\\": \\"pages\\", \\"sortableFields\\": List [], \\"view_filters\\": List [], \\"create\\": false }"
-        viewstyle="VIEW_STYLE_LIST"
+        viewstyle="VIEW_STYLE_GRID"
       />
     </main>
   </div>


### PR DESCRIPTION
**Summary**

fixes #3876 

Currently the default collection is displayed in List View instead of Grid View.
This fixes set the default view type to Grid View.

**Test plan**

When loading the CMS locally, without selecting any view type, this is what is shown on the UI

<img width="1428" alt="Screenshot" src="https://user-images.githubusercontent.com/11392022/89785562-310b2480-db4d-11ea-8172-812877496153.png">

**A picture of a cute animal (not mandatory but encouraged)**

![image](https://user-images.githubusercontent.com/11392022/89785186-914d9680-db4c-11ea-8355-d37a07a9a6d5.png)