### PR TITLE
chore: use webpack serve instead of webpack-dev-server

### DIFF
--- a/packages/netlify-cms/package.json
+++ b/packages/netlify-cms/package.json
@@ -9,8 +9,8 @@
   "scripts": {
     "webpack": "node --max_old_space_size=4096 ../../node_modules/webpack/bin/webpack.js",
     "build": "cross-env NODE_ENV=production run-s webpack",
-    "build-preview": "cross-env NODE_ENV=production webpack-dev-server --open",
-    "develop": "webpack-dev-server --hot"
+    "build-preview": "cross-env NODE_ENV=production webpack serve --open",
+    "develop": "webpack serve --hot"
   },
   "keywords": [
     "netlify",


### PR DESCRIPTION
See https://github.com/webpack/webpack-dev-server/issues/2759

`yarn start` stopped working due to https://github.com/netlify/netlify-cms/pull/4451