### PR TITLE
fix(typings): discriminated types for widgets

### DIFF
--- a/packages/netlify-cms-core/index.d.ts
+++ b/packages/netlify-cms-core/index.d.ts
@@ -56,23 +56,29 @@ declare module 'netlify-cms-core' {
     default_locale?: string;
   }
 
-  export interface CmsField {
+  export interface CmsFieldBase {
     name: string;
     label?: string;
-    widget?: string;
     required?: boolean;
     hint?: string;
     pattern?: [string, string];
-    default?: any;
     i18n?: boolean | 'translate' | 'duplicate';
+  }
 
-    /** If widget === "code" */
+  export interface CmsFieldCode {
+    widget: 'code';
+    default?: any;
+
     default_language?: string;
     allow_language_selection?: boolean;
     keys?: { code: string; lang: string };
     output_code_only?: boolean;
+  }
 
-    /** If widget === "datetime" */
+  export interface CmsFieldDateTime {
+    widget: 'datetime';
+    default?: string;
+
     format?: string;
     date_format?: boolean | string;
     time_format?: boolean | string;
@@ -90,60 +96,102 @@ declare module 'netlify-cms-core' {
      * @deprecated Use picker_utc instead
      */
     pickerUtc?: boolean;
+  }
 
-    /** If widget === "file" || widget === "image" */
+  export interface CmsFieldFileOrImage {
+    widget: 'file' | 'image';
+    default?: string;
+
     media_library?: CmsMediaLibrary;
     allow_multiple?: boolean;
     config?: any;
+  }
 
-    /** If widget === "object" || widget === "list" */
-    fields?: CmsField[];
+  export interface CmsFieldObject {
+    widget: 'object';
+    default?: any;
+
     collapsed?: boolean;
+    summary?: string;
+    fields: CmsField[];
+  }
 
-    /** If widget === "list" */
-    field?: CmsField;
+  export interface CmsFieldList {
+    widget: 'list';
+    default?: any;
+
     allow_add?: boolean;
+    collapsed?: boolean;
     summary?: string;
     minimize_collapsed?: boolean;
     label_singular?: string;
-    types?: CmsField[];
+    field?: CmsField;
+    fields?: CmsField[];
+    max?: number;
+    min?: number;
+    add_to_top?: boolean;
+    types?: (CmsFieldBase & CmsFieldObject)[];
+  }
 
-    /** If widget === "map" */
+  export interface CmsFieldMap {
+    widget: 'map';
+    default?: string;
+
     decimals?: number;
     type?: CmsMapWidgetType;
+  }
 
-    /** If widget === "markdown" */
+  export interface CmsFieldMarkdown {
+    widget: 'markdown';
+    default?: string;
+
     minimal?: boolean;
     buttons?: CmsMarkdownWidgetButton[];
     editor_components?: string[];
+    modes?: ('raw' | 'rich_text')[];
 
     /**
      * @deprecated Use editor_components instead
      */
     editorComponents?: string[];
+  }
 
-    /** If widget === "number" */
+  export interface CmsFieldNumber {
+    widget: 'number';
+    default?: string | number;
+
     value_type?: 'int' | 'float' | string;
+    min?: number;
+    max?: number;
+
     step?: number;
 
     /**
      * @deprecated Use valueType instead
      */
     valueType?: 'int' | 'float' | string;
+  }
 
-    /** If widget === "number" || widget === "select" */
+  export interface CmsFieldSelect {
+    widget: 'select';
+    default?: string | string[];
+
+    options: string[] | CmsSelectWidgetOptionObject[];
+    multiple?: boolean;
     min?: number;
     max?: number;
+  }
 
-    /** If widget === "relation" || widget === "select" */
-    multiple?: boolean;
+  export interface CmsFieldRelation {
+    widget: 'relation';
+    default?: string | string[];
 
-    /** If widget === "relation" */
-    collection?: string;
-    value_field?: string;
-    search_fields?: string[];
+    collection: string;
+    value_field: string;
+    search_fields: string[];
     file?: string;
     display_fields?: string[];
+    multiple?: boolean;
     options_length?: number;
 
     /**
@@ -162,10 +210,34 @@ declare module 'netlify-cms-core' {
      * @deprecated Use options_length instead
      */
     optionsLength?: number;
-
-    /** If widget === "select" */
-    options?: string[] | CmsSelectWidgetOptionObject[];
   }
+
+  export interface CmsFieldHidden {
+    widget: 'hidden';
+    default?: any;
+  }
+
+  export interface CmsFieldStringOrText {
+    // This is the default widget, so declaring its type is optional.
+    widget?: 'string' | 'text';
+    default?: string;
+  }
+
+  export type CmsField = CmsFieldBase &
+    (
+      | CmsFieldCode
+      | CmsFieldDateTime
+      | CmsFieldFileOrImage
+      | CmsFieldList
+      | CmsFieldMap
+      | CmsFieldMarkdown
+      | CmsFieldNumber
+      | CmsFieldObject
+      | CmsFieldRelation
+      | CmsFieldSelect
+      | CmsFieldHidden
+      | CmsFieldStringOrText
+    );
 
   export interface CmsCollectionFile {
     name: string;


### PR DESCRIPTION
**Summary**

This PR introduces makes the `widget` field for the `CmsField` type a discriminant. Not only does this allow for much better type inference when declaring fields, it also makes the typings for individual widgets much easier and less error-prone to maintain, since they're split out rather than pooled together under one mega-interface where all properties are optional.

**Test plan**

I've tested this with my own practical code and verified that it works correctly. It correctly supports fields that don't declare a widget type.

One thing to note is that it _doesn't_ support widgets registered with `CMS.registerWidget` -- but the current typings don't really support them either. (The current typings will tolerate any string value for the `widget` field, but not any configuration fields. For example, with the current typings, the 'categories' widget from the [documentation's custom widgets example](https://www.netlifycms.org/docs/custom-widgets/) currently would not allow you to define a `separator` field.) This PR should (I think) provide a way for developers shipping widgets via NPM with typings to cleanly augment the `CmsField` type (via [module augmentation](https://www.typescriptlang.org/docs/handbook/declaration-merging.html#module-augmentation)).


