### PR TITLE
feat(widget-file): allow adding file from url

### DIFF
--- a/packages/netlify-cms-locales/src/en/index.js
+++ b/packages/netlify-cms-locales/src/en/index.js
@@ -158,14 +158,14 @@ const en = {
       image: {
         choose: 'Choose an image',
         chooseUrl: 'Insert from URL',
-        promptUrl: 'Please enter URL for your image.',
+        promptUrl: 'Enter the URL of the image',
         chooseDifferent: 'Choose different image',
         remove: 'Remove image',
       },
       file: {
         choose: 'Choose a file',
         chooseUrl: 'Insert from URL',
-        promptUrl: 'Please enter URL for your file.',
+        promptUrl: 'Enter the URL of the file',
         chooseDifferent: 'Choose different file',
         remove: 'Remove file',
       },

--- a/packages/netlify-cms-locales/src/en/index.js
+++ b/packages/netlify-cms-locales/src/en/index.js
@@ -158,6 +158,7 @@ const en = {
       image: {
         choose: 'Choose an image',
         chooseUrl: 'Insert from URL',
+        replaceUrl: 'Replace with URL',
         promptUrl: 'Enter the URL of the image',
         chooseDifferent: 'Choose different image',
         remove: 'Remove image',
@@ -165,6 +166,7 @@ const en = {
       file: {
         choose: 'Choose a file',
         chooseUrl: 'Insert from URL',
+        replaceUrl: 'Replace with URL',
         promptUrl: 'Enter the URL of the file',
         chooseDifferent: 'Choose different file',
         remove: 'Remove file',

--- a/packages/netlify-cms-locales/src/en/index.js
+++ b/packages/netlify-cms-locales/src/en/index.js
@@ -157,11 +157,15 @@ const en = {
       },
       image: {
         choose: 'Choose an image',
+        chooseUrl: 'Insert from URL',
+        promptUrl: 'Please enter URL for your image.',
         chooseDifferent: 'Choose different image',
         remove: 'Remove image',
       },
       file: {
         choose: 'Choose a file',
+        chooseUrl: 'Insert from URL',
+        promptUrl: 'Please enter URL for your file.',
         chooseDifferent: 'Choose different file',
         remove: 'Remove file',
       },

--- a/packages/netlify-cms-widget-file/src/withFileControl.js
+++ b/packages/netlify-cms-widget-file/src/withFileControl.js
@@ -50,7 +50,7 @@ const FileLink = styled.a`
 `;
 
 const FileLinks = styled.div`
-  margin-bottom: 12px;
+  margin-bottom: 10px;
 `;
 
 const FileLinkList = styled.ul`
@@ -60,18 +60,12 @@ const FileLinkList = styled.ul`
 const FileWidgetButton = styled.button`
   ${buttons.button};
   ${components.badge};
-`;
-
-const FileWidgetButtonUrl = styled.button`
-  ${buttons.button};
-  ${components.badge};
-  margin-top: 12px;
+  margin-bottom: 12px;
 `;
 
 const FileWidgetButtonRemove = styled.button`
   ${buttons.button};
   ${components.badgeDanger};
-  margin-top: 12px;
 `;
 
 function isMultiple(value) {
@@ -269,6 +263,9 @@ export default function withFileControl({ forImage } = {}) {
             <FileWidgetButton onClick={this.handleChange}>
               {t(`editor.editorWidgets.${subject}.chooseDifferent`)}
             </FileWidgetButton>
+            <FileWidgetButton onClick={this.handleUrl(subject)}>
+              {t(`editor.editorWidgets.${subject}.replaceUrl`)}
+            </FileWidgetButton>
             <FileWidgetButtonRemove onClick={this.handleRemove}>
               {t(`editor.editorWidgets.${subject}.remove`)}
             </FileWidgetButtonRemove>
@@ -284,9 +281,9 @@ export default function withFileControl({ forImage } = {}) {
           <FileWidgetButton onClick={this.handleChange}>
             {t(`editor.editorWidgets.${subject}.choose`)}
           </FileWidgetButton>
-          <FileWidgetButtonUrl onClick={this.handleUrl(subject)}>
+          <FileWidgetButton onClick={this.handleUrl(subject)}>
             {t(`editor.editorWidgets.${subject}.chooseUrl`)}
-          </FileWidgetButtonUrl>
+          </FileWidgetButton>
         </>
       );
     };

--- a/packages/netlify-cms-widget-file/src/withFileControl.js
+++ b/packages/netlify-cms-widget-file/src/withFileControl.js
@@ -50,7 +50,7 @@ const FileLink = styled.a`
 `;
 
 const FileLinks = styled.div`
-  margin-bottom: 10px;
+  margin-bottom: 12px;
 `;
 
 const FileLinkList = styled.ul`

--- a/packages/netlify-cms-widget-file/src/withFileControl.js
+++ b/packages/netlify-cms-widget-file/src/withFileControl.js
@@ -62,6 +62,12 @@ const FileWidgetButton = styled.button`
   ${components.badge};
 `;
 
+const FileWidgetButtonUrl = styled.button`
+  ${buttons.button};
+  ${components.badge};
+  margin-top: 12px;
+`;
+
 const FileWidgetButtonRemove = styled.button`
   ${buttons.button};
   ${components.badgeDanger};
@@ -174,6 +180,14 @@ export default function withFileControl({ forImage } = {}) {
       });
     };
 
+    handleUrl = subject => e => {
+      e.preventDefault();
+
+      const url = window.prompt(this.props.t(`editor.editorWidgets.${subject}.promptUrl`));
+
+      return this.props.onChange(url);
+    }
+
     handleRemove = e => {
       e.preventDefault();
       this.props.onClearMediaControl(this.controlID);
@@ -266,9 +280,14 @@ export default function withFileControl({ forImage } = {}) {
     renderNoSelection = subject => {
       const { t } = this.props;
       return (
-        <FileWidgetButton onClick={this.handleChange}>
-          {t(`editor.editorWidgets.${subject}.choose`)}
-        </FileWidgetButton>
+        <>
+          <FileWidgetButton onClick={this.handleChange}>
+            {t(`editor.editorWidgets.${subject}.choose`)}
+          </FileWidgetButton>
+          <FileWidgetButtonUrl onClick={this.handleUrl(subject)}>
+            {t(`editor.editorWidgets.${subject}.chooseUrl`)}
+          </FileWidgetButtonUrl>
+        </>
       );
     };
 

--- a/packages/netlify-cms-widget-file/src/withFileControl.js
+++ b/packages/netlify-cms-widget-file/src/withFileControl.js
@@ -186,7 +186,7 @@ export default function withFileControl({ forImage } = {}) {
       const url = window.prompt(this.props.t(`editor.editorWidgets.${subject}.promptUrl`));
 
       return this.props.onChange(url);
-    }
+    };
 
     handleRemove = e => {
       e.preventDefault();


### PR DESCRIPTION
![Screenshot of two button, one says Chose an image and the other says Insert from URL](https://user-images.githubusercontent.com/7413880/101625055-3bd3b880-3a5e-11eb-9ed3-37720150a5e3.png)

**Summary**
Closes #1293, and enble Netlify CMS users to use images from other sources.

**Test plan**
Testing this could be done just like testing with media library, although this one requires the image URL to be reliable. I'm not very sure where to put those tests, so please let me know where should I put it if you think these requires some testing.

**A picture of a cute animal (not mandatory but encouraged)**
![My sleeping cat](https://user-images.githubusercontent.com/7413880/101625380-a8e74e00-3a5e-11eb-9206-83f4179761fb.jpg)
Here's my cat!