### PR TITLE
fix(widget-select): allow number value type

### DIFF
--- a/dev-test/config.yml
+++ b/dev-test/config.yml
@@ -143,6 +143,13 @@ collections: # A list of collections the CMS should be able to edit
           options: ['a', 'b', 'c'],
           multiple: true,
         }
+      - {
+          label: 'Select numeric',
+          name: 'select_numeric',
+          widget: 'select',
+          options:
+            [{ label: 'One', value: 1 }, { label: 'Two', value: 2 }, { label: 'Three', value: 3 }],
+        }
       - { label: 'Hidden', name: 'hidden', widget: 'hidden', default: 'hidden' }
       - label: 'Object'
         name: 'object'

--- a/packages/netlify-cms-widget-select/src/schema.js
+++ b/packages/netlify-cms-widget-select/src/schema.js
@@ -8,11 +8,12 @@ export default {
       items: {
         oneOf: [
           { type: 'string' },
+          { type: 'number' },
           {
             type: 'object',
             properties: {
               label: { type: 'string' },
-              value: { type: 'string' },
+              value: { oneOf: [{ type: 'string' }, { type: 'number' }] },
             },
             required: ['label', 'value'],
           },


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines.

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first two fields are mandatory:
-->

**Summary**
Fixes #4577 

Allows numbers to be used as the value type in select widgets
Added an example in the dev-test environment

<!--
Explain the **motivation** for making this change.
What existing problem does the pull request solve?
-->

**Test plan**
`yarn start`
Open the kitchen sink collection and open the first entry
Scroll down to the select widgets (end of chapter 1)
<img width="916" alt="Screen Shot 2020-11-15 at 8 57 10 PM" src="https://user-images.githubusercontent.com/32177944/99214517-351a9400-2785-11eb-806a-239c6c6fc55f.png">

<!--
Demonstrate the code is solid.
Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.
-->

Obligatory cute koala:
<img width="307" alt="koala" src="https://i.pinimg.com/originals/38/18/4b/38184b12e09824b16ae5dc1117a3a9dc.jpg">
