### PR TITLE
Update DOCS: Working with a Local Git Repository

### DIFF
--- a/website/content/docs/beta-features.md
+++ b/website/content/docs/beta-features.md
@@ -23,10 +23,9 @@ backend:
 
 # when using the default proxy server port
 local_backend: true
-
 ```
 
-4. Optional: To use a non-default port, create a `.env` file in the project's root folder and add the following:
+4. Optional: To run the CMS proxy server on a non-default port, create a `.env` file in the project's root folder and add the following:
 
 ```ini
 # the non-default port to be used by the CMS proxy server (default is 8081)

--- a/website/content/docs/beta-features.md
+++ b/website/content/docs/beta-features.md
@@ -1,16 +1,15 @@
 ---
-title: Beta Features!
-weight: 200
 group: Configuration
+weight: 200
+title: Beta Features!
 ---
-
-We run new functionality in an open beta format from time to time. That means that this functionality is totally available for use, and we _think_ it might be ready for primetime, but it could break or change without notice.
+We run new functionality in an open beta format from time to time. That means that this functionality is totally available for use, and we *think* it might be ready for primetime, but it could break or change without notice.
 
 **Use these features at your own risk.**
 
 ## Working with a Local Git Repository
 
-**_added in netlify-cms@2.10.17 / netlify-cms-app@2.11.14_**
+***added in netlify-cms@2.10.17 / netlify-cms-app@2.11.14***
 
 You can connect Netlify CMS to a local Git repository, instead of working with a live repo.
 
@@ -25,20 +24,22 @@ backend:
 # when using the default proxy server port
 local_backend: true
 
-local_backend:
-  # when using a custom proxy server port
-  url: http://localhost:8082/api/v1
-  # when accessing the local site from a host other than 'localhost' or '127.0.0.1'
-  allowed_hosts: ['192.168.0.1']
 ```
 
-4. Start your local development server (e.g. run `gatsby develop`).
+4. Optional: To use a non-default port, create a `.env` file in the project's root folder and add the following:
+
+```ini
+# the non-default port to be used by the CMS proxy server (default is 8081)
+PORT=8082
+```
+
+5. Start your local development server (e.g. run `gatsby develop`).
 
 **Note:** `netlify-cms-proxy-server` runs an unauthenticated express server. As any client can send requests to the server, it should only be used for local development.
 
 ## GitLab and BitBucket Editorial Workflow Support
 
-**_added in netlify-cms@2.10.6 / netlify-cms-app@2.11.3_**
+***added in netlify-cms@2.10.6 / netlify-cms-app@2.11.3***
 
 You can enable the Editorial Workflow with the following line in your Netlify CMS `config.yml` file:
 
@@ -175,7 +176,7 @@ Learn more about the benefits of GraphQL in the [GraphQL docs](https://graphql.o
 
 When using the [GitHub backend](/docs/github-backend), you can use Netlify CMS to accept contributions from GitHub users without giving them access to your repository. When they make changes in the CMS, the CMS forks your repository for them behind the scenes, and all the changes are made to the fork. When the contributor is ready to submit their changes, they can set their draft as ready for review in the CMS. This triggers a pull request to your repository, which you can merge using the GitHub UI.
 
-At the same time, any contributors who _do_ have write access to the repository can continue to use Netlify CMS normally.
+At the same time, any contributors who *do* have write access to the repository can continue to use Netlify CMS normally.
 
 More details and setup instructions can be found on [the Open Authoring docs page](/docs/open-authoring).
 
@@ -248,11 +249,11 @@ And for the image field being populated with a value of `image.png`.
 
 Supports all of the [`slug` templates](/docs/configuration-options#slug) and:
 
-- `{{dirname}}` The path to the file's parent directory, relative to the collection's `folder`.
-- `{{filename}}` The file name without the extension part.
-- `{{extension}}` The file extension.
-- `{{media_folder}}` The global `media_folder`.
-- `{{public_folder}}` The global `public_folder`.
+* `{{dirname}}` The path to the file's parent directory, relative to the collection's `folder`.
+* `{{filename}}` The file name without the extension part.
+* `{{extension}}` The file extension.
+* `{{media_folder}}` The global `media_folder`.
+* `{{public_folder}}` The global `public_folder`.
 
 ## List Widget: Variable Types
 
@@ -268,9 +269,9 @@ To use variable types in the list widget, update your field configuration as fol
 
 ### Additional list widget options
 
-- `types`: a nested list of object widgets. All widgets must be of type `object`. Every object widget may define different set of fields.
-- `typeKey`: the name of the field that will be added to every item in list representing the name of the object widget that item belongs to. Ignored if `types` is not defined. Default is `type`.
-- `summary`: allows customization of a collapsed list item object in a similar way to a [collection summary](/docs/configuration-options/?#summary)
+* `types`: a nested list of object widgets. All widgets must be of type `object`. Every object widget may define different set of fields.
+* `typeKey`: the name of the field that will be added to every item in list representing the name of the object widget that item belongs to. Ignored if `types` is not defined. Default is `type`.
+* `summary`: allows customization of a collapsed list item object in a similar way to a [collection summary](/docs/configuration-options/?#summary)
 
 ### Example Configuration
 
@@ -465,17 +466,12 @@ Netlify CMS generates the following commit types:
 
 Template tags produce the following output:
 
-- `{{slug}}`: the url-safe filename of the entry changed
-
-- `{{collection}}`: the name of the collection containing the entry changed
-
-- `{{path}}`: the full path to the file changed
-
-- `{{message}}`: the relevant message based on the current change (e.g. the `create` message when an entry is created)
-
-- `{{author-login}}`: the login/username of the author
-
-- `{{author-name}}`: the full name of the author (might be empty based on the user's profile)
+* `{{slug}}`: the url-safe filename of the entry changed
+* `{{collection}}`: the name of the collection containing the entry changed
+* `{{path}}`: the full path to the file changed
+* `{{message}}`: the relevant message based on the current change (e.g. the `create` message when an entry is created)
+* `{{author-login}}`: the login/username of the author
+* `{{author-name}}`: the full name of the author (might be empty based on the user's profile)
 
 ## Image widget file size limit
 
@@ -512,7 +508,6 @@ collections:
 
 The above config will transform the title field to uppercase and format the date field using `YYYY-MM-DD` format.
 Available transformations are `upper`, `lower` and `date('<format>')`
-
 
 ## Registering to CMS Events
 


### PR DESCRIPTION
**Summary**

While attempting to use the beta feature [Working with a Local Git Repository](https://www.netlifycms.org/docs/beta-features/#working-with-a-local-git-repository) I found some errors in the docs. Specifically, I was trying to use a custom port but the configuration options described in step 3 didn’t work. I kept getting an error telling me that the default port (8081) was in use.

The [netlify-cms-proxy-server docs](https://github.com/netlify/netlify-cms/tree/master/packages/netlify-cms-proxy-server) mention that you have to create an .env file in the project root but this step isn’t mentioned in “our” instructions.

Also, the suggested updates to `config.yml` cause config errors…

```
Error loading the CMS configuration
Config Errors:
  'local_backend' should be boolean
  'local_backend' should NOT have additional properties
  'local_backend' should NOT have additional properties
  'local_backend' should match exactly one schema in oneOf
Check your config.yml file.
```
I managed to get my configuration working so I'd like to update the docs to reflect what works.

**A picture of a cute animal (not mandatory but encouraged)**
![IMG_3345](https://user-images.githubusercontent.com/1766935/100147062-d3cf8080-2e68-11eb-8671-3c2367a52e57.jpg)
Tim says hi!