### PR TITLE
Update DOCS: Working with a Local Git Repository (take 2)

### DIFF
--- a/website/content/docs/beta-features.md
+++ b/website/content/docs/beta-features.md
@@ -25,7 +25,7 @@ local_backend: true
 
 ```
 3. Run `npx netlify-cms-proxy-server` from the root directory of the above repository.
-    - If the default port (8081) is in use you will see an error message in the console. See [below](#configure-the-netlify-cms-proxy-server-port-number) to configure the Netlify CMS Proxy Server to use a different port number.
+    - If the default port (8081) is in use, the proxy server won't start and you will see an error message. In this case, follow [these steps](#configure-the-netlify-cms-proxy-server-port-number) before proceeding.
 4. Start your local development server (e.g. run `gatsby develop`).
 5. Open [http://localhost:8000/admin](http://localhost:8000/admin) to verify that your can administer your content locally.
 

--- a/website/content/docs/beta-features.md
+++ b/website/content/docs/beta-features.md
@@ -1,22 +1,20 @@
 ---
-title: Beta Features!
-weight: 200
 group: Configuration
+weight: 200
+title: Beta Features!
 ---
-
-We run new functionality in an open beta format from time to time. That means that this functionality is totally available for use, and we _think_ it might be ready for primetime, but it could break or change without notice.
+We run new functionality in an open beta format from time to time. That means that this functionality is totally available for use, and we *think* it might be ready for primetime, but it could break or change without notice.
 
 **Use these features at your own risk.**
 
 ## Working with a Local Git Repository
 
-**_added in netlify-cms@2.10.17 / netlify-cms-app@2.11.14_**
+***added in netlify-cms@2.10.17 / netlify-cms-app@2.11.14***
 
 You can connect Netlify CMS to a local Git repository, instead of working with a live repo.
 
 1. Navigate to a local Git repository configured with the CMS.
-2. Run `npx netlify-cms-proxy-server` from the root directory of the above repository.
-3. Add the top-level property `local_backend` configuration to your `config.yml`:
+2. Add the top-level property `local_backend` configuration to your `config.yml`:
 
 ```yaml
 backend:
@@ -25,20 +23,38 @@ backend:
 # when using the default proxy server port
 local_backend: true
 
-local_backend:
-  # when using a custom proxy server port
-  url: http://localhost:8082/api/v1
-  # when accessing the local site from a host other than 'localhost' or '127.0.0.1'
-  allowed_hosts: ['192.168.0.1']
 ```
-
+3. Run `npx netlify-cms-proxy-server` from the root directory of the above repository.
+    - If the default port (8081) is in use you will see an error message in the console. See [below](#configure-the-netlify-cms-proxy-server-port-number) to configure the Netlify CMS Proxy Server to use a different port number.
 4. Start your local development server (e.g. run `gatsby develop`).
+5. Open [http://localhost:8000/admin](http://localhost:8000/admin) to verify that your can administer your content locally.
 
 **Note:** `netlify-cms-proxy-server` runs an unauthenticated express server. As any client can send requests to the server, it should only be used for local development.
 
+### Configure the Netlify CMS proxy server port number
+
+1. Create a `.env` file in the project's root folder and define the PORT you'd like the proxy server to use
+
+```ini
+PORT=8082
+```
+
+2. Update the `local_backend` object in `config.yml` and specify a `url` property to use your custom port number
+
+```yaml
+backend:
+  name: git-gateway
+
+# when using the custom proxy server port
+local_backend:
+  url: http://localhost:8082/api/v1
+
+```
+
+
 ## GitLab and BitBucket Editorial Workflow Support
 
-**_added in netlify-cms@2.10.6 / netlify-cms-app@2.11.3_**
+***added in netlify-cms@2.10.6 / netlify-cms-app@2.11.3***
 
 You can enable the Editorial Workflow with the following line in your Netlify CMS `config.yml` file:
 
@@ -175,7 +191,7 @@ Learn more about the benefits of GraphQL in the [GraphQL docs](https://graphql.o
 
 When using the [GitHub backend](/docs/github-backend), you can use Netlify CMS to accept contributions from GitHub users without giving them access to your repository. When they make changes in the CMS, the CMS forks your repository for them behind the scenes, and all the changes are made to the fork. When the contributor is ready to submit their changes, they can set their draft as ready for review in the CMS. This triggers a pull request to your repository, which you can merge using the GitHub UI.
 
-At the same time, any contributors who _do_ have write access to the repository can continue to use Netlify CMS normally.
+At the same time, any contributors who *do* have write access to the repository can continue to use Netlify CMS normally.
 
 More details and setup instructions can be found on [the Open Authoring docs page](/docs/open-authoring).
 
@@ -248,11 +264,11 @@ And for the image field being populated with a value of `image.png`.
 
 Supports all of the [`slug` templates](/docs/configuration-options#slug) and:
 
-- `{{dirname}}` The path to the file's parent directory, relative to the collection's `folder`.
-- `{{filename}}` The file name without the extension part.
-- `{{extension}}` The file extension.
-- `{{media_folder}}` The global `media_folder`.
-- `{{public_folder}}` The global `public_folder`.
+* `{{dirname}}` The path to the file's parent directory, relative to the collection's `folder`.
+* `{{filename}}` The file name without the extension part.
+* `{{extension}}` The file extension.
+* `{{media_folder}}` The global `media_folder`.
+* `{{public_folder}}` The global `public_folder`.
 
 ## List Widget: Variable Types
 
@@ -268,9 +284,9 @@ To use variable types in the list widget, update your field configuration as fol
 
 ### Additional list widget options
 
-- `types`: a nested list of object widgets. All widgets must be of type `object`. Every object widget may define different set of fields.
-- `typeKey`: the name of the field that will be added to every item in list representing the name of the object widget that item belongs to. Ignored if `types` is not defined. Default is `type`.
-- `summary`: allows customization of a collapsed list item object in a similar way to a [collection summary](/docs/configuration-options/?#summary)
+* `types`: a nested list of object widgets. All widgets must be of type `object`. Every object widget may define different set of fields.
+* `typeKey`: the name of the field that will be added to every item in list representing the name of the object widget that item belongs to. Ignored if `types` is not defined. Default is `type`.
+* `summary`: allows customization of a collapsed list item object in a similar way to a [collection summary](/docs/configuration-options/?#summary)
 
 ### Example Configuration
 
@@ -465,17 +481,12 @@ Netlify CMS generates the following commit types:
 
 Template tags produce the following output:
 
-- `{{slug}}`: the url-safe filename of the entry changed
-
-- `{{collection}}`: the name of the collection containing the entry changed
-
-- `{{path}}`: the full path to the file changed
-
-- `{{message}}`: the relevant message based on the current change (e.g. the `create` message when an entry is created)
-
-- `{{author-login}}`: the login/username of the author
-
-- `{{author-name}}`: the full name of the author (might be empty based on the user's profile)
+* `{{slug}}`: the url-safe filename of the entry changed
+* `{{collection}}`: the name of the collection containing the entry changed
+* `{{path}}`: the full path to the file changed
+* `{{message}}`: the relevant message based on the current change (e.g. the `create` message when an entry is created)
+* `{{author-login}}`: the login/username of the author
+* `{{author-name}}`: the full name of the author (might be empty based on the user's profile)
 
 ## Image widget file size limit
 
@@ -512,7 +523,6 @@ collections:
 
 The above config will transform the title field to uppercase and format the date field using `YYYY-MM-DD` format.
 Available transformations are `upper`, `lower` and `date('<format>')`
-
 
 ## Registering to CMS Events
 

--- a/website/content/docs/beta-features.md
+++ b/website/content/docs/beta-features.md
@@ -24,6 +24,7 @@ backend:
 local_backend: true
 
 ```
+
 3. Run `npx netlify-cms-proxy-server` from the root directory of the above repository.
     - If the default port (8081) is in use, the proxy server won't start and you will see an error message. In this case, follow [these steps](#configure-the-netlify-cms-proxy-server-port-number) before proceeding.
 4. Start your local development server (e.g. run `gatsby develop`).

--- a/website/content/docs/beta-features.md
+++ b/website/content/docs/beta-features.md
@@ -45,9 +45,11 @@ PORT=8082
 backend:
   name: git-gateway
 
-# when using the custom proxy server port
 local_backend:
+  # when using a custom proxy server port
   url: http://localhost:8082/api/v1
+  # when accessing the local site from a host other than 'localhost' or '127.0.0.1'
+  allowed_hosts: ['192.168.0.1']
 
 ```
 


### PR DESCRIPTION
**Summary**
This PR is a follow up to #4632. 

The existing documentation at https://www.netlifycms.org/docs/beta-features/#working-with-a-local-git-repository is confusing because it mixes instructions for _default_ configuration with instructions for _optional_ custom configuration. Also the custom configuration instructions are missing a critical step for defining the custom port number in a `.env` file

This change separates the custom configuration instructions into a separate section and adds a step that explains how to define the custom port number.

