### PR TITLE
Fixes #3807 by ensuring we don't attempt to split an empty string.

### DIFF
--- a/packages/netlify-cms-widget-list/src/ListControl.js
+++ b/packages/netlify-cms-widget-list/src/ListControl.js
@@ -154,8 +154,8 @@ export default class ListControl extends React.Component {
   handleChange = e => {
     const { onChange } = this.props;
     const oldValue = this.state.value;
-    const newValue = e.target.value;
-    const listValue = e.target.value.split(',');
+    const newValue = e.target.value.trim();
+    const listValue = newValue ? newValue.split(',') : [];
     if (newValue.match(/,$/) && oldValue.match(/, $/)) {
       listValue.pop();
     }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines.

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first two fields are mandatory:
-->

**Summary**

Fixes #3807 ("Removing all values from the list with empty array as default value results in array of one empty string")

As per issue #3807 , the Widget List would save an array with an empty string when attempting to delete all elements from the widget.

The source of the problem is that splitting an empty string in Javascript returns an array with an empty string - this is as the language is designed, see: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/split

<!--
Explain the **motivation** for making this change.
What existing problem does the pull request solve?
-->

**Test plan**

<!--
Demonstrate the code is solid.
Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.
-->

I ran `yarn test` and `yarn format`.

**A picture of a cute animal (not mandatory but encouraged)**

![image](https://user-images.githubusercontent.com/23342513/96347267-6de91f80-1098-11eb-8a3e-a38bd695a27b.png)

