### PR TITLE
Fixed translation issue of newButton (#4778)

### DIFF
--- a/packages/netlify-cms-locales/src/de/index.js
+++ b/packages/netlify-cms-locales/src/de/index.js
@@ -41,7 +41,7 @@ const de = {
     collectionTop: {
       sortBy: 'Sortieren nach',
       viewAs: 'Anzeigen als',
-      newButton: 'Neue(r) %{collectionLabel}',
+      newButton: 'Neue(r/s) %{collectionLabel}',
       ascending: 'Aufsteigend',
       descending: 'Absteigend',
       searchResults: 'Suchergebnisse für "%{searchTerm}"',


### PR DESCRIPTION
Closes #4778

**Summary**

The translation of newButton is supposed to be Neue(r/s), because there are 3 possible cases:
Neue Blume
Neuer Artikel
Neues Tier

**Test plan**

Nothing to test here. The .js file syntax is still correct.
