### PR TITLE
fix(widget-string): fix cursor jumping to end of line

### DIFF
--- a/packages/netlify-cms-widget-string/src/StringControl.js
+++ b/packages/netlify-cms-widget-string/src/StringControl.js
@@ -15,6 +15,31 @@ export default class StringControl extends React.Component {
     value: '',
   };
 
+  // The selection to maintain for the input element
+  _sel = 0;
+
+  // The input element ref
+  _el = null;
+
+  // NOTE: This prevents the cursor from jumping to the end of the text for
+  // nested inputs. In other words, this is not an issue on top-level text
+  // fields such as the `title` of a collection post. However, it becomes an
+  // issue on fields nested within other components, namely widgets nested
+  // within a `markdown` widget. For example, the alt text on a block image
+  // within markdown.
+  // SEE: https://github.com/netlify/netlify-cms/issues/4539
+  // SEE: https://github.com/netlify/netlify-cms/issues/3578
+  componentDidUpdate() {
+    if (this._el && this._el.selectionStart !== this._sel) {
+      this._el.setSelectionRange(this._sel, this._sel);
+    }
+  }
+
+  handleChange = e => {
+    this._sel = e.target.selectionStart;
+    this.props.onChange(e.target.value);
+  };
+
   render() {
     const {
       forID,
@@ -27,11 +52,14 @@ export default class StringControl extends React.Component {
 
     return (
       <input
+        ref={el => {
+          this._el = el;
+        }}
         type="text"
         id={forID}
         className={classNameWrapper}
         value={value || ''}
-        onChange={e => onChange(e.target.value)}
+        onChange={this.handleChange}
         onFocus={setActiveStyle}
         onBlur={setInactiveStyle}
       />

--- a/packages/netlify-cms-widget-string/src/StringControl.js
+++ b/packages/netlify-cms-widget-string/src/StringControl.js
@@ -41,14 +41,7 @@ export default class StringControl extends React.Component {
   };
 
   render() {
-    const {
-      forID,
-      value,
-      onChange,
-      classNameWrapper,
-      setActiveStyle,
-      setInactiveStyle,
-    } = this.props;
+    const { forID, value, classNameWrapper, setActiveStyle, setInactiveStyle } = this.props;
 
     return (
       <input


### PR DESCRIPTION
Closes #3578
Closes #4539

The approach taken here seems suboptimal since it's generally not necessary when writing React components to manually update cursor location. Please let me know if anyone has a better solution.

I did do some debugging to try to identify the root issue, but did not find the root cause.

The summary of what I found is this: It seems that nested widgets undergo additional rendering because they trigger a state update for their parent component as well as themself. For example, when editing the alt text of an image using the built-in image block element the updating markdown string causes the parent markdown widget to update. 

**Summary**

This PR fixes the cursor problem described in detail in the linked issues. To summarize: Nested inputs within any collection would consistently force the cursor to the end of the line. Making nested inputs unusable for content editing.

"Nested" refers to text inputs within another widget—the alt text input element on the image widget for example.

**Test plan**

No automated tests have been created. I tested this by first running `yarn start` and then inserting an image into the markdown widget. I inserted an image into a post in the "Posts" collection of the test server, then typed in the "Alt text" field. The cursor remained where you would expect it to remain. 

Although the URL may change, it looks something like: http://localhost:8080/#/collections/posts/entries/2020-11-20-post-number-19 