### PR TITLE
fix(slugs): escape special characters in slugs

### DIFF
--- a/packages/netlify-cms-core/src/lib/__tests__/formatters.spec.js
+++ b/packages/netlify-cms-core/src/lib/__tests__/formatters.spec.js
@@ -241,6 +241,34 @@ describe('formatters', () => {
       expect(prepareSlug(`sl'ug`)).toBe('slug');
     });
 
+    it('should remove double quotes', () => {
+      expect(prepareSlug(`s"lu"g`)).toBe('slug');
+    });
+
+    it('should remove curly quotes', () => {
+      expect(prepareSlug(`s‘lu’g`)).toBe('slug');
+    });
+
+    it('should remove curly double quotes', () => {
+      expect(prepareSlug(`s“lu”g`)).toBe('slug');
+    });
+
+    it('should remove double quotes', () => {
+      expect(prepareSlug(`s"lu"g`)).toBe('slug');
+    });
+
+    it('should remove commas', () => {
+      expect(prepareSlug(`slu,g`)).toBe('slug');
+    });
+
+    it('should remove exclamation marks', () => {
+      expect(prepareSlug(`slu!g`)).toBe('slug');
+    });
+
+    it('should remove question marks', () => {
+      expect(prepareSlug(`slu?g`)).toBe('slug');
+    });
+
     it('should replace periods with slashes', () => {
       expect(prepareSlug(`sl.ug`)).toBe('sl-ug');
     });

--- a/packages/netlify-cms-core/src/lib/formatters.ts
+++ b/packages/netlify-cms-core/src/lib/formatters.ts
@@ -95,8 +95,8 @@ export const prepareSlug = (slug: string) => {
       // Convert slug to lower-case
       .toLocaleLowerCase()
 
-      // Remove single quotes.
-      .replace(/[']/g, '')
+      // Remove special characters.
+      .replace(/[!?,'"”’“‘]/g, '')
 
       // Replace periods with dashes.
       .replace(/[.]/g, '-')


### PR DESCRIPTION
**Summary**

Fixes #4212. Removes special characters from slugs to prevent errors in loading pages at invalid routes. 

**Test plan**

Added unit tests to ensure the additional characters are being properly removed from the slugs.