### PR TITLE
fix: added a TS type definition for local_backend schema field

### DIFF
--- a/packages/netlify-cms-core/index.d.ts
+++ b/packages/netlify-cms-core/index.d.ts
@@ -236,6 +236,11 @@ declare module 'netlify-cms-core' {
     clean_accents?: boolean;
   }
 
+  export interface CmsLocalBackend {
+    url?: string;
+    allowed_hosts?: string[];
+  }
+
   export interface CmsConfig {
     backend: CmsBackend;
     collections: CmsCollection[];
@@ -251,6 +256,7 @@ declare module 'netlify-cms-core' {
     publish_mode?: CmsPublishMode;
     slug?: CmsSlug;
     i18n?: CmsI18nConfig;
+    local_backend?: boolean | CmsLocalBackend;
   }
 
   export interface InitOptions {


### PR DESCRIPTION
**Summary**

Hi! The TS typing for the [`local_backend`](https://www.netlifycms.org/docs/beta-features/#working-with-a-local-git-repository) scheme's field seems missing. The PR is intended to fill the gap.

The added types are based on the [docs](https://www.netlifycms.org/docs/beta-features/#working-with-a-local-git-repository) and the [schema](https://github.com/netlify/netlify-cms/blob/master/packages/netlify-cms-core/src/constants/configSchema.js#L137).

**Test plan**

I tested it locally in my project, works well. 👌 

**A picture of a cute animal (not mandatory but encouraged)**

![image_11649](https://user-images.githubusercontent.com/10692413/100602939-d157a580-3304-11eb-8cdc-a77cd0b4543a.jpg)

