### PR TITLE
refactor: use redux-devtools-extension package

### DIFF
--- a/packages/netlify-cms-core/package.json
+++ b/packages/netlify-cms-core/package.json
@@ -61,6 +61,7 @@
     "react-waypoint": "^9.0.3",
     "react-window": "^1.8.5",
     "redux": "^4.0.5",
+    "redux-devtools-extension": "^2.13.8",
     "redux-notifications": "^4.0.1",
     "redux-thunk": "^2.3.0",
     "sanitize-filename": "^1.6.1",

--- a/packages/netlify-cms-core/src/redux/index.ts
+++ b/packages/netlify-cms-core/src/redux/index.ts
@@ -1,4 +1,5 @@
-import { createStore, applyMiddleware, compose, AnyAction } from 'redux';
+import { createStore, applyMiddleware, AnyAction } from 'redux';
+import { composeWithDevTools } from 'redux-devtools-extension';
 import thunkMiddleware, { ThunkMiddleware } from 'redux-thunk';
 import { routerMiddleware } from 'connected-react-router';
 import { waitUntilAction } from './middleware/waitUntilAction';
@@ -7,23 +8,14 @@ import history from '../routing/history';
 import { State } from '../types/redux';
 import { Reducer } from 'react';
 
-declare global {
-  interface Window {
-    __REDUX_DEVTOOLS_EXTENSION__?: Function;
-  }
-}
-
 const store = createStore<State | undefined, AnyAction, unknown, unknown>(
   (createRootReducer(history) as unknown) as Reducer<State | undefined, AnyAction>,
-  compose(
+  composeWithDevTools(
     applyMiddleware(
       routerMiddleware(history),
       thunkMiddleware as ThunkMiddleware<State, AnyAction>,
       waitUntilAction,
     ),
-    window.__REDUX_DEVTOOLS_EXTENSION__
-      ? window.__REDUX_DEVTOOLS_EXTENSION__()
-      : (f: Function): Function => f,
   ),
 );
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -6516,7 +6516,7 @@ create-hmac@^1.1.0, create-hmac@^1.1.4, create-hmac@^1.1.7:
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
 
-create-react-class@^15.5.2:
+create-react-class@^15.5.1, create-react-class@^15.5.2:
   version "15.7.0"
   resolved "https://registry.yarnpkg.com/create-react-class/-/create-react-class-15.7.0.tgz#7499d7ca2e69bb51d13faf59bd04f0c65a1d6c1e"
   integrity sha512-QZv4sFWG9S5RUvkTYWbflxeZX+JG7Cz0Tn33rQBJ+WFQTqTfUTjMjiv9tnfXazjsO5r0KhPs+AqCjyrQX6h2ng==
@@ -10067,7 +10067,7 @@ interpret@^2.0.0, interpret@^2.2.0:
   resolved "https://registry.yarnpkg.com/interpret/-/interpret-2.2.0.tgz#1a78a0b5965c40a5416d007ad6f50ad27c417df9"
   integrity sha512-Ju0Bz/cEia55xDwUWEa8+olFpCiQoypjnQySseKtmjNrnps3P+xfpUmGr90T7yjlVJmOtybRvPXhKMbHr+fWnw==
 
-invariant@^2.1.0, invariant@^2.2.2, invariant@^2.2.3, invariant@^2.2.4:
+invariant@^2.0.0, invariant@^2.1.0, invariant@^2.2.2, invariant@^2.2.3, invariant@^2.2.4:
   version "2.2.4"
   resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.4.tgz#610f3c92c9359ce1db616e538008d23ff35158e6"
   integrity sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==
@@ -14705,7 +14705,19 @@ react-popper@^1.3.7:
     typed-styles "^0.0.7"
     warning "^4.0.2"
 
-react-redux@^4.0.0, react-redux@^7.2.0:
+react-redux@^4.0.0:
+  version "4.4.10"
+  resolved "https://registry.yarnpkg.com/react-redux/-/react-redux-4.4.10.tgz#ad57bd1db00c2d0aa7db992b360ce63dd0b80ec5"
+  integrity sha512-tjL0Bmpkj75Td0k+lXlF8Fc8a9GuXFv/3ahUOCXExWs/jhsKiQeTffdH0j5byejCGCRL4tvGFYlrwBF1X/Aujg==
+  dependencies:
+    create-react-class "^15.5.1"
+    hoist-non-react-statics "^3.3.0"
+    invariant "^2.0.0"
+    lodash "^4.17.11"
+    loose-envify "^1.4.0"
+    prop-types "^15.7.2"
+
+react-redux@^7.2.0:
   version "7.2.2"
   resolved "https://registry.yarnpkg.com/react-redux/-/react-redux-7.2.2.tgz#03862e803a30b6b9ef8582dadcc810947f74b736"
   integrity sha512-8+CQ1EvIVFkYL/vu6Olo7JFLWop1qRUeb46sGtIMDCSpgwPQq8fPLpirIB0iTqFe9XYEFPHssdX8/UwN6pAkEA==
@@ -15102,6 +15114,11 @@ redent@^3.0.0:
   dependencies:
     indent-string "^4.0.0"
     strip-indent "^3.0.0"
+
+redux-devtools-extension@^2.13.8:
+  version "2.13.8"
+  resolved "https://registry.yarnpkg.com/redux-devtools-extension/-/redux-devtools-extension-2.13.8.tgz#37b982688626e5e4993ff87220c9bbb7cd2d96e1"
+  integrity sha512-8qlpooP2QqPtZHQZRhx3x3OP5skEV1py/zUdMY28WNAocbafxdG2tRD1MWE7sp8obGMNYuLWanhhQ7EQvT1FBg==
 
 redux-mock-store@^1.5.3:
   version "1.5.4"


### PR DESCRIPTION
**Summary**

Use redux-devtools-extension package (extracted from https://github.com/netlify/netlify-cms/pull/4776). Benefits: less code, happier TypeScript.

**Test plan**

Make sure that redux devtools extension works
