### PR TITLE
fix - `TypeError e.join() is not a function` issue

### DIFF
--- a/packages/netlify-cms-widget-list/src/ListControl.js
+++ b/packages/netlify-cms-widget-list/src/ListControl.js
@@ -18,7 +18,11 @@ import { ListItemTopBar, ObjectWidgetTopBar, colors, lengths } from 'netlify-cms
 import { stringTemplate, validations } from 'netlify-cms-lib-widgets';
 
 function valueToString(value) {
-  return value ? value.join(',').replace(/,([^\s]|$)/g, ', $1') : '';
+  if(value.isArray()){
+    return value ? value.join(',').replace(/,([^\s]|$)/g, ', $1') : '';
+  } else {
+    return value ? value.replace(/,([^\s]|$)/g, ', $1') : '';
+  }
 }
 
 const ObjectControl = NetlifyCmsWidgetObject.controlComponent;


### PR DESCRIPTION
Closes #4481

**Summary**

the error: create a collection with a string widget, create an entry with the string filled in, and update the config file by changing the string widget to list, now when the entry is tried to open again, this error occours.

Fix: check wether value is an array before doing value.join()

