### PR TITLE
fix: allow setting per-file editor preview

### DIFF
--- a/packages/netlify-cms-core/src/components/Editor/EditorInterface.js
+++ b/packages/netlify-cms-core/src/components/Editor/EditorInterface.js
@@ -17,6 +17,8 @@ import EditorControlPane from './EditorControlPane/EditorControlPane';
 import EditorPreviewPane from './EditorPreviewPane/EditorPreviewPane';
 import EditorToolbar from './EditorToolbar';
 import { hasI18n, getI18nInfo, getPreviewEntry } from '../../lib/i18n';
+import { FILES } from '../../constants/collectionTypes';
+import { getFileFromSlug } from '../../reducers/collections';
 
 const PREVIEW_VISIBLE = 'cms.preview-visible';
 const SCROLL_SYNC_ENABLED = 'cms.scroll-sync-enabled';
@@ -135,6 +137,15 @@ const EditorContent = ({
   }
 };
 
+function isPreviewEnabled(collection, entry) {
+  if (collection.get('type') === FILES) {
+    const file = getFileFromSlug(collection, entry.get('slug'));
+    const previewEnabled = file?.getIn(['editor', 'preview']);
+    if (previewEnabled != null) return previewEnabled;
+  }
+  return collection.getIn(['editor', 'preview'], true);
+}
+
 class EditorInterface extends Component {
   state = {
     showEventBlocker: false,
@@ -221,14 +232,9 @@ class EditorInterface extends Component {
     } = this.props;
 
     const { scrollSyncEnabled, showEventBlocker } = this.state;
-    let previewEnabled;
-    if (collection.get('type') === 'file_based_collection') {
-      const files = collection.get('files');
-      const fileName = entry.get('slug');
-      const file = files?.find(f => f?.get('name') === fileName);
-      previewEnabled = file?.getIn(['editor', 'preview']);
-    }
-    previewEnabled = previewEnabled ?? collection.getIn(['editor', 'preview'], true);
+
+    const previewEnabled = isPreviewEnabled(collection, entry);
+
     const collectionI18nEnabled = hasI18n(collection);
     const { locales, defaultLocale } = getI18nInfo(this.props.collection);
     const editorProps = {

--- a/packages/netlify-cms-core/src/components/Editor/EditorInterface.js
+++ b/packages/netlify-cms-core/src/components/Editor/EditorInterface.js
@@ -221,7 +221,14 @@ class EditorInterface extends Component {
     } = this.props;
 
     const { scrollSyncEnabled, showEventBlocker } = this.state;
-    const collectionPreviewEnabled = collection.getIn(['editor', 'preview'], true);
+    let previewEnabled;
+    if (collection.get('type') === 'file_based_collection') {
+      const files = collection.get('files');
+      const fileName = entry.get('slug');
+      const file = files?.find(f => f?.get('name') === fileName);
+      previewEnabled = file?.getIn(['editor', 'preview']);
+    }
+    previewEnabled = previewEnabled ?? collection.getIn(['editor', 'preview'], true);
     const collectionI18nEnabled = hasI18n(collection);
     const { locales, defaultLocale } = getI18nInfo(this.props.collection);
     const editorProps = {
@@ -300,7 +307,7 @@ class EditorInterface extends Component {
     );
 
     const i18nVisible = collectionI18nEnabled && this.state.i18nVisible;
-    const previewVisible = collectionPreviewEnabled && this.state.previewVisible;
+    const previewVisible = previewEnabled && this.state.previewVisible;
     const scrollSyncVisible = i18nVisible || previewVisible;
 
     return (
@@ -349,7 +356,7 @@ class EditorInterface extends Component {
                 marginTop="70px"
               />
             )}
-            {collectionPreviewEnabled && (
+            {previewEnabled && (
               <EditorToggle
                 isActive={previewVisible}
                 onClick={this.handleTogglePreview}

--- a/packages/netlify-cms-core/src/reducers/collections.ts
+++ b/packages/netlify-cms-core/src/reducers/collections.ts
@@ -146,7 +146,7 @@ export const getFileFromSlug = (collection: Collection, slug: string) => {
   return collection
     .get('files')
     ?.toArray()
-    .find((f) => f.get('name') === slug);
+    .find(f => f.get('name') === slug);
 };
 
 export const selectFieldsWithMediaFolders = (collection: Collection, slug: string) => {

--- a/packages/netlify-cms-core/src/reducers/collections.ts
+++ b/packages/netlify-cms-core/src/reducers/collections.ts
@@ -142,11 +142,11 @@ const getFieldsWithMediaFolders = (fields: EntryField[]) => {
   return fieldsWithMediaFolders;
 };
 
-const getFileFromSlug = (collection: Collection, slug: string) => {
+export const getFileFromSlug = (collection: Collection, slug: string) => {
   return collection
     .get('files')
     ?.toArray()
-    .filter(f => f.get('name') === slug)[0];
+    .find((f) => f.get('name') === slug);
 };
 
 export const selectFieldsWithMediaFolders = (collection: Collection, slug: string) => {


### PR DESCRIPTION
**Summary**

currently, the editor preview pane can only be configured on the collection level. for file-based collections it is not possible to set editor preview for individual files. this pr adds that.

closes #3581