### PR TITLE
Skip creating a CI pipeline when rebasing the merge request

### DIFF
--- a/packages/netlify-cms-backend-gitlab/src/API.ts
+++ b/packages/netlify-cms-backend-gitlab/src/API.ts
@@ -678,7 +678,7 @@ export default class API {
   async rebaseMergeRequest(mergeRequest: GitLabMergeRequest) {
     let rebase: GitLabMergeRebase = await this.requestJSON({
       method: 'PUT',
-      url: `${this.repoURL}/merge_requests/${mergeRequest.iid}/rebase`,
+      url: `${this.repoURL}/merge_requests/${mergeRequest.iid}/rebase?skip_ci=true`,
     });
 
     let i = 1;


### PR DESCRIPTION
**Summary**
Fixes #4786

Merge request rebasing creates a GitLab CI pipeline and the subsequent commit creates another. This fix skips the first pipeline creation. Relevant API documentation is located here: https://docs.gitlab.com/ee/api/merge_requests.html#rebase-a-merge-request

**A picture of a cute animal (not mandatory but encouraged)**

![240px-The_GIMP_icon_-_gnome svg](https://user-images.githubusercontent.com/12914806/103587232-144dff80-4ee7-11eb-9ef0-7dd12e8af6d3.png)

<sup>[GIMP's official mascot Wilber](https://commons.wikimedia.org/wiki/File:The_GIMP_icon_-_gnome.svg) by Tuomas Kuosmanen licensed under [GNU GPLv2+](http://www.gnu.org/licenses/gpl.html)</sup>