### PR TITLE
chore: fix vale linting

### DIFF
--- a/.github/workflows/docslint.yml
+++ b/.github/workflows/docslint.yml
@@ -25,7 +25,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Vale Linter
-        uses: errata-ai/vale-action@master
+        uses: errata-ai/vale-action@0dec3032fa59c4097deece7cf6ee3261b27bb3f1
         with:
           # Optional
           files: website/content/docs

--- a/.github/workflows/docslint.yml
+++ b/.github/workflows/docslint.yml
@@ -25,7 +25,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Vale Linter
-        uses: errata-ai/vale-action@v1.3.0
+        uses: errata-ai/vale-action@master
         with:
           # Optional
           files: website/content/docs


### PR DESCRIPTION
`v1.3.0` uses the latest docker tag from https://hub.docker.com/r/jdkato/vale/tags?page=1&ordering=last_updated

This PR pins it to https://github.com/errata-ai/vale-action/commit/0dec3032fa59c4097deece7cf6ee3261b27bb3f1