### PR TITLE
feat: added the referrer param for the workflow page

### DIFF
--- a/packages/netlify-cms-core/src/components/Editor/Editor.js
+++ b/packages/netlify-cms-core/src/components/Editor/Editor.js
@@ -446,6 +446,10 @@ function mapStateToProps(state, ownProps) {
   const localBackup = entryDraft.get('localBackup');
   const draftKey = entryDraft.get('key');
   let editorBackLink = `/collections/${collectionName}`;
+  if (new URLSearchParams(ownProps.location.search).get('ref') === 'workflow') {
+    editorBackLink = `/workflow`;
+  }
+
   if (collection.has('nested') && slug) {
     const pathParts = slug.split('/');
     if (pathParts.length > 2) {

--- a/packages/netlify-cms-core/src/components/Workflow/WorkflowList.js
+++ b/packages/netlify-cms-core/src/components/Workflow/WorkflowList.js
@@ -209,7 +209,7 @@ class WorkflowList extends React.Component {
           );
           const slug = entry.get('slug');
           const collectionName = entry.get('collection');
-          const editLink = `collections/${collectionName}/entries/${slug}`;
+          const editLink = `collections/${collectionName}/entries/${slug}?ref=workflow`;
           const ownStatus = entry.get('status');
           const collection = collections.find(
             collection => collection.get('name') === collectionName,


### PR DESCRIPTION
closes #4541 

**Summary**

Assume you are on the workflow page and want to edit the post. After you finish your edit process, you click the "backlink" button, you would like to go to the workflow page. But you directed to the home page.
This behavior is wrong. 

What did I do? 

I added a referrer param for the workflow page. 
If you were on the workflow page and wanted to edit the post, I added the param at the end of the URL. 
If you want to go back, I check the URL whether has a param. 
If the `ref` param exists, then I return the user to the workflow page.

**Test plan**

I have done manual tests

**A picture of a cute animal (not mandatory but encouraged)**

![giphy (2)](https://user-images.githubusercontent.com/1583507/99251992-8b7fe500-280e-11eb-9428-b830f1080c1d.gif)

