### PR TITLE
fix(large-media): mark pointer files as binary

### DIFF
--- a/packages/netlify-cms-backend-git-gateway/src/GitHubAPI.ts
+++ b/packages/netlify-cms-backend-git-gateway/src/GitHubAPI.ts
@@ -1,22 +1,26 @@
 import { API as GithubAPI } from 'netlify-cms-backend-github';
-import { Config as GitHubConfig } from 'netlify-cms-backend-github/src/API';
+import { Config as GitHubConfig, Diff } from 'netlify-cms-backend-github/src/API';
 import { APIError, FetchError } from 'netlify-cms-lib-util';
+import { Octokit } from '@octokit/rest';
 
 type Config = GitHubConfig & {
   apiRoot: string;
   tokenPromise: () => Promise<string>;
   commitAuthor: { name: string };
+  isLargeMedia: (filename: string) => Promise<boolean>;
 };
 
 export default class API extends GithubAPI {
   tokenPromise: () => Promise<string>;
   commitAuthor: { name: string };
+  isLargeMedia: (filename: string) => Promise<boolean>;
 
   constructor(config: Config) {
     super(config);
     this.apiRoot = config.apiRoot;
     this.tokenPromise = config.tokenPromise;
     this.commitAuthor = config.commitAuthor;
+    this.isLargeMedia = config.isLargeMedia;
     this.repoURL = '';
     this.originRepoURL = '';
   }
@@ -112,5 +116,13 @@ export default class API extends GithubAPI {
 
   nextUrlProcessor() {
     return (url: string) => url.replace(/^(?:[a-z]+:\/\/.+?\/.+?\/.+?\/)/, `${this.apiRoot}/`);
+  }
+
+  async diffFromFile(file: Octokit.ReposCompareCommitsResponseFilesItem): Promise<Diff> {
+    const diff = await super.diffFromFile(file);
+    return {
+      ...diff,
+      binary: diff.binary || (await this.isLargeMedia(file.filename)),
+    };
   }
 }

--- a/packages/netlify-cms-backend-github/src/API.ts
+++ b/packages/netlify-cms-backend-github/src/API.ts
@@ -154,22 +154,11 @@ const getTreeFiles = (files: GitHubCompareFiles) => {
   return treeFiles;
 };
 
-type Diff = {
+export type Diff = {
   path: string;
   newFile: boolean;
   sha: string;
   binary: boolean;
-};
-
-const diffFromFile = (diff: Octokit.ReposCompareCommitsResponseFilesItem): Diff => {
-  return {
-    path: diff.filename,
-    newFile: diff.status === 'added',
-    sha: diff.sha,
-    // media files diffs don't have a patch attribute, except svg files
-    // renamed files don't have a patch attribute too
-    binary: (diff.status !== 'renamed' && !diff.patch) || diff.filename.endsWith('.svg'),
-  };
 };
 
 let migrationNotified = false;
@@ -581,7 +570,7 @@ export default class API {
     const branch = branchFromContentKey(contentKey);
     const pullRequest = await this.getBranchPullRequest(branch);
     const { files } = await this.getDifferences(this.branch, pullRequest.head.sha);
-    const diffs = files.map(diffFromFile);
+    const diffs = await Promise.all(files.map(file => this.diffFromFile(file)));
     const label = pullRequest.labels.find(l => isCMSLabel(l.name, this.cmsLabelPrefix)) as {
       name: string;
     };
@@ -943,6 +932,18 @@ export default class API {
     });
   }
 
+  // async since it is overridden in a child class
+  async diffFromFile(diff: Octokit.ReposCompareCommitsResponseFilesItem): Promise<Diff> {
+    return {
+      path: diff.filename,
+      newFile: diff.status === 'added',
+      sha: diff.sha,
+      // media files diffs don't have a patch attribute, except svg files
+      // renamed files don't have a patch attribute too
+      binary: (diff.status !== 'renamed' && !diff.patch) || diff.filename.endsWith('.svg'),
+    };
+  }
+
   async editorialWorkflowGit(
     files: TreeFile[],
     slug: string,
@@ -974,7 +975,7 @@ export default class API {
         await this.getHeadReference(branch),
       );
 
-      const diffs = diffFiles.map(diffFromFile);
+      const diffs = await Promise.all(diffFiles.map(file => this.diffFromFile(file)));
       // mark media files to remove
       const mediaFilesToRemove: { path: string; sha: string | null }[] = [];
       for (const diff of diffs.filter(d => d.binary)) {


### PR DESCRIPTION
Replaces https://github.com/netlify/netlify-cms/pull/4613

We can't skip files (as suggested in that PR) as the CMS synchronizes client state with server state on save.
Filtering files means those file will be removed on save - the reason it's not happening is due to another bug with large media where pointer files are not marked as binary here:
https://github.com/netlify/netlify-cms/blob/dd080347b09606d651bb154a9a4870d704f0d48e/packages/netlify-cms-backend-github/src/API.ts#L171

So the solution is to both fix marking LFS files as binary and retrieving metadata for the original non transformed files.

This PR also fixes another issue where setting `use_large_media_transforms_in_media_library: false` did not work.