### PR TITLE
feat(widget-string): add trim option

### DIFF
--- a/packages/netlify-cms-widget-string/src/StringControl.js
+++ b/packages/netlify-cms-widget-string/src/StringControl.js
@@ -1,8 +1,10 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import ImmutablePropTypes from 'react-immutable-proptypes';
 
 export default class StringControl extends React.Component {
   static propTypes = {
+    field: ImmutablePropTypes.map.isRequired,
     onChange: PropTypes.func.isRequired,
     forID: PropTypes.string,
     value: PropTypes.node,
@@ -36,8 +38,25 @@ export default class StringControl extends React.Component {
   }
 
   handleChange = e => {
-    this._sel = e.target.selectionStart;
-    this.props.onChange(e.target.value);
+    const { onChange, field } = this.props;
+    const trim = field.get('trim', false);
+    let sel = e.target.selectionStart;
+
+    if (trim) {
+      const beforeTrimmed = e.target.value;
+      const trimmed = beforeTrimmed.trim();
+      const offset = beforeTrimmed.indexOf(trimmed);
+
+      sel = sel - offset;
+
+      e.target.value = trimmed;
+
+      this._el.setSelectionRange(sel, sel);
+    }
+
+    this._sel = sel;
+
+    onChange(e.target.value);
   };
 
   render() {

--- a/website/content/docs/widgets/string.md
+++ b/website/content/docs/widgets/string.md
@@ -10,7 +10,12 @@ The string widget translates a basic text input to a string value. For larger te
 - **Data type:** string
 - **Options:**
   - `default`: accepts a string; defaults to an empty string
+    - `trim`: accepts a boolean, defaults to `false`. Trims whitespace from the beginning and the end of the input string
 - **Example:**
     ```yaml
     - {label: "Title", name: "title", widget: "string"}
+    ```
+- **With trim:**
+    ```yaml
+    - {label: "Title", name: "title", widget: "string", trim: true}
     ```


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines.

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first two fields are mandatory:
-->

**Summary**
<!--
Explain the **motivation** for making this change.
What existing problem does the pull request solve?
-->
Add an option for the string widget to trim content. We need this feature because users can accidentally (e.g. pasting from another document, pasting an accidental carriage return) input extra spaces.

**Test plan**
<!--
Demonstrate the code is solid.
Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.
-->

https://user-images.githubusercontent.com/1474786/103036236-48b0db80-4537-11eb-973b-a6acddaadd81.mp4


**A picture of a cute animal (not mandatory but encouraged)**
![6f29b17b8fcde2889c18c07f571438bb](https://user-images.githubusercontent.com/1474786/103036430-beb54280-4537-11eb-8efc-d6f8e1cd4a64.jpg)
