### PR TITLE
feat(media dir nav): navigation through sub directories and breadcrumbs

### DIFF
--- a/packages/netlify-cms-core/src/actions/mediaLibrary.ts
+++ b/packages/netlify-cms-core/src/actions/mediaLibrary.ts
@@ -44,6 +44,8 @@ export const MEDIA_DELETE_FAILURE = 'MEDIA_DELETE_FAILURE';
 export const MEDIA_DISPLAY_URL_REQUEST = 'MEDIA_DISPLAY_URL_REQUEST';
 export const MEDIA_DISPLAY_URL_SUCCESS = 'MEDIA_DISPLAY_URL_SUCCESS';
 export const MEDIA_DISPLAY_URL_FAILURE = 'MEDIA_DISPLAY_URL_FAILURE';
+export const MEDIA_FOLDER_UPDATE = 'MEDIA_FOLDER_UPDATE';
+export const DEFAULT_MEDIA_FOLDER = 'DEFAULT_MEDIA_FOLDER';
 
 export function createMediaLibrary(instance: MediaLibraryInstance) {
   const api = {
@@ -131,9 +133,19 @@ export function removeInsertedMedia(controlID: string) {
   return { type: MEDIA_REMOVE_INSERTED, payload: { controlID } };
 }
 
-export function loadMedia(
-  opts: { delay?: number; query?: string; page?: number; privateUpload?: boolean } = {},
-) {
+export function updateMediaFolder(selectedMediaFolder: string) {
+  return (dispatch: ThunkDispatch<State, {}, AnyAction>, getState: () => State) => {
+    const state = getState();
+    const backend = currentBackend(state.config);
+    const currentMediaFolder = backend.updateMediaFolder(selectedMediaFolder);
+    const defaultMediaFolder = backend.getDefaultMediaFolder();
+    dispatch({ type: MEDIA_FOLDER_UPDATE, payload: { currentMediaFolder, defaultMediaFolder } });
+  };
+}
+
+export function loadMedia( 
+  opts: { delay?: number; query?: string; page?: number; privateUpload?: boolean } = {}
+  ) {
   const { delay = 0, query = '', page = 1, privateUpload } = opts;
   return async (dispatch: ThunkDispatch<State, {}, AnyAction>, getState: () => State) => {
     const state = getState();
@@ -157,7 +169,6 @@ export function loadMedia(
       }
     }
     dispatch(mediaLoading(page));
-
     const loadFunction = () =>
       backend
         .getMedia()
@@ -262,6 +273,7 @@ export function persistMedia(file: File, opts: MediaOptions = {}) {
       } else {
         const entry = state.entryDraft.get('entry');
         const collection = state.collections.get(entry?.get('collection'));
+        console.log(state);
         const path = selectMediaFilePath(state.config, collection, entry, fileName, field);
         assetProxy = createAssetProxy({
           file,
@@ -287,6 +299,8 @@ export function persistMedia(file: File, opts: MediaOptions = {}) {
         });
         return dispatch(addDraftEntryMediaFile(mediaFile));
       } else {
+        console.log('backend.persistMedia');
+        console.log(state.config);
         mediaFile = await backend.persistMedia(state.config, assetProxy);
       }
 

--- a/packages/netlify-cms-core/src/backend.ts
+++ b/packages/netlify-cms-core/src/backend.ts
@@ -805,6 +805,14 @@ export class Backend {
     return entryValue;
   }
 
+  updateMediaFolder(path: string) {
+    return this.implementation.updateMediaFolder(path);
+  }
+
+  getDefaultMediaFolder() {
+    return this.implementation.getDefaultMediaFolder();
+  }
+
   getMedia() {
     return this.implementation.getMedia();
   }

--- a/packages/netlify-cms-core/src/components/MediaLibrary/MediaLibraryBreadCrumbs.js
+++ b/packages/netlify-cms-core/src/components/MediaLibrary/MediaLibraryBreadCrumbs.js
@@ -1,0 +1,72 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { trim } from 'lodash';
+import styled from '@emotion/styled';
+import { Icon } from 'netlify-cms-ui-default';
+
+const BreadCrumbsContainer = styled.div`
+  display: flex;
+  justify-content: flex-start;
+  margin: 20px 0;
+`
+const BreadCrumbsItem = styled.div`
+  display: flex;
+`
+
+const BreadCrumbsItemLabel = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  cursor: pointer;
+  padding: 6px 8px;
+  background: #eff0f4;
+  border-radius: 5px;
+`
+
+const BreadCrumbsItemDivider = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+`
+
+class MediaLibraryBreadcrumbs extends React.Component {
+  render() {
+    const {
+      handleBreadcrumbClick,
+      currentMediaFolder,
+      defaultMediaFolder,
+    } = this.props;
+    var hiddenPath = defaultMediaFolder.split('/').slice(0, -1).join('/');
+    var currentMediaFolderParts = trim(currentMediaFolder.replace(hiddenPath, ''), '/').split('/');
+    var breadcrumbsArray = currentMediaFolderParts.map((part, index) => {
+      return {
+        isDefaultMediaDirectory: index === 0,
+        path: `${hiddenPath}/${currentMediaFolderParts.slice(0, index+ 1).join('/')}`,
+        label: part
+      }
+    });
+
+    this.BreadCrumbsContent = breadcrumbsArray.map((item, index) => {
+      return (
+        <BreadCrumbsItem key={index}>
+          <BreadCrumbsItemLabel onClick={() => handleBreadcrumbClick(item.path)}>
+            {item.isDefaultMediaDirectory ? <Icon type="home" /> : item.label}
+            </BreadCrumbsItemLabel>
+          <BreadCrumbsItemDivider>/</BreadCrumbsItemDivider>
+        </BreadCrumbsItem>
+      )
+    });
+    return (
+      <BreadCrumbsContainer>
+        {this.BreadCrumbsContent}
+      </BreadCrumbsContainer>
+    );
+  }
+}
+
+MediaLibraryBreadcrumbs.propTypes = {
+  handleBreadcrumbClick: PropTypes.func.isRequired,
+  currentMediaFolder: PropTypes.string,
+};
+
+export default MediaLibraryBreadcrumbs;

--- a/packages/netlify-cms-core/src/components/MediaLibrary/MediaLibraryCard.js
+++ b/packages/netlify-cms-core/src/components/MediaLibrary/MediaLibraryCard.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import ImmutablePropTypes from 'react-immutable-proptypes';
 import styled from '@emotion/styled';
-import { colors, borders, lengths, shadows, effects } from 'netlify-cms-ui-default';
+import { colors, borders, lengths, shadows, effects, Icon } from 'netlify-cms-ui-default';
 
 const IMAGE_HEIGHT = 160;
 
@@ -77,8 +77,19 @@ class MediaLibraryCard extends React.Component {
       type,
       isViewableImage,
       isDraft,
+      isDirectory,
     } = this.props;
     const url = displayURL.get('url');
+    var cardImageWrapper = (<CardImageWrapper>
+      {isDraft ? <DraftText data-testid="draft-text">{draftText}</DraftText> : null}
+      {url && isViewableImage ? (
+        <CardImage src={url} />
+      ) : (
+        <CardFileIcon data-testid="card-file-icon">{type}</CardFileIcon>
+      )}
+    </CardImageWrapper>);
+    var cardDirectoryWrapper =  <Icon type="folder" />; 
+    var previewElement = isDirectory ? cardDirectoryWrapper : cardImageWrapper;
     return (
       <Card
         isSelected={isSelected}
@@ -89,21 +100,14 @@ class MediaLibraryCard extends React.Component {
         tabIndex="-1"
         isPrivate={isPrivate}
       >
-        <CardImageWrapper>
-          {isDraft ? <DraftText data-testid="draft-text">{draftText}</DraftText> : null}
-          {url && isViewableImage ? (
-            <CardImage src={url} />
-          ) : (
-            <CardFileIcon data-testid="card-file-icon">{type}</CardFileIcon>
-          )}
-        </CardImageWrapper>
+        {previewElement}
         <CardText>{text}</CardText>
       </Card>
     );
   }
   componentDidMount() {
-    const { displayURL, loadDisplayURL } = this.props;
-    if (!displayURL.get('url')) {
+    const { displayURL, loadDisplayURL, isViewableImage } = this.props;
+    if (!displayURL.get('url') && isViewableImage) {
       loadDisplayURL();
     }
   }

--- a/packages/netlify-cms-core/src/components/MediaLibrary/MediaLibraryCardGrid.js
+++ b/packages/netlify-cms-core/src/components/MediaLibrary/MediaLibraryCardGrid.js
@@ -58,6 +58,7 @@ const CardWrapper = props => {
         loadDisplayURL={() => loadDisplayURL(file)}
         type={file.type}
         isViewableImage={file.isViewableImage}
+        isDirectory={file.isDirectory}
       />
     </div>
   );

--- a/packages/netlify-cms-core/src/components/MediaLibrary/MediaLibraryModal.js
+++ b/packages/netlify-cms-core/src/components/MediaLibrary/MediaLibraryModal.js
@@ -26,7 +26,7 @@ const cardOutsideWidth = `300px`;
 
 const StyledModal = styled(Modal)`
   display: grid;
-  grid-template-rows: 120px auto;
+  grid-template-rows: 170px auto;
   width: calc(${cardOutsideWidth} + 20px);
   background-color: ${props => props.isPrivate && colors.grayDark};
 
@@ -87,10 +87,13 @@ const MediaLibraryModal = ({
   handleDownload,
   setScrollContainerRef,
   handleAssetClick,
+  handleBreadcrumbClick,
   handleLoadMore,
   loadDisplayURL,
   displayURLs,
   t,
+  currentMediaFolder,
+  defaultMediaFolder,
 }) => {
   const filteredFiles = forImage ? handleFilter(files) : files;
   const queriedFiles = !dynamicSearch && query ? handleQuery(query, filteredFiles) : filteredFiles;
@@ -128,7 +131,11 @@ const MediaLibraryModal = ({
         hasSelection={hasSelection}
         isPersisting={isPersisting}
         isDeleting={isDeleting}
-      />
+        handleBreadcrumbClick={handleBreadcrumbClick}
+        currentMediaFolder={currentMediaFolder}
+        defaultMediaFolder={defaultMediaFolder}
+        />
+      
       {!shouldShowEmptyMessage ? null : (
         <EmptyMessage content={emptyMessage} isPrivate={privateUpload} />
       )}
@@ -189,6 +196,7 @@ MediaLibraryModal.propTypes = {
   handleInsert: PropTypes.func.isRequired,
   setScrollContainerRef: PropTypes.func.isRequired,
   handleAssetClick: PropTypes.func.isRequired,
+  handleBreadcrumbClick: PropTypes.func.isRequired,
   handleLoadMore: PropTypes.func.isRequired,
   loadDisplayURL: PropTypes.func.isRequired,
   t: PropTypes.func.isRequired,

--- a/packages/netlify-cms-core/src/components/MediaLibrary/MediaLibraryTop.js
+++ b/packages/netlify-cms-core/src/components/MediaLibrary/MediaLibraryTop.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import styled from '@emotion/styled';
 import MediaLibrarySearch from './MediaLibrarySearch';
 import MediaLibraryHeader from './MediaLibraryHeader';
+import MediaLibraryBreadcrumbs from './MediaLibraryBreadCrumbs';
 import { UploadButton, DeleteButton, DownloadButton, InsertButton } from './MediaLibraryButtons';
 
 const LibraryTop = styled.div`
@@ -37,6 +38,9 @@ const MediaLibraryTop = ({
   hasSelection,
   isPersisting,
   isDeleting,
+  handleBreadcrumbClick,
+  currentMediaFolder,
+  defaultMediaFolder,
 }) => {
   const shouldShowButtonLoader = isPersisting || isDeleting;
   const uploadEnabled = !shouldShowButtonLoader;
@@ -99,6 +103,13 @@ const MediaLibraryTop = ({
             </InsertButton>
           )}
         </ButtonsContainer>
+      </RowContainer>
+      <RowContainer>
+        <MediaLibraryBreadcrumbs
+          handleBreadcrumbClick={handleBreadcrumbClick}
+          currentMediaFolder={currentMediaFolder}
+          defaultMediaFolder={defaultMediaFolder}
+        />
       </RowContainer>
     </LibraryTop>
   );

--- a/packages/netlify-cms-core/src/reducers/entries.ts
+++ b/packages/netlify-cms-core/src/reducers/entries.ts
@@ -762,9 +762,10 @@ export const selectMediaFilePath = (
   if (isAbsolutePath(mediaPath)) {
     return mediaPath;
   }
-
+  console.log('mediaPath');
+  console.log(mediaPath);
   const mediaFolder = selectMediaFolder(config, collection, entryMap, field);
-
+  console.log(mediaFolder);
   return join(mediaFolder, basename(mediaPath));
 };
 

--- a/packages/netlify-cms-core/src/reducers/mediaLibrary.ts
+++ b/packages/netlify-cms-core/src/reducers/mediaLibrary.ts
@@ -18,6 +18,8 @@ import {
   MEDIA_DISPLAY_URL_REQUEST,
   MEDIA_DISPLAY_URL_SUCCESS,
   MEDIA_DISPLAY_URL_FAILURE,
+  MEDIA_FOLDER_UPDATE,
+  DEFAULT_MEDIA_FOLDER,
 } from '../actions/mediaLibrary';
 import { selectEditingDraft, selectMediaFolder } from './entries';
 import { selectIntegration } from './';
@@ -209,6 +211,16 @@ const mediaLibrary = (state = Map(defaultState), action: MediaLibraryAction) => 
           .deleteIn([...displayURLPath, 'url'])
       );
     }
+
+    case MEDIA_FOLDER_UPDATE: {
+      // zzz not sure what this is doing?
+      return state.withMutations(map => {
+        map.set('currentMediaFolder', action.payload.currentMediaFolder);
+        map.set('defaultMediaFolder', action.payload.defaultMediaFolder);
+        map.set('isLoading', false);
+      });
+    }
+
     default:
       return state;
   }
@@ -233,7 +245,6 @@ export function selectMediaFiles(state: State, field?: EntryField) {
   } else {
     files = mediaLibrary.get('files') || [];
   }
-
   return files;
 }
 

--- a/packages/netlify-cms-core/src/types/redux.ts
+++ b/packages/netlify-cms-core/src/types/redux.ts
@@ -440,6 +440,8 @@ export interface MediaLibraryAction extends Action<string> {
   payload: MediaLibraryInstance & {
     controlID: string;
     forImage: boolean;
+    currentMediaFolder: string,
+    defaultMediaFolder: string,
     privateUpload: boolean;
     config: Map<string, string>;
     field?: EntryField;


### PR DESCRIPTION
This is just a small first step in attempting nested media directories (https://github.com/netlify/netlify-cms/issues/3240)

So far it only works with Github, and only navigation up and down directories with breadcrumbs is implemented. As I'm not too familiar with the codebase, it would help to have someone give it a cursory sanity check, before continuing too far on the current path.

My approach has been to add a `listDirs` function to `packages/netlify-cms-backend-github/src/API.ts` and then update the `getMedia()` function in `packages/netlify-cms-backend-github/src/implementation.tsx` to run both `listFiles()` and `listDirs()` and concatenate the result.

This means both the directories and files are passed to the `MediaLibrary` component in the `files` array. As the Github type is included with each object in the array, the `toTableData()` function in `packages/netlify-cms-core/src/components/MediaLibrary/MediaLibrary.js` sets the `isDirectory` prop for each file object, based on whether it is a `tree` or `blob`. The `MediaLibraryCard` component can display and behave accordingly.

I'm struggling to see if it would be wiser to pass the directories to the component as a separate array altogether. One issue is that a directory should not technically have a `displayURL` prop, but if ommitted the following error is thown:

`Warning: Failed prop type: The prop files[0].displayURL is marked as required in MediaLibrary, but its value is undefined`

I'm also not 100% sure if the way in which I've added the `updateMediaFolder()` action is correct. Lastly, in order to get the default media directory into the breadcrumbs component, I have ended up adding an action called `getDefaultMediaFolder()` to set a prop called `defaultMediaFolder` and pass that to the component. 

I'm guessing there is an easier way to get a prop from the site config into a component?