### PR TITLE
fix(api): bitbucket implicit auth login delay

### DIFF
--- a/packages/netlify-cms-lib-util/src/API.ts
+++ b/packages/netlify-cms-lib-util/src/API.ts
@@ -151,7 +151,7 @@ export const isPreviewContext = (context: string, previewContext: string) => {
   if (previewContext) {
     return context === previewContext;
   }
-  return PREVIEW_CONTEXT_KEYWORDS.some((keyword) => context.includes(keyword));
+  return PREVIEW_CONTEXT_KEYWORDS.some(keyword => context.includes(keyword));
 };
 
 export enum PreviewState {
@@ -197,9 +197,9 @@ export const throwOnConflictingBranches = async (
   const possibleConflictingBranches = getConflictingBranches(branchName);
 
   const conflictingBranches = await Promise.all(
-    possibleConflictingBranches.map((b) =>
+    possibleConflictingBranches.map(b =>
       getBranch(b)
-        .then((b) => b.name)
+        .then(b => b.name)
         .catch(() => ''),
     ),
   );

--- a/packages/netlify-cms-lib-util/src/API.ts
+++ b/packages/netlify-cms-lib-util/src/API.ts
@@ -69,7 +69,9 @@ export const requestWithBackoff = async (
     }
     return response;
   } catch (err) {
-    if (attempt <= 5) {
+    if (attempt > 5 || err.message === "Can't refresh access token when using implicit auth") {
+      throw err;
+    } else {
       if (!api.rateLimiter) {
         const timeout = err.resetSeconds || attempt * attempt;
         console.log(
@@ -87,8 +89,6 @@ export const requestWithBackoff = async (
         }, 1000 * timeout);
       }
       return requestWithBackoff(api, req, attempt + 1);
-    } else {
-      throw err;
     }
   }
 };
@@ -151,7 +151,7 @@ export const isPreviewContext = (context: string, previewContext: string) => {
   if (previewContext) {
     return context === previewContext;
   }
-  return PREVIEW_CONTEXT_KEYWORDS.some(keyword => context.includes(keyword));
+  return PREVIEW_CONTEXT_KEYWORDS.some((keyword) => context.includes(keyword));
 };
 
 export enum PreviewState {
@@ -197,9 +197,9 @@ export const throwOnConflictingBranches = async (
   const possibleConflictingBranches = getConflictingBranches(branchName);
 
   const conflictingBranches = await Promise.all(
-    possibleConflictingBranches.map(b =>
+    possibleConflictingBranches.map((b) =>
       getBranch(b)
-        .then(b => b.name)
+        .then((b) => b.name)
         .catch(() => ''),
     ),
   );


### PR DESCRIPTION
**Summary**

Fixes #4183. If a bitbucket auth token expires when using implicit auth, when the user tries to log in again they need to wait for repeated failing attempts to refresh the token. This PR check for the error message in the requestWithBackoff and throws an error instead of continuing to make new requests.

**Test plan**

All existing tests pass. Need help to properly test this locally, is there a way to mock in a bitbucket backend and try out the login page?