### PR TITLE
feat(core) feat(lib-widget) Add {{dirname}} to summary and preview_path

### DIFF
--- a/dev-test/config.yml
+++ b/dev-test/config.yml
@@ -56,16 +56,21 @@ collections: # A list of collections the CMS should be able to edit
 
   - name: 'nested_collection'
     create: true
-    label: 'Nested Collection'
+    label: 'Pages'
+    label_singular: 'Page'
     folder: '_nested'
-    preview_path: '{{nested_path}}'
-    summary: '{{title}} - [{{nested_path}}]'
-    nested: { depth: 100, summary: '{{meta.path}}' }
+    preview_path: '{{dirname}}'
+    media_folder: '/{{media_folder}}/pages/{{dirname}}'
+    summary: '{{title}} - [{{dirname}}]'
+    nested: { depth: 100 }
     meta: { path: { widget: string, label: 'Path', index_file: 'index' } }
     fields:
       - label: 'Title'
         name: 'title'
         widget: 'string'
+      - label: 'Image'
+        name: 'image'
+        widget: 'image'
 
   - name: 'settings'
     label: 'Settings'

--- a/dev-test/config.yml
+++ b/dev-test/config.yml
@@ -1,9 +1,11 @@
 backend:
-  name: test-repo
+  name: proxy
+  proxy_url: http://localhost:8081/api/v1
+  branch: master
 
 site_url: https://example.com
 
-publish_mode: editorial_workflow
+#publish_mode: editorial_workflow
 media_folder: assets/uploads
 
 collections: # A list of collections the CMS should be able to edit
@@ -75,12 +77,13 @@ collections: # A list of collections the CMS should be able to edit
   - name: 'settings'
     label: 'Settings'
     delete: false # Prevent users from deleting documents in this collection
+    summary: '{{title}} -- {{dirname}}'
     editor:
       preview: false
     files:
       - name: 'general'
         label: 'Site Settings'
-        file: '_data/settings.json'
+        file: '_data/blah/settings.json'
         description: 'General Site Settings'
         fields:
           - { label: 'Global title', name: 'site_title', widget: 'string' }

--- a/dev-test/config.yml
+++ b/dev-test/config.yml
@@ -1,11 +1,9 @@
 backend:
-  name: proxy
-  proxy_url: http://localhost:8081/api/v1
-  branch: master
+  name: test-repo
 
 site_url: https://example.com
 
-#publish_mode: editorial_workflow
+publish_mode: editorial_workflow
 media_folder: assets/uploads
 
 collections: # A list of collections the CMS should be able to edit
@@ -77,13 +75,12 @@ collections: # A list of collections the CMS should be able to edit
   - name: 'settings'
     label: 'Settings'
     delete: false # Prevent users from deleting documents in this collection
-    summary: '{{title}} -- {{dirname}}'
     editor:
       preview: false
     files:
       - name: 'general'
         label: 'Site Settings'
-        file: '_data/blah/settings.json'
+        file: '_data/settings.json'
         description: 'General Site Settings'
         fields:
           - { label: 'Global title', name: 'site_title', widget: 'string' }

--- a/dev-test/config.yml
+++ b/dev-test/config.yml
@@ -54,24 +54,6 @@ collections: # A list of collections the CMS should be able to edit
       - { label: 'Question', name: 'title', widget: 'string', tagname: 'h1' }
       - { label: 'Answer', name: 'body', widget: 'markdown' }
 
-  - name: 'nested_collection'
-    create: true
-    label: 'Pages'
-    label_singular: 'Page'
-    folder: '_nested'
-    preview_path: '{{dirname}}'
-    media_folder: '/{{media_folder}}/pages/{{dirname}}'
-    summary: '{{title}} - [{{dirname}}]'
-    nested: { depth: 100 }
-    meta: { path: { widget: string, label: 'Path', index_file: 'index' } }
-    fields:
-      - label: 'Title'
-        name: 'title'
-        widget: 'string'
-      - label: 'Image'
-        name: 'image'
-        widget: 'image'
-
   - name: 'settings'
     label: 'Settings'
     delete: false # Prevent users from deleting documents in this collection

--- a/dev-test/config.yml
+++ b/dev-test/config.yml
@@ -54,6 +54,19 @@ collections: # A list of collections the CMS should be able to edit
       - { label: 'Question', name: 'title', widget: 'string', tagname: 'h1' }
       - { label: 'Answer', name: 'body', widget: 'markdown' }
 
+  - name: 'nested_collection'
+    create: true
+    label: 'Nested Collection'
+    folder: '_nested'
+    preview_path: '{{nested_path}}'
+    summary: '{{title}} - [{{nested_path}}]'
+    nested: { depth: 100, summary: '{{meta.path}}' }
+    meta: { path: { widget: string, label: 'Path', index_file: 'index' } }
+    fields:
+      - label: 'Title'
+        name: 'title'
+        widget: 'string'
+
   - name: 'settings'
     label: 'Settings'
     delete: false # Prevent users from deleting documents in this collection

--- a/packages/netlify-cms-core/src/backend.ts
+++ b/packages/netlify-cms-core/src/backend.ts
@@ -474,6 +474,7 @@ export class Backend {
           label: loadedEntry.file.label,
           author: loadedEntry.file.author,
           updatedOn: loadedEntry.file.updatedOn,
+          meta: { path: prepareMetaPath(loadedEntry.file.path, collection) },
         },
       ),
     );

--- a/packages/netlify-cms-core/src/lib/__tests__/formatters.spec.js
+++ b/packages/netlify-cms-core/src/lib/__tests__/formatters.spec.js
@@ -402,6 +402,38 @@ describe('formatters', () => {
       ).toBe('https://www.example.com/posts/title.md');
     });
 
+    it('should compile the dirname template value to empty in a regular collection', () => {
+      expect(
+        previewUrlFormatter(
+          'https://www.example.com',
+          Map({
+            folder: '_portfolio',
+            preview_path: 'portfolio/{{dirname}}',
+          }),
+          'backendSlug',
+          slugConfig,
+          Map({ data: Map({}), path: '_portfolio/i-am-the-slug.md' }),
+        ),
+      ).toBe('https://www.example.com/portfolio/');
+    });
+
+    it('should compile dirname template value when in a nested collection', () => {
+      expect(
+        previewUrlFormatter(
+          'https://www.example.com',
+          Map({
+            folder: '_portfolio',
+            preview_path: 'portfolio/{{dirname}}',
+            nested: { depth: 100 },
+            meta: { path: { widget: 'string', label: 'Path', index_file: 'index' } },
+          }),
+          'backendSlug',
+          slugConfig,
+          Map({ data: Map({}), path: '_portfolio/drawing/i-am-the-slug/index.md' }),
+        ),
+      ).toBe('https://www.example.com/portfolio/drawing/i-am-the-slug');
+    });
+
     it('should log error and ignore preview_path when date is missing', () => {
       jest.spyOn(console, 'error').mockImplementation(() => {});
       expect(
@@ -448,6 +480,46 @@ describe('formatters', () => {
       expect(
         summaryFormatter('{{title}}-{{year}}-{{filename}}.{{extension}}', entry, collection),
       ).toBe('title-2020-post.md');
+    });
+
+    it('should handle the dirname variable in a regular collection', () => {
+      const { selectInferedField } = require('../../reducers/collections');
+      selectInferedField.mockReturnValue('date');
+
+      const date = new Date('2020-01-02T13:28:27.679Z');
+      const entry = fromJS({
+        path: '_portfolio/drawing.md',
+        data: { date, title: 'title' },
+      });
+      const collection = fromJS({
+        folder: '_portfolio',
+        fields: [{ name: 'date', widget: 'date' }],
+      });
+
+      expect(summaryFormatter('{{dirname}}/{{title}}-{{year}}', entry, collection)).toBe(
+        '/title-2020',
+      );
+    });
+
+    it('should handle the dirname variable in a nested collection', () => {
+      const { selectInferedField } = require('../../reducers/collections');
+      selectInferedField.mockReturnValue('date');
+
+      const date = new Date('2020-01-02T13:28:27.679Z');
+      const entry = fromJS({
+        path: '_portfolio/drawing/index.md',
+        data: { date, title: 'title' },
+      });
+      const collection = fromJS({
+        folder: '_portfolio',
+        nested: { depth: 100 },
+        meta: { path: { widget: 'string', label: 'Path', index_file: 'index' } },
+        fields: [{ name: 'date', widget: 'date' }],
+      });
+
+      expect(summaryFormatter('{{dirname}}/{{title}}-{{year}}', entry, collection)).toBe(
+        'drawing/title-2020',
+      );
     });
   });
 
@@ -518,6 +590,51 @@ describe('formatters', () => {
           slugConfig,
         ),
       ).toBe('md');
+    });
+
+    it('should compile dirname template value in a regular collection', () => {
+      const entry = fromJS({
+        path: 'content/en/hosting-and-deployment/deployment-with-nanobox.md',
+        data: { category: 'Hosting And Deployment' },
+      });
+      const collection = fromJS({
+        folder: 'content/en/',
+      });
+
+      expect(
+        folderFormatter(
+          '{{dirname}}',
+          entry,
+          collection,
+          'static/images',
+          'media_folder',
+          slugConfig,
+        ),
+      ).toBe('hosting-and-deployment');
+    });
+
+    it('should compile dirname template value in a nested collection', () => {
+      const entry = fromJS({
+        path: '_portfolio/drawing/i-am-the-slug/index.md',
+        data: { category: 'Hosting And Deployment' },
+      });
+      const collection = fromJS({
+        folder: '_portfolio',
+        nested: { depth: 100 },
+        meta: { path: { widget: 'string', label: 'Path', index_file: 'index' } },
+        fields: [{ name: 'date', widget: 'date' }]
+      });
+
+      expect(
+        folderFormatter(
+          '{{dirname}}',
+          entry,
+          collection,
+          'static/images',
+          'media_folder',
+          slugConfig,
+        ),
+      ).toBe('drawing/i-am-the-slug');
     });
   });
 });

--- a/packages/netlify-cms-core/src/lib/__tests__/formatters.spec.js
+++ b/packages/netlify-cms-core/src/lib/__tests__/formatters.spec.js
@@ -622,7 +622,7 @@ describe('formatters', () => {
         folder: '_portfolio',
         nested: { depth: 100 },
         meta: { path: { widget: 'string', label: 'Path', index_file: 'index' } },
-        fields: [{ name: 'date', widget: 'date' }]
+        fields: [{ name: 'date', widget: 'date' }],
       });
 
       expect(

--- a/packages/netlify-cms-core/src/lib/formatters.ts
+++ b/packages/netlify-cms-core/src/lib/formatters.ts
@@ -18,6 +18,7 @@ const {
   SLUG_MISSING_REQUIRED_DATE,
   keyToPathArray,
   addFileTemplateFields,
+  addNestedPath,
 } = stringTemplate;
 
 const commitMessageTemplates = Map({
@@ -165,13 +166,17 @@ export const previewUrlFormatter = (
   const pathTemplate = collection.get('preview_path') as string;
   let fields = entry.get('data') as Map<string, string>;
   fields = addFileTemplateFields(entry.get('path'), fields);
+  fields = addNestedPath(entry.get('meta')?.get('path'), fields);
   const dateFieldName =
     collection.get('preview_path_date_field') || selectInferedField(collection, 'date');
   const date = parseDateFromEntry((entry as unknown) as Map<string, unknown>, dateFieldName);
 
   // Prepare and sanitize slug variables only, leave the rest of the
   // `preview_path` template as is.
-  const processSegment = getProcessSegment(slugConfig);
+  const processSegment = (value: string, key: string) => {
+    // `nested_path` should not be sanitized
+    return key === 'nested_path' ? value : getProcessSegment(slugConfig)(value, key);
+  };
   let compiledPath;
 
   try {
@@ -208,6 +213,7 @@ export const summaryFormatter = (
   const identifier = entryData.getIn(keyToPathArray(selectIdentifier(collection) as string));
 
   entryData = addFileTemplateFields(entry.get('path'), entryData);
+  entryData = addNestedPath(entry.get('meta')?.get('path'), entryData);
   // allow commit information in summary template
   if (entry.get('author') && !selectField(collection, COMMIT_AUTHOR)) {
     entryData = entryData.set(COMMIT_AUTHOR, entry.get('author'));
@@ -233,6 +239,7 @@ export const folderFormatter = (
 
   let fields = (entry.get('data') as Map<string, string>).set(folderKey, defaultFolder);
   fields = addFileTemplateFields(entry.get('path'), fields);
+  fields = addNestedPath(entry.get('meta')?.get('path'), fields);
 
   const date =
     parseDateFromEntry(

--- a/packages/netlify-cms-lib-widgets/src/stringTemplate.ts
+++ b/packages/netlify-cms-lib-widgets/src/stringTemplate.ts
@@ -1,7 +1,7 @@
 import moment from 'moment';
 import { Map } from 'immutable';
-import { basename, extname } from 'path';
-import { get, trimEnd, trim } from 'lodash';
+import { basename, extname, dirname } from 'path';
+import { get, trimEnd } from 'lodash';
 
 const FIELD_PREFIX = 'fields.';
 const templateContentPattern = '[^}{]+';
@@ -169,29 +169,30 @@ export function extractTemplateVars(template: string) {
   });
 }
 
-export const addFileTemplateFields = (entryPath: string, fields: Map<string, string>) => {
+/**
+ * Appends `dirname`, `filename` and `extension` to the provided `fields` map.
+ * @param entryPath
+ * @param fields
+ * @param folder - optionally include a folder that the dirname will be relative to.
+ *   eg: `addFileTemplateFields('foo/bar/baz.ext', fields, 'foo')`
+ *       will result in: `{ dirname: 'bar', filename: 'baz', extension: 'ext' }`
+ */
+export const addFileTemplateFields = (
+  entryPath: string,
+  fields: Map<string, string>,
+  folder = '',
+) => {
   if (!entryPath) {
     return fields;
   }
 
   const extension = extname(entryPath);
   const filename = basename(entryPath, extension);
+  const dirnameExcludingFolder = dirname(entryPath).replace(new RegExp(`^(/?)${folder}/?`), '$1');
   fields = fields.withMutations(map => {
+    map.set('dirname', dirnameExcludingFolder);
     map.set('filename', filename);
     map.set('extension', extension === '' ? extension : extension.substr(1));
-  });
-
-  return fields;
-};
-
-export const addNestedPath = (nestedPath: string, fields: Map<string, string>) => {
-  if (!nestedPath) {
-    return fields;
-  }
-
-  fields = fields.withMutations(map => {
-    // Ensure the nested_path is always prefixed with a slash and has no trailing slash.
-    map.set('nested_path', `/${trim(nestedPath, '/')}`);
   });
 
   return fields;

--- a/packages/netlify-cms-lib-widgets/src/stringTemplate.ts
+++ b/packages/netlify-cms-lib-widgets/src/stringTemplate.ts
@@ -115,7 +115,7 @@ export function compileStringTemplate(
   date: Date | undefined | null,
   identifier = '',
   data = Map<string, unknown>(),
-  processor?: (value: string, key: string) => string,
+  processor?: (value: string) => string,
 ) {
   let missingRequiredDate;
 
@@ -143,7 +143,7 @@ export function compileStringTemplate(
       }
 
       if (processor) {
-        return processor(replacement, key);
+        return processor(replacement);
       }
 
       return replacement;

--- a/packages/netlify-cms-lib-widgets/src/stringTemplate.ts
+++ b/packages/netlify-cms-lib-widgets/src/stringTemplate.ts
@@ -1,7 +1,7 @@
 import moment from 'moment';
 import { Map } from 'immutable';
 import { basename, extname } from 'path';
-import { get, trimEnd } from 'lodash';
+import { get, trimEnd, trim } from 'lodash';
 
 const FIELD_PREFIX = 'fields.';
 const templateContentPattern = '[^}{]+';
@@ -115,7 +115,7 @@ export function compileStringTemplate(
   date: Date | undefined | null,
   identifier = '',
   data = Map<string, unknown>(),
-  processor?: (value: string) => string,
+  processor?: (value: string, key: string) => string,
 ) {
   let missingRequiredDate;
 
@@ -143,7 +143,7 @@ export function compileStringTemplate(
       }
 
       if (processor) {
-        return processor(replacement);
+        return processor(replacement, key);
       }
 
       return replacement;
@@ -179,6 +179,19 @@ export const addFileTemplateFields = (entryPath: string, fields: Map<string, str
   fields = fields.withMutations(map => {
     map.set('filename', filename);
     map.set('extension', extension === '' ? extension : extension.substr(1));
+  });
+
+  return fields;
+};
+
+export const addNestedPath = (nestedPath: string, fields: Map<string, string>) => {
+  if (!nestedPath) {
+    return fields;
+  }
+
+  fields = fields.withMutations(map => {
+    // Ensure the nested_path is always prefixed with a slash and has no trailing slash.
+    map.set('nested_path', `/${trim(nestedPath, '/')}`);
   });
 
   return fields;

--- a/website/content/docs/beta-features.md
+++ b/website/content/docs/beta-features.md
@@ -248,6 +248,7 @@ And for the image field being populated with a value of `image.png`.
 
 Supports all of the [`slug` templates](/docs/configuration-options#slug) and:
 
+- `{{dirname}}` The path to the file's parent directory, relative to the collection's `folder`.
 - `{{filename}}` The file name without the extension part.
 - `{{extension}}` The file extension.
 - `{{media_folder}}` The global `media_folder`.

--- a/website/content/docs/configuration-options.md
+++ b/website/content/docs/configuration-options.md
@@ -293,6 +293,7 @@ Template tags are the same as those for [slug](#slug), with the following except
 
 * `{{slug}}` is the entire slug for the current entry (not just the url-safe identifier, as is the case with [`slug` configuration](#slug))
 * The date based template tags, such as `{{year}}` and `{{month}}`, are pulled from a date field in your entry, and may require additional configuration - see [`preview_path_date_field`](#preview_path_date_field) for details. If a date template tag is used and no date can be found, `preview_path` will be ignored.
+* `{{dirname}}` The path to the file's parent directory, relative to the collection's `folder`.
 * `{{filename}}` The file name without the extension part.
 * `{{extension}}` The file extension.
 
@@ -373,6 +374,7 @@ This setting allows the customization of the collection list view. Similar to th
 
 Template tags are the same as those for [slug](#slug), with the following additions:
 
+* `{{dirname}}` The path to the file's parent directory, relative to the collection's `folder`.
 * `{{filename}}` The file name without the extension part.
 * `{{extension}}` The file extension.
 * `{{commit_date}}` The file commit date on supported backends (git based backends).


### PR DESCRIPTION
Related to: #445

**Summary**

This PR allows the generated `meta.path` to be accessible in `summary` and `preview_path` when using nested collections.

eg:

```yaml
collections:
  - name: 'pages'
    create: true
    label: 'Pages'
    label_singular: 'Page'
    folder: 'src/content/pages'
    preview_path: '{{dirname}}'
    media_folder: '/{{media_folder}}/pages/{{dirname}}'
    summary: '{{title}} - {{dirname}}'
    nested: { depth: 100 }
    meta: { path: { widget: string, label: 'Path', index_file: 'index' } }
    fields:
      - label: 'Title'
        name: 'title'
        widget: 'string'
      - label: 'Image'
        name: 'image'
        widget: 'image'
      - label: 'Body'
        name: 'body'
        widget: 'markdown'
```

**Docs Preview** 

https://deploy-preview-4279--netlify-cms-www.netlify.app/docs/configuration-options/#preview_path
https://deploy-preview-4279--netlify-cms-www.netlify.app/docs/configuration-options/#summary
https://deploy-preview-4279--netlify-cms-www.netlify.app/docs/beta-features/#folder-collections-media-and-public-folder

**Questions for reviewers**

- Is the naming convention of the PR title okay?
- ~~Thoughts on using `nested_path` as the template key?~~ Going with `dirname`
- ~~Where should I document this? In the [Beta Features](https://www.netlifycms.org/docs/beta-features/#nested-collections) or [`summary`](https://www.netlifycms.org/docs/configuration-options/#summary) and [`preview_path`](https://www.netlifycms.org/docs/configuration-options/#preview_path) sections?~~ 

**Test plan**

1. Set up the config as above.
1. Create a new "Nested Collection" with a `Path` set to `dir-a/dir-b/hello-world` and a `Title` of `Hello World`
1. Save and publish
1. Return to "Contents" list. The newly created item should look like this screenshot (Note the summary now includes the `nested_path`):
![Screen Shot 2020-09-08 at 9 14 16 am](https://user-images.githubusercontent.com/3537963/92419920-b10bc500-f1b3-11ea-890d-0cfce661618e.png)
1. Click on the `Hello World` item to go into edit view
1. Observe the destination for the "View Live" link. It should point to `https://example.com/dir-a/dir-b/hello-world`

![Screen Shot 2020-09-08 at 9 15 10 am](https://user-images.githubusercontent.com/3537963/92420079-a998eb80-f1b4-11ea-9b4a-9e69b9d46d70.png)



**To Do**

- [X] Write tests
- [X] Update docs

**A picture of a cute animal (not mandatory but encouraged)**

My parents' dogs:
![IMG_20200226_114708](https://user-images.githubusercontent.com/3537963/92342682-e0172d80-f104-11ea-9085-d699fc77b9c7.jpg)

