### PR TITLE
fix: remove redundant ajv option

### DIFF
--- a/packages/netlify-cms-core/src/constants/configSchema.js
+++ b/packages/netlify-cms-core/src/constants/configSchema.js
@@ -351,7 +351,7 @@ class ConfigError extends Error {
  * the config that is passed in.
  */
 export function validateConfig(config) {
-  const ajv = new AJV({ allErrors: true, jsonPointers: true, $data: true, strict: false });
+  const ajv = new AJV({ allErrors: true, $data: true, strict: false });
   uniqueItemProperties(ajv);
   select(ajv);
   instanceOf(ajv);


### PR DESCRIPTION
This option was [removed in ajv v7](https://github.com/ajv-validator/ajv/releases/tag/v7.0.0)