### PR TITLE
Update Docs: Intro “start-with-a-template”

### DIFF
--- a/website/content/docs/start-with-a-template.md
+++ b/website/content/docs/start-with-a-template.md
@@ -52,8 +52,8 @@ You can add Netlify CMS [to an existing site](/docs/add-to-your-site/), but the 
         <div style="padding: 0 30%; height: 100px; display: flex; justify-content: center;">
           <img style="display: flex" src="/img/nuxt.svg"/>
         </div>
-        <h4>Nuxt.js Boilerplate</h4>
-        <p><a href="https://app.netlify.com/start/deploy?repository=https://github.com/knogobert/ntn-boilerplate&amp;stack=cms"><img src="https://www.netlify.com/img/deploy/button.svg" alt="Deploy to Netlify" /></a></p>
+        <h4>Nuxt.js Site Starter</h4>
+        <p><a href="https://app.netlify.com/start/deploy?repository=https://github.com/lukeocodes/nuxt-starter-netlify-cms&amp;stack=cms"><img src="https://www.netlify.com/img/deploy/button.svg" alt="Deploy to Netlify" /></a></p>
     </div>
 </div>
 


### PR DESCRIPTION
**Summary**

The existing Nuxt boilerplate wasn't built for the latest features in Nuxt.

This is a Nuxt port of the Netlify maintained [gatsby starter](https://github.com/netlify-templates/gatsby-starter-netlify-cms). And, I've ported the Bulma Kaldi theme used in the gatsby starter using TailwindCSS.

It includes the crawler and `@nuxt/content` for reading markdown content efficiently. It builds in under half the time of the existing boilerplate as a result.

https://nuxt-starter-netlify-cms.netlify.app/ / https://github.com/lukeocodes/nuxt-starter-netlify-cms

**Test plan**

Minor text change. Local build fails if there are errors (it built)

**A picture of a cute animal (not mandatory but encouraged)**

*strong assumptions included*

![image](https://user-images.githubusercontent.com/956290/98469389-16d9f480-21d7-11eb-89ad-2a7ca4e5c617.png)
