### PR TITLE
Fix the code highlights in docs/customization

### DIFF
--- a/website/content/docs/customization.md
+++ b/website/content/docs/customization.md
@@ -89,7 +89,8 @@ Registers a template for a folder collection or an individual file in a file col
     ```
   * document: The preview pane iframe's [document instance](https://github.com/ryanseddon/react-frame-component/tree/9f8f06e1d3fc40da7122f0a57c62f7dec306e6cb#accessing-the-iframes-window-and-document).
   * window: The preview pane iframe's [window instance](https://github.com/ryanseddon/react-frame-component/tree/9f8f06e1d3fc40da7122f0a57c62f7dec306e6cb#accessing-the-iframes-window-and-document).
-    ### Lists and Objects
+
+  ### Lists and Objects
     The API for accessing the individual fields of list- and object-type entries is similar to the API for accessing fields in standard entries, but there are a few key differences. Access to these nested fields is facilitated through the `widgetsFor` function, which is passed to the preview template component during render.
 	**Note**: as is often the case with the NetlifyCMS API, arrays and objects are created with Immutable.js. If some of the methods that we use are unfamiliar, such as `getIn`, check out [their docs](https://facebook.github.io/immutable-js/docs/#/) to get a better understanding.
     **List Example:**
@@ -130,10 +131,10 @@ Registers a template for a folder collection or an individual file in a file col
         );
       }
     });
-
     CMS.registerPreviewTemplate("authors", AuthorsPreview);
     </script>
     ```
+    
     **Object Example:**
     ```html
     <script>


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines.

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first two fields are mandatory:
-->

**Summary**
The document highlighting in the following URLs was broken, so I fixed it.

https://www.netlifycms.org/docs/customization/

- Before
  <img width="1440" alt="スクリーンショット 2020-11-27 14 10 55" src="https://user-images.githubusercontent.com/24843808/100414790-e8588680-30bd-11eb-8af9-69b416ce7562.png">
- After
  <img width="1440" alt="スクリーンショット 2020-11-27 14 30 36" src="https://user-images.githubusercontent.com/24843808/100414779-e393d280-30bd-11eb-9a6b-c271c72bdb72.png">



<!--
Explain the **motivation** for making this change.
What existing problem does the pull request solve?
-->

**Test plan**

<!--
Demonstrate the code is solid.
Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.
-->

Please Check changing md file.

**A picture of a cute animal (not mandatory but encouraged)**

![](https://i1.wp.com/netgeek.biz/wp-content/uploads/2017/10/kakuhocat-1.jpg?w=1200)
