### PR TITLE
fix(i18n filtering): enable filtering when i18n is enabled

### DIFF
--- a/packages/netlify-cms-core/src/backend.ts
+++ b/packages/netlify-cms-core/src/backend.ts
@@ -487,7 +487,7 @@ export class Backend {
 
     if (hasI18n(collection)) {
       const extension = selectFolderEntryExtension(collection);
-      const groupedEntries = groupEntries(collection, extension, entries);
+      const groupedEntries = groupEntries(collection, extension, filteredEntries);
       return groupedEntries;
     }
 


### PR DESCRIPTION
**Summary**

Fixes #4665 to allow collections with i18n enabled to use filtered entries.

**Test plan**

Ran yarn test and all tests pass.

![image](https://user-images.githubusercontent.com/13420359/102023113-270b6380-3d83-11eb-8405-1bf016611460.png)


**A picture of a cute animal (not mandatory but encouraged)**

I don't have a cute animal unfortunately :(
