### PR TITLE
feat: added the committer info to the commit

### DIFF
--- a/packages/netlify-cms-backend-git-gateway/src/GitHubAPI.ts
+++ b/packages/netlify-cms-backend-git-gateway/src/GitHubAPI.ts
@@ -6,17 +6,20 @@ type Config = GitHubConfig & {
   apiRoot: string;
   tokenPromise: () => Promise<string>;
   commitAuthor: { name: string };
+  committer: { name: string };
 };
 
 export default class API extends GithubAPI {
   tokenPromise: () => Promise<string>;
   commitAuthor: { name: string };
+  committer: { name: string };
 
   constructor(config: Config) {
     super(config);
     this.apiRoot = config.apiRoot;
     this.tokenPromise = config.tokenPromise;
     this.commitAuthor = config.commitAuthor;
+    this.committer = config.committer;
     this.repoURL = '';
     this.originRepoURL = '';
   }
@@ -91,11 +94,19 @@ export default class API extends GithubAPI {
       tree: string;
       parents: string[];
       author?: { name: string; date: string };
+      committer?: { name: string; date: string };
     } = {
       message,
       tree: changeTree.sha,
       parents: changeTree.parentSha ? [changeTree.parentSha] : [],
     };
+
+    if (this.committer) {
+      commitParams.committer = {
+        ...this.committer,
+        date: new Date().toISOString(),
+      };
+    }
 
     if (this.commitAuthor) {
       commitParams.author = {

--- a/packages/netlify-cms-backend-git-gateway/src/implementation.ts
+++ b/packages/netlify-cms-backend-git-gateway/src/implementation.ts
@@ -333,6 +333,7 @@ export default class GitGateway implements Implementation {
         branch: this.branch,
         tokenPromise: this.tokenPromise!,
         commitAuthor: pick(userData, ['name', 'email']),
+        committer: pick(userData, ['name', 'email']),
         squashMerges: this.squashMerges,
         cmsLabelPrefix: this.cmsLabelPrefix,
         initialWorkflowStatus: this.options.initialWorkflowStatus,


### PR DESCRIPTION

closes #2676 

**Summary**
When users (with git-gateway and netlify identify) delete content, the commit message says that I (github account owner) deleted the content.
We would like to know who made change something.

<!--
Explain the **motivation** for making this change.
What existing problem does the pull request solve?
-->
I used the gatsby starter netlify cms project to repeat the problem. I created, deleted, and edited a blog with another user. For each action, I saw my own name in my Github account, instead of seeing the user's name.
After making my local Netlify cms project usable connected with GitHub, I added the committer info into the commit.
Then I repeated the same manual tests. 
When I checked the commits, saw the user name that made a change. 
The change I made worked!

**Test plan**
for now, I don't have
<!--
Demonstrate the code is solid.
Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.
-->

**A picture of a cute animal (not mandatory but encouraged)**

![giphy](https://user-images.githubusercontent.com/1583507/98684855-f5a80e00-2366-11eb-9873-5cbb37feb76c.gif)
