### PR TITLE
Update Docs: Widgets “select”

### DIFF
--- a/website/content/docs/widgets/select.md
+++ b/website/content/docs/widgets/select.md
@@ -20,58 +20,60 @@ The select widget allows you to pick a string value from a dropdown menu.
   * `multiple`: accepts a boolean; defaults to `false`
   * `min`: minimum number of items; ignored if **multiple** is  `false`
   * `max`: maximum number of items; ignored if **multiple** is  `false`
+
 * **Example** (options as strings):
 
-  ```yaml
-  - label: "Align Content"
-    name: "align"
-    widget: "select"
-    options: ["left", "center", "right"]
-  ```
+```yaml
+- label: "Align Content"
+  name: "align"
+  widget: "select"
+  options: ["left", "center", "right"]
+```
 
-  Selecting the `center` option, will save the value as:
+Selecting the `center` option, will save the value as:
 
-  ```yaml
-  align: "center"
-  ```
+```yaml
+align: "center"
+```
+
 * **Example** (options as objects):
 
-  ```yaml
-  - label: "City"
-    name: "airport-code"
-    widget: "select"
-    options:
-      [
-        { label: 'Chicago', value: 'ORD' },
-        { label: 'Paris', value: 'CDG' },
-        { label: 'Tokyo', value: 'HND' },
-      ],
-  ```
+```yaml
+- label: "City"
+  name: "airport-code"
+  widget: "select"
+  options:
+    - { label: "Chicago", value: "ORD" }
+    - { label: "Paris", value: "CDG" }
+    - { label: "Tokyo", value: "HND" }
+```
 
-  Selecting the `Chicago` option, will save the value as:
+Selecting the `Chicago` option, will save the value as:
 
-  ```yaml
-  airport-code: "ORD"
-  ```
+```yaml
+airport-code: "ORD"
+```
+
 * **Example** (multiple):
 
-  ```yaml
-  - label: "Tags"
-    name: "tags"
-    widget: "select"
-    multiple: true
-    options: ["Design", "UX", "Dev"]
-    default: ["Design"]
-  ```
+```yaml
+- label: "Tags"
+  name: "tags"
+  widget: "select"
+  multiple: true
+  options: ["Design", "UX", "Dev"]
+  default: ["Design"]
+```
+
 * **Example** (min/max):
 
-  ```yaml
-  - label: "Tags"
-    name: "tags"
-    widget: "select"
-    multiple: true
-    min: 1
-    max: 3
-    options: ["Design", "UX", "Dev"]
-    default: ["Design"]
-  ```
+```yaml
+- label: "Tags"
+  name: "tags"
+  widget: "select"
+  multiple: true
+  min: 1
+  max: 3
+  options: ["Design", "UX", "Dev"]
+  default: ["Design"]
+```

--- a/website/content/docs/widgets/select.md
+++ b/website/content/docs/widgets/select.md
@@ -41,9 +41,11 @@ The select widget allows you to pick a string value from a dropdown menu.
     name: "airport-code"
     widget: "select"
     options:
-      - { label: "Chicago", value: "ORD" }
-      - { label: "Paris", value: "CDG" }
-      - { label: "Tokyo", value: "HND" }
+      [
+        { label: 'Chicago', value: 'ORD' },
+        { label: 'Paris', value: 'CDG' },
+        { label: 'Tokyo', value: 'HND' },
+      ],
   ```
 
   Selecting the `Chicago` option, will save the value as:


### PR DESCRIPTION
As is, the code to create a `select` widget with options as objects will **not** compile. It throws the following error:

```
YAMLSemanticError: Separator , missing in flow map at line 49, column 15:

            - { label: "Chicago", value: "ORD" }
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```

I've changed the code to match the [kitchen sink config example](https://github.com/netlify/netlify-cms/blob/master/dev-test/config.yml#L151).