### PR TITLE
chore: update slack invite link

### DIFF
--- a/website/static/_redirects
+++ b/website/static/_redirects
@@ -6,5 +6,5 @@
 /docs/editorial-workflow                /docs/configuration/#publish-mode 301
 /docs/test-drive                        /docs/start-with-a-template 301
 /docs/quick-start                       /docs/add-to-your-site 301
-/chat                                   https://join.slack.com/t/netlifycms/shared_invite/zt-izc82req-45s7bSMB52vd7DGpXuDfjQ 301
+/chat                                   https://join.slack.com/t/netlifycms/shared_invite/zt-kmftg9fo-1CL9Pv7CMnMymKPSJegoag 301
 /docs/update-the-cms-version            /docs/releases 301


### PR DESCRIPTION
Current link is expired