### PR TITLE
fix(list-entries-integration): don't show commit date & author as default sort

### DIFF
--- a/packages/netlify-cms-core/src/actions/config.js
+++ b/packages/netlify-cms-core/src/actions/config.js
@@ -5,6 +5,7 @@ import { trimStart, trim, get, isPlainObject, isEmpty } from 'lodash';
 import * as publishModes from 'Constants/publishModes';
 import { validateConfig } from 'Constants/configSchema';
 import { selectDefaultSortableFields, traverseFields } from '../reducers/collections';
+import { getIntegrations, selectIntegration } from '../reducers/integrations';
 import { resolveBackend } from 'coreSrc/backend';
 import { I18N, I18N_FIELD, I18N_STRUCTURE } from '../lib/i18n';
 
@@ -141,6 +142,12 @@ const setViewPatternsDefaults = (key, collection) => {
 
 const defaults = {
   publish_mode: publishModes.SIMPLE,
+};
+
+const hasIntegration = (config, collection) => {
+  const integrations = getIntegrations(config);
+  const integration = selectIntegration(integrations, collection.get('name'), 'listEntries');
+  return !!integration;
 };
 
 export function normalizeConfig(config) {
@@ -281,7 +288,11 @@ export function applyDefaults(config) {
 
           if (!collection.has('sortable_fields')) {
             const backend = resolveBackend(config);
-            const defaultSortable = selectDefaultSortableFields(collection, backend);
+            const defaultSortable = selectDefaultSortableFields(
+              collection,
+              backend,
+              hasIntegration(map, collection),
+            );
             collection = collection.set('sortable_fields', fromJS(defaultSortable));
           }
 

--- a/packages/netlify-cms-core/src/reducers/collections.ts
+++ b/packages/netlify-cms-core/src/reducers/collections.ts
@@ -377,17 +377,21 @@ export const selectEntryCollectionTitle = (collection: Collection, entry: EntryM
 export const COMMIT_AUTHOR = 'commit_author';
 export const COMMIT_DATE = 'commit_date';
 
-export const selectDefaultSortableFields = (collection: Collection, backend: Backend) => {
+export const selectDefaultSortableFields = (
+  collection: Collection,
+  backend: Backend,
+  hasIntegration: boolean,
+) => {
   let defaultSortable = SORTABLE_FIELDS.map((type: string) => {
     const field = selectInferedField(collection, type);
-    if (backend.isGitBackend() && type === 'author' && !field) {
+    if (backend.isGitBackend() && type === 'author' && !field && !hasIntegration) {
       // default to commit author if not author field is found
       return COMMIT_AUTHOR;
     }
     return field;
   }).filter(Boolean);
 
-  if (backend.isGitBackend()) {
+  if (backend.isGitBackend() && !hasIntegration) {
     // always have commit date by default
     defaultSortable = [COMMIT_DATE, ...defaultSortable];
   }

--- a/packages/netlify-cms-core/src/reducers/integrations.ts
+++ b/packages/netlify-cms-core/src/reducers/integrations.ts
@@ -1,42 +1,49 @@
 import { fromJS, List } from 'immutable';
 import { CONFIG_SUCCESS } from '../actions/config';
-import { Integrations, IntegrationsAction, Integration } from '../types/redux';
+import { Integrations, IntegrationsAction, Integration, Config } from '../types/redux';
 
 interface Acc {
   providers: Record<string, {}>;
   hooks: Record<string, string | Record<string, string>>;
 }
 
+export const getIntegrations = (config: Config) => {
+  const integrations: Integration[] = config.get('integrations', List()).toJS() || [];
+  const newState = integrations.reduce(
+    (acc, integration) => {
+      const { hooks, collections, provider, ...providerData } = integration;
+      acc.providers[provider] = { ...providerData };
+      if (!collections) {
+        hooks.forEach(hook => {
+          acc.hooks[hook] = provider;
+        });
+        return acc;
+      }
+      const integrationCollections =
+        collections === '*'
+          ? config
+              .get('collections')
+              .map(collection => collection!.get('name'))
+              .toArray()
+          : (collections as string[]);
+      integrationCollections.forEach(collection => {
+        hooks.forEach(hook => {
+          acc.hooks[collection]
+            ? ((acc.hooks[collection] as Record<string, string>)[hook] = provider)
+            : (acc.hooks[collection] = { [hook]: provider });
+        });
+      });
+      return acc;
+    },
+    { providers: {}, hooks: {} } as Acc,
+  );
+  return fromJS(newState);
+};
+
 const integrations = (state = null, action: IntegrationsAction): Integrations | null => {
   switch (action.type) {
     case CONFIG_SUCCESS: {
-      const integrations: Integration[] = action.payload.get('integrations', List()).toJS() || [];
-      const newState = integrations.reduce(
-        (acc, integration) => {
-          const { hooks, collections, provider, ...providerData } = integration;
-          acc.providers[provider] = { ...providerData };
-          if (!collections) {
-            hooks.forEach(hook => {
-              acc.hooks[hook] = provider;
-            });
-            return acc;
-          }
-          const integrationCollections =
-            collections === '*'
-              ? action.payload.get('collections').map(collection => collection.get('name'))
-              : (collections as string[]);
-          integrationCollections.forEach(collection => {
-            hooks.forEach(hook => {
-              acc.hooks[collection]
-                ? ((acc.hooks[collection] as Record<string, string>)[hook] = provider)
-                : (acc.hooks[collection] = { [hook]: provider });
-            });
-          });
-          return acc;
-        },
-        { providers: {}, hooks: {} } as Acc,
-      );
-      return fromJS(newState);
+      return getIntegrations(action.payload);
     }
     default:
       return state;

--- a/packages/netlify-cms-core/src/types/redux.ts
+++ b/packages/netlify-cms-core/src/types/redux.ts
@@ -44,6 +44,8 @@ export type Config = StaticallyTypedRecord<{
   site_url?: string;
   show_preview_links?: boolean;
   isFetching?: boolean;
+  integrations: List<Integration>;
+  collections: List<StaticallyTypedRecord<{ name: string }>>;
 }>;
 
 type PagesObject = {
@@ -315,10 +317,7 @@ export interface Integration {
 }
 
 export interface IntegrationsAction extends Action<string> {
-  payload: StaticallyTypedRecord<{
-    integrations: List<Integration>;
-    collections: StaticallyTypedRecord<{ name: string }>[];
-  }>;
+  payload: Config;
 }
 
 interface EntryPayload {


### PR DESCRIPTION
Fixes an issue with the `listEntries` integration where it would infer commit author and date a default sort fields.
There is no guarantee that information is available when using an external integration.