### PR TITLE
Fixed sha256 import

### DIFF
--- a/packages/netlify-cms-lib-util/src/getBlobSHA.ts
+++ b/packages/netlify-cms-lib-util/src/getBlobSHA.ts
@@ -3,7 +3,7 @@ import { sha256 } from 'js-sha256';
 export default (blob: Blob): Promise<string> =>
   new Promise((resolve, reject) => {
     const fr = new FileReader();
-    fr.onload = ({ target }) => resolve(sha256(target?.result));
+    fr.onload = ({ target }) => resolve(sha256(target?.result || ''));
     fr.onerror = err => {
       fr.abort();
       reject(err);

--- a/packages/netlify-cms-lib-util/src/getBlobSHA.ts
+++ b/packages/netlify-cms-lib-util/src/getBlobSHA.ts
@@ -1,4 +1,4 @@
-import sha256 from 'js-sha256';
+import { sha256 } from 'js-sha256';
 
 export default (blob: Blob): Promise<string> =>
   new Promise((resolve, reject) => {

--- a/packages/netlify-cms-lib-util/src/types/js-sha256.d.ts
+++ b/packages/netlify-cms-lib-util/src/types/js-sha256.d.ts
@@ -1,4 +1,0 @@
-declare module 'js-sha256' {
-  const sha256: (reader: string | ArrayBuffer | null | undefined) => string;
-  export default sha256;
-}


### PR DESCRIPTION
Import named export because no default export exists

**Summary**

I was trying to create a custom backend and my typescript compiler complained about a wrong import. There is no default export in js-sha256, only named exports.