### PR TITLE
fix(lfs): fixes lfs pointers in editorial workflow

### DIFF
--- a/packages/netlify-cms-lib-util/src/git-lfs.ts
+++ b/packages/netlify-cms-lib-util/src/git-lfs.ts
@@ -103,7 +103,7 @@ export async function getLargeMediaFilteredMediaFiles(
   },
   mediaFiles: AssetProxy[],
 ) {
-  return await Promise.all(
+  const filteredMediaFiles = await Promise.all(
     mediaFiles.map(async mediaFile => {
       const { fileObj, path } = mediaFile;
       const fixedPath = path.startsWith('/') ? path.slice(1) : path;
@@ -115,4 +115,5 @@ export async function getLargeMediaFilteredMediaFiles(
       return { ...mediaFile, ...pointerFileDetails };
     }),
   );
+  return filteredMediaFiles.filter(mediaFile => mediaFile.fileObj?.name != '');
 }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines.

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first two fields are mandatory:
-->

**Summary**
Without this commit, the CMS would alter the pointer files for each large media file whenever you edit a draft in editorial mode. The problem is that the filesize, blob and name are not available at the time when a commit is being generated which leads to all pointer files looking like this when you edit a draft that already contained an LFS object (i.e. first time adding an image works but editing text afterward will lead to this issue):
```
version https://git-lfs.github.com/spec/v1
oid sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855      # = hash of ""  because blob is empty
size 0
```
This PR fixes this problem by skipping all media files that do not have a name. Alternatively, there could be check for size == 0 instead.

I also thought about loading the correct metadata and blobs in the `unpublishedEntryMediaFile` in `backend-git-gateway` but that causes additional loading time every time someone opens a draft, so I believe skipping the commits when saving a draft is the better option. Happy to make adjustments to this though if needed. I'm really looking forward for this to be fixed because this bug makes using editorial workflow with images in LFS a huge pain.

Steps to reproduce the issue:
1. Create a netlify site with netlify lfs (and in my case git-gateway provided by netlify and hooked up for github but it should affect other backends as well)
2. Enable editorial_workflow
3. Create a draft and add an image in the content which matches the LFS pattern
4. Save the draft
5. Edit the draft
6. Save the draft again => now the CMS will change 2 files in the commit. Instead of just changing the markdown file, it will also set the LFS pointer for the image to the zero-pointer as shown in the code snippet above.

<!--
Explain the **motivation** for making this change.
What existing problem does the pull request solve?
-->

**Test plan**
Ran `yarn test` and tested the behavior with a netlify-hosted blog page using git-gateway backed by github and netlify-lfs.


Thanks for looking into this. Netlify CMS is awesome!


<!--
Demonstrate the code is solid.
Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.
-->

**A picture of a cute animal (not mandatory but encouraged)**
