### PR TITLE
fix: allow per-file preview_path in file collection

### DIFF
--- a/packages/netlify-cms-core/src/constants/configSchema.js
+++ b/packages/netlify-cms-core/src/constants/configSchema.js
@@ -187,6 +187,8 @@ const getConfigSchema = () => ({
                 label_singular: { type: 'string' },
                 description: { type: 'string' },
                 file: { type: 'string' },
+                preview_path: { type: 'string' },
+                preview_path_date_field: { type: 'string' },
                 fields: fieldsConfig(),
               },
               required: ['name', 'label', 'file', 'fields'],

--- a/packages/netlify-cms-core/src/lib/__tests__/formatters.spec.js
+++ b/packages/netlify-cms-core/src/lib/__tests__/formatters.spec.js
@@ -1,4 +1,4 @@
-import { Map, fromJS } from 'immutable';
+import { List, Map, fromJS } from 'immutable';
 import {
   commitMessageFormatter,
   prepareSlug,
@@ -367,6 +367,40 @@ describe('formatters', () => {
           Map({ data: Map({ customDateField: date, slug: 'entrySlug', title: 'title' }) }),
         ),
       ).toBe('https://www.example.com/2020/backendslug/title/entryslug');
+    });
+
+    it('should return preview url for files in file collection', () => {
+      expect(
+        previewUrlFormatter(
+          'https://www.example.com',
+          Map({
+            preview_path: '{{slug}}/{{title}}/{{fields.slug}}',
+            type: 'file_based_collection',
+            files: List([
+              Map({ name: 'about-file', preview_path: '{{slug}}/{{fields.slug}}/{{title}}' }),
+            ]),
+          }),
+          'backendSlug',
+          slugConfig,
+          Map({ data: Map({ slug: 'about-the-project', title: 'title' }), slug: 'about-file' }),
+        ),
+      ).toBe('https://www.example.com/backendslug/about-the-project/title');
+    });
+
+    it('should fall back to collection preview url for files in file collection', () => {
+      expect(
+        previewUrlFormatter(
+          'https://www.example.com',
+          Map({
+            preview_path: '{{slug}}/{{title}}/{{fields.slug}}',
+            type: 'file_based_collection',
+            files: List([Map({ name: 'about-file' })]),
+          }),
+          'backendSlug',
+          slugConfig,
+          Map({ data: Map({ slug: 'about-the-project', title: 'title' }), slug: 'about-file' }),
+        ),
+      ).toBe('https://www.example.com/backendslug/title/about-the-project');
     });
 
     it('should infer date field when preview_path_date_field is not configured', () => {

--- a/packages/netlify-cms-core/src/lib/formatters.ts
+++ b/packages/netlify-cms-core/src/lib/formatters.ts
@@ -166,11 +166,25 @@ export const previewUrlFormatter = (
    * URL path.
    */
   const basePath = trimEnd(baseUrl, '/');
-  const pathTemplate = collection.get('preview_path') as string;
+
+  let filePathTemplate;
+  let fileDateField;
+  if (collection.get('type') === 'file_based_collection') {
+    const files = collection.get('files');
+    const fileName = entry.get('slug');
+    const file = files?.find(f => f?.get('name') === fileName);
+    filePathTemplate = file?.get('preview_path') as string;
+    fileDateField = file?.get('preview_path_date_field') as string;
+  }
+
+  const pathTemplate = filePathTemplate || (collection.get('preview_path') as string);
+
   let fields = entry.get('data') as Map<string, string>;
   fields = addFileTemplateFields(entry.get('path'), fields, collection.get('folder'));
   const dateFieldName =
-    collection.get('preview_path_date_field') || selectInferedField(collection, 'date');
+    fileDateField ||
+    collection.get('preview_path_date_field') ||
+    selectInferedField(collection, 'date');
   const date = parseDateFromEntry((entry as unknown) as Map<string, unknown>, dateFieldName);
 
   // Prepare and sanitize slug variables only, leave the rest of the

--- a/packages/netlify-cms-core/src/types/redux.ts
+++ b/packages/netlify-cms-core/src/types/redux.ts
@@ -140,6 +140,8 @@ export type CollectionFile = StaticallyTypedRecord<{
   label: string;
   media_folder?: string;
   public_folder?: string;
+  preview_path?: string;
+  preview_path_date_field?: string;
 }>;
 
 export type CollectionFiles = List<CollectionFile>;


### PR DESCRIPTION
**Summary**

currently, the `preview_path` setting is only applied for whole collections. for file-collections this means that is not possible to set a `preview_path` for an individual file in a file collection.

this pr allows setting `preview_path` on the file level.

closes #2262