### PR TITLE
feat: add add_to_top option to list widget

### DIFF
--- a/packages/netlify-cms-widget-list/src/ListControl.js
+++ b/packages/netlify-cms-widget-list/src/ListControl.js
@@ -180,16 +180,12 @@ export default class ListControl extends React.Component {
 
   handleAdd = e => {
     e.preventDefault();
-    const { value, onChange, field } = this.props;
+    const { field } = this.props;
     const parsedValue =
       this.getValueType() === valueTypes.SINGLE
         ? this.singleDefault()
         : fromJS(this.multipleDefault(field.get('fields')));
-    this.setState({
-      itemsCollapsed: [...this.state.itemsCollapsed, false],
-      keys: [...this.state.keys, uuid()],
-    });
-    onChange((value || List()).push(parsedValue));
+    this.addItem(parsedValue);
   };
 
   singleDefault = () => {
@@ -201,13 +197,8 @@ export default class ListControl extends React.Component {
   };
 
   handleAddType = (type, typeKey) => {
-    const { value, onChange } = this.props;
     const parsedValue = fromJS(this.mixedDefault(typeKey, type));
-    this.setState({
-      itemsCollapsed: [...this.state.itemsCollapsed, false],
-      keys: [...this.state.keys, uuid()],
-    });
-    onChange((value || List()).push(parsedValue));
+    this.addItem(parsedValue);
   };
 
   mixedDefault = (typeKey, type) => {
@@ -242,6 +233,24 @@ export default class ListControl extends React.Component {
 
       return acc;
     }, initialValue);
+  };
+
+  addItem = parsedValue => {
+    const { value, onChange, field } = this.props;
+    const addToTop = field.get('add_to_top', false);
+
+    this.setState({
+      itemsCollapsed: addToTop
+        ? [false, ...this.state.itemsCollapsed]
+        : [...this.state.itemsCollapsed, false],
+      keys: addToTop ? [uuid(), ...this.state.keys] : [...this.state.keys, uuid()],
+    });
+
+    if (addToTop) {
+      onChange((value || List()).unshift(parsedValue));
+    } else {
+      onChange((value || List()).push(parsedValue));
+    }
   };
 
   processControlRef = ref => {

--- a/packages/netlify-cms-widget-list/src/ListControl.js
+++ b/packages/netlify-cms-widget-list/src/ListControl.js
@@ -239,17 +239,19 @@ export default class ListControl extends React.Component {
     const { value, onChange, field } = this.props;
     const addToTop = field.get('add_to_top', false);
 
+    const itemKey = uuid();
     this.setState({
       itemsCollapsed: addToTop
         ? [false, ...this.state.itemsCollapsed]
         : [...this.state.itemsCollapsed, false],
-      keys: addToTop ? [uuid(), ...this.state.keys] : [...this.state.keys, uuid()],
+      keys: addToTop ? [itemKey, ...this.state.keys] : [...this.state.keys, itemKey],
     });
 
+    const listValue = value || List();
     if (addToTop) {
-      onChange((value || List()).unshift(parsedValue));
+      onChange(listValue.unshift(parsedValue));
     } else {
-      onChange((value || List()).push(parsedValue));
+      onChange(listValue.push(parsedValue));
     }
   };
 

--- a/website/content/docs/widgets/list.md
+++ b/website/content/docs/widgets/list.md
@@ -19,6 +19,7 @@ The list widget allows you to create a repeatable item in the UI which saves as 
   * `fields`: a nested list of multiple widget fields to be included in each repeatable iteration
   * `max`: maximum number of items in the list
   * `min`: minimum number of items in the list
+  * `add_to_top`: when `true`, new entries will be added to the top of the list
 * **Example** (`field`/`fields` not specified):
 
   ```yaml
@@ -92,4 +93,11 @@ The list widget allows you to create a repeatable item in the UI which saves as 
     max: 3
     min: 1
     default: ["news"]
+  ```
+* **Example** (`add_to_top` marked `true`):
+  ```yaml
+  - label: "Tags"
+    name: "tags"
+    widget: "list"
+    add_to_top: true
   ```


### PR DESCRIPTION
## Summary

Currently, when a user adds a new item to a list, that item is added to the bottom. If the user would prefer to have the new item added to the top of the list, they would need to click the "add" button, scroll to the bottom of the list, edit the new entry, and drag it all the way to the top of the list. For long lists, this can be tedious.

This change adds a new `add_to_top` option to the list widget. For a list that the user intends to maintain in a newest-first order, adding this option would prevent them from going through the tedious scrolling and dragging task for each new item.

closes https://github.com/netlify/netlify-cms/issues/3270

## Test plan

I tested the new option locally by updating the two list widgets in the Kitchen Sink collection in `dev-test/config.yml`.

### `add_to_top` not specified or `false`

![no-add-to-top-specified](https://user-images.githubusercontent.com/7942714/96354748-de8b3e80-108e-11eb-838e-7d3da701fdc2.gif)

### `add_to_top: true`

![add-to-list-true](https://user-images.githubusercontent.com/7942714/96354751-e519b600-108e-11eb-9372-3abad180909c.gif)

## A picture of a cute animal (not mandatory but encouraged)

![IMG_20200725_115334](https://user-images.githubusercontent.com/7942714/96354771-24e09d80-108f-11eb-804d-ceb41e6cfc5f.jpg)
