### PR TITLE
fix: persistent view style

### DIFF
--- a/packages/netlify-cms-core/src/actions/entries.ts
+++ b/packages/netlify-cms-core/src/actions/entries.ts
@@ -73,6 +73,8 @@ export const ENTRY_DELETE_FAILURE = 'ENTRY_DELETE_FAILURE';
 export const ADD_DRAFT_ENTRY_MEDIA_FILE = 'ADD_DRAFT_ENTRY_MEDIA_FILE';
 export const REMOVE_DRAFT_ENTRY_MEDIA_FILE = 'REMOVE_DRAFT_ENTRY_MEDIA_FILE';
 
+export const CHANGE_VIEW_STYLE = 'CHANGE_VIEW_STYLE';
+
 /*
  * Simple Action Creators (Internal)
  * We still need to export them for tests
@@ -237,6 +239,15 @@ export function filterByField(collection: Collection, filter: ViewFilter) {
         },
       });
     }
+  };
+}
+
+export function changeViewStyle(viewStyle: string) {
+  return {
+    type: CHANGE_VIEW_STYLE,
+    payload: {
+      style: viewStyle,
+    },
   };
 }
 

--- a/packages/netlify-cms-core/src/components/Collection/Collection.js
+++ b/packages/netlify-cms-core/src/components/Collection/Collection.js
@@ -53,11 +53,7 @@ export class Collection extends React.Component {
   renderEntriesCollection = () => {
     const { collection, filterTerm, viewStyle } = this.props;
     return (
-      <EntriesCollection
-        collection={collection}
-        viewStyle={viewStyle}
-        filterTerm={filterTerm}
-      />
+      <EntriesCollection collection={collection} viewStyle={viewStyle} filterTerm={filterTerm} />
     );
   };
 

--- a/packages/netlify-cms-core/src/components/Collection/Collection.js
+++ b/packages/netlify-cms-core/src/components/Collection/Collection.js
@@ -140,7 +140,7 @@ function mapStateToProps(state, ownProps) {
   const sortableFields = selectSortableFields(collection, t);
   const viewFilters = selectViewFilters(collection);
   const filter = selectEntriesFilter(state.entries, collection.get('name'));
-  const viewStyle = selectViewStyle();
+  const viewStyle = selectViewStyle(state.entries);
 
   return {
     collection,

--- a/packages/netlify-cms-core/src/components/Collection/Collection.js
+++ b/packages/netlify-cms-core/src/components/Collection/Collection.js
@@ -11,7 +11,7 @@ import CollectionTop from './CollectionTop';
 import EntriesCollection from './Entries/EntriesCollection';
 import EntriesSearch from './Entries/EntriesSearch';
 import CollectionControls from './CollectionControls';
-import { sortByField, filterByField } from '../../actions/entries';
+import { sortByField, filterByField, changeViewStyle } from '../../actions/entries';
 import { selectSortableFields, selectViewFilters } from '../../reducers/collections';
 import { selectEntriesSort, selectEntriesFilter } from '../../reducers/entries';
 import { VIEW_STYLE_LIST } from '../../constants/collectionViews';
@@ -93,6 +93,7 @@ export class Collection extends React.Component {
       t,
       onFilterClick,
       filter,
+      onChangeViewStyle,
     } = this.props;
 
     let newEntryUrl = collection.get('create') ? getNewEntryUrl(collectionName) : '';
@@ -125,8 +126,7 @@ export class Collection extends React.Component {
             <>
               <CollectionTop collection={collection} newEntryUrl={newEntryUrl} />
               <CollectionControls
-                viewStyle={this.state.viewStyle}
-                onChangeViewStyle={this.handleChangeViewStyle}
+                onChangeViewStyle={onChangeViewStyle}
                 sortableFields={sortableFields}
                 onSortClick={onSortClick}
                 sort={sort}
@@ -171,6 +171,7 @@ function mapStateToProps(state, ownProps) {
 const mapDispatchToProps = {
   sortByField,
   filterByField,
+  changeViewStyle,
 };
 
 const mergeProps = (stateProps, dispatchProps, ownProps) => {
@@ -180,6 +181,7 @@ const mergeProps = (stateProps, dispatchProps, ownProps) => {
     onSortClick: (key, direction) =>
       dispatchProps.sortByField(stateProps.collection, key, direction),
     onFilterClick: filter => dispatchProps.filterByField(stateProps.collection, filter),
+    onChangeViewStyle: viewStyle => dispatchProps.changeViewStyle(viewStyle),
   };
 };
 

--- a/packages/netlify-cms-core/src/components/Collection/Collection.js
+++ b/packages/netlify-cms-core/src/components/Collection/Collection.js
@@ -67,12 +67,6 @@ export class Collection extends React.Component {
     );
   };
 
-  handleChangeViewStyle = viewStyle => {
-    if (this.state.viewStyle !== viewStyle) {
-      this.setState({ viewStyle });
-    }
-  };
-
   render() {
     const {
       collection,

--- a/packages/netlify-cms-core/src/components/Collection/Collection.js
+++ b/packages/netlify-cms-core/src/components/Collection/Collection.js
@@ -13,7 +13,7 @@ import EntriesSearch from './Entries/EntriesSearch';
 import CollectionControls from './CollectionControls';
 import { sortByField, filterByField, changeViewStyle } from '../../actions/entries';
 import { selectSortableFields, selectViewFilters } from '../../reducers/collections';
-import { selectEntriesSort, selectEntriesFilter } from '../../reducers/entries';
+import { selectEntriesSort, selectEntriesFilter, selectViewStyle } from '../../reducers/entries';
 import { VIEW_STYLE_LIST } from '../../constants/collectionViews';
 
 const CollectionContainer = styled.div`
@@ -51,11 +51,11 @@ export class Collection extends React.Component {
   };
 
   renderEntriesCollection = () => {
-    const { collection, filterTerm } = this.props;
+    const { collection, filterTerm, viewStyle } = this.props;
     return (
       <EntriesCollection
         collection={collection}
-        viewStyle={this.state.viewStyle}
+        viewStyle={viewStyle}
         filterTerm={filterTerm}
       />
     );
@@ -94,6 +94,7 @@ export class Collection extends React.Component {
       onFilterClick,
       filter,
       onChangeViewStyle,
+      viewStyle,
     } = this.props;
 
     let newEntryUrl = collection.get('create') ? getNewEntryUrl(collectionName) : '';
@@ -126,6 +127,7 @@ export class Collection extends React.Component {
             <>
               <CollectionTop collection={collection} newEntryUrl={newEntryUrl} />
               <CollectionControls
+                viewStyle={viewStyle}
                 onChangeViewStyle={onChangeViewStyle}
                 sortableFields={sortableFields}
                 onSortClick={onSortClick}
@@ -153,6 +155,7 @@ function mapStateToProps(state, ownProps) {
   const sortableFields = selectSortableFields(collection, t);
   const viewFilters = selectViewFilters(collection);
   const filter = selectEntriesFilter(state.entries, collection.get('name'));
+  const viewStyle = selectViewStyle();
 
   return {
     collection,
@@ -165,6 +168,7 @@ function mapStateToProps(state, ownProps) {
     sortableFields,
     viewFilters,
     filter,
+    viewStyle,
   };
 }
 

--- a/packages/netlify-cms-core/src/components/Collection/Collection.js
+++ b/packages/netlify-cms-core/src/components/Collection/Collection.js
@@ -14,7 +14,6 @@ import CollectionControls from './CollectionControls';
 import { sortByField, filterByField, changeViewStyle } from '../../actions/entries';
 import { selectSortableFields, selectViewFilters } from '../../reducers/collections';
 import { selectEntriesSort, selectEntriesFilter, selectViewStyle } from '../../reducers/entries';
-import { VIEW_STYLE_LIST } from '../../constants/collectionViews';
 
 const CollectionContainer = styled.div`
   margin: ${lengths.pageMargin};
@@ -44,10 +43,6 @@ export class Collection extends React.Component {
     sortableFields: PropTypes.array,
     sort: ImmutablePropTypes.orderedMap,
     onSortClick: PropTypes.func.isRequired,
-  };
-
-  state = {
-    viewStyle: VIEW_STYLE_LIST,
   };
 
   renderEntriesCollection = () => {

--- a/packages/netlify-cms-core/src/components/Collection/__tests__/__snapshots__/Collection.spec.js.snap
+++ b/packages/netlify-cms-core/src/components/Collection/__tests__/__snapshots__/Collection.spec.js.snap
@@ -30,12 +30,10 @@ exports[`Collection should render connected component 1`] = `
         filter="Map {}"
         sortablefields=""
         viewfilters=""
-        viewstyle="VIEW_STYLE_LIST"
       />
       <mock-entries-collection
         collection="Map { \\"name\\": \\"pages\\", \\"sortableFields\\": List [], \\"view_filters\\": List [] }"
         filterterm=""
-        viewstyle="VIEW_STYLE_LIST"
       />
     </main>
   </div>

--- a/packages/netlify-cms-core/src/components/Collection/__tests__/__snapshots__/Collection.spec.js.snap
+++ b/packages/netlify-cms-core/src/components/Collection/__tests__/__snapshots__/Collection.spec.js.snap
@@ -66,12 +66,9 @@ exports[`Collection should render with collection with create url 1`] = `
         collection="Map { \\"name\\": \\"pages\\", \\"sortableFields\\": List [], \\"view_filters\\": List [], \\"create\\": true }"
         newentryurl="/collections/pages/new"
       />
-      <mock-collection-controls
-        viewstyle="VIEW_STYLE_LIST"
-      />
+      <mock-collection-controls />
       <mock-entries-collection
         collection="Map { \\"name\\": \\"pages\\", \\"sortableFields\\": List [], \\"view_filters\\": List [], \\"create\\": true }"
-        viewstyle="VIEW_STYLE_LIST"
       />
     </main>
   </div>
@@ -103,13 +100,10 @@ exports[`Collection should render with collection with create url and path 1`] =
         collection="Map { \\"name\\": \\"pages\\", \\"sortableFields\\": List [], \\"view_filters\\": List [], \\"create\\": true }"
         newentryurl="/collections/pages/new?path=dir1/dir2"
       />
-      <mock-collection-controls
-        viewstyle="VIEW_STYLE_LIST"
-      />
+      <mock-collection-controls />
       <mock-entries-collection
         collection="Map { \\"name\\": \\"pages\\", \\"sortableFields\\": List [], \\"view_filters\\": List [], \\"create\\": true }"
         filterterm="dir1/dir2"
-        viewstyle="VIEW_STYLE_LIST"
       />
     </main>
   </div>
@@ -140,12 +134,9 @@ exports[`Collection should render with collection without create url 1`] = `
         collection="Map { \\"name\\": \\"pages\\", \\"sortableFields\\": List [], \\"view_filters\\": List [], \\"create\\": false }"
         newentryurl=""
       />
-      <mock-collection-controls
-        viewstyle="VIEW_STYLE_LIST"
-      />
+      <mock-collection-controls />
       <mock-entries-collection
         collection="Map { \\"name\\": \\"pages\\", \\"sortableFields\\": List [], \\"view_filters\\": List [], \\"create\\": false }"
-        viewstyle="VIEW_STYLE_LIST"
       />
     </main>
   </div>

--- a/packages/netlify-cms-core/src/reducers/entries.ts
+++ b/packages/netlify-cms-core/src/reducers/entries.ts
@@ -14,6 +14,7 @@ import {
   FILTER_ENTRIES_REQUEST,
   FILTER_ENTRIES_SUCCESS,
   FILTER_ENTRIES_FAILURE,
+  CHANGE_VIEW_STYLE,
 } from '../actions/entries';
 import { SEARCH_ENTRIES_SUCCESS } from '../actions/search';
 import {
@@ -42,6 +43,7 @@ import {
   FilterMap,
   EntriesFilterRequestPayload,
   EntriesFilterFailurePayload,
+  ChangeViewStylePayload,
 } from '../types/redux';
 import { folderFormatter } from '../lib/formatters';
 import { isAbsolutePath, basename } from 'netlify-cms-lib-util';
@@ -58,6 +60,7 @@ let page: number;
 let slug: string;
 
 const storageSortKey = 'netlify-cms.entries.sort';
+const viewStyleKey = 'netlify-cms.entries.viewStyle';
 type StorageSortObject = SortObject & { index: number };
 type StorageSort = { [collection: string]: { [key: string]: StorageSortObject } };
 
@@ -270,6 +273,22 @@ const entries = (
         map.setIn(['pages', collection, 'isFetching'], false);
       });
       return newState;
+    }
+
+    case CHANGE_VIEW_STYLE: {
+      const payload = (action.payload as unknown) as ChangeViewStylePayload;
+      const { style } = payload;
+
+      const oldStyle = localStorage.getItem(viewStyleKey);
+      if (oldStyle !== style) {
+        localStorage.setItem(viewStyleKey, style);
+
+        return state.withMutations(map => {
+          map.setIn(['viewStyle'], style);
+        });
+      }
+
+      return state;
     }
 
     default:

--- a/packages/netlify-cms-core/src/reducers/entries.ts
+++ b/packages/netlify-cms-core/src/reducers/entries.ts
@@ -50,6 +50,7 @@ import { isAbsolutePath, basename } from 'netlify-cms-lib-util';
 import { trim, once, sortBy, set, orderBy } from 'lodash';
 import { selectSortDataPath } from './collections';
 import { stringTemplate } from 'netlify-cms-lib-widgets';
+import { VIEW_STYLE_LIST } from '../constants/collectionViews';
 
 const { keyToPathArray } = stringTemplate;
 
@@ -325,6 +326,15 @@ export const selectEntriesFilterFields = (entries: Entries, collection: string) 
       .filter(v => v?.get('active') === true)
       .toArray() || [];
   return values;
+};
+
+export const selectViewStyle = () => {
+  const viewStyle = localStorage.getItem(viewStyleKey);
+  if (viewStyle == null) {
+    localStorage.setItem(viewStyleKey, VIEW_STYLE_LIST);
+    return VIEW_STYLE_LIST;
+  }
+  return viewStyle;
 };
 
 export const selectEntry = (state: Entries, collection: string, slug: string) =>

--- a/packages/netlify-cms-core/src/reducers/entries.ts
+++ b/packages/netlify-cms-core/src/reducers/entries.ts
@@ -111,8 +111,30 @@ const persistSort = (sort: Sort | undefined) => {
   }
 };
 
+const loadViewStyle = once(() => {
+  const viewStyle = localStorage.getItem(viewStyleKey);
+  if (viewStyle) {
+    return viewStyle;
+  }
+
+  localStorage.setItem(viewStyleKey, VIEW_STYLE_LIST);
+  return VIEW_STYLE_LIST;
+});
+
+const clearViewStyle = () => {
+  localStorage.removeItem(viewStyleKey);
+};
+
+const persistViewStyle = (viewStyle: string | undefined) => {
+  if (viewStyle) {
+    localStorage.setItem(viewStyleKey, viewStyle);
+  } else {
+    clearViewStyle();
+  }
+};
+
 const entries = (
-  state = Map({ entities: Map(), pages: Map(), sort: loadSort() }),
+  state = Map({ entities: Map(), pages: Map(), sort: loadSort(), viewStyle: loadViewStyle() }),
   action: EntriesAction,
 ) => {
   switch (action.type) {
@@ -279,18 +301,12 @@ const entries = (
     case CHANGE_VIEW_STYLE: {
       const payload = (action.payload as unknown) as ChangeViewStylePayload;
       const { style } = payload;
-
-      const oldStyle = localStorage.getItem(viewStyleKey);
-      if (oldStyle !== style) {
-        localStorage.setItem(viewStyleKey, style);
-
-        return state.withMutations(map => {
+      const newState = state.withMutations(map => {
           map.setIn(['viewStyle'], style);
         });
+      persistViewStyle(newState.get('viewStyle') as string);
+      return newState;
       }
-
-      return state;
-    }
 
     default:
       return state;

--- a/packages/netlify-cms-core/src/reducers/entries.ts
+++ b/packages/netlify-cms-core/src/reducers/entries.ts
@@ -302,11 +302,11 @@ const entries = (
       const payload = (action.payload as unknown) as ChangeViewStylePayload;
       const { style } = payload;
       const newState = state.withMutations(map => {
-          map.setIn(['viewStyle'], style);
-        });
+        map.setIn(['viewStyle'], style);
+      });
       persistViewStyle(newState.get('viewStyle') as string);
       return newState;
-      }
+    }
 
     default:
       return state;
@@ -344,13 +344,8 @@ export const selectEntriesFilterFields = (entries: Entries, collection: string) 
   return values;
 };
 
-export const selectViewStyle = () => {
-  const viewStyle = localStorage.getItem(viewStyleKey);
-  if (viewStyle == null) {
-    localStorage.setItem(viewStyleKey, VIEW_STYLE_LIST);
-    return VIEW_STYLE_LIST;
-  }
-  return viewStyle;
+export const selectViewStyle = (entries: Entries) => {
+  return entries.get('viewStyle');
 };
 
 export const selectEntry = (state: Entries, collection: string, slug: string) =>

--- a/packages/netlify-cms-core/src/types/redux.ts
+++ b/packages/netlify-cms-core/src/types/redux.ts
@@ -348,6 +348,10 @@ export interface EntriesFilterFailurePayload {
   error: Error;
 }
 
+export interface ChangeViewStylePayload {
+  style: string;
+}
+
 export interface EntriesMoveSuccessPayload extends EntryPayload {
   entries: EntryObject[];
 }

--- a/packages/netlify-cms-core/src/types/redux.ts
+++ b/packages/netlify-cms-core/src/types/redux.ts
@@ -75,6 +75,7 @@ export type Entries = StaticallyTypedRecord<{
   entities: Entities & EntitiesObject;
   sort: Sort;
   filter: Filter;
+  viewStyle: string;
 }>;
 
 export type Deploys = StaticallyTypedRecord<{}>;


### PR DESCRIPTION
**Summary**

fixes #3876 

Currently view style preference is not persisting in local storage.
This fixes save, maintain, and retrieve view style in local storage under `netlify-cms.entries.viewStyle` key

**Test plan**

The following image shows the saved view style in local storage

<img width="1440" alt="Screenshot" src="https://user-images.githubusercontent.com/11392022/89880933-69ffd380-dbf7-11ea-8110-a9b56b40e8cd.png">

**A picture of a cute animal (not mandatory but encouraged)**

<img width="400" alt="fox" src="https://user-images.githubusercontent.com/11392022/89881198-bfd47b80-dbf7-11ea-8341-63c2145acd7d.png">