### PR TITLE
fix: add missing displayURLs to state

### DIFF
--- a/packages/netlify-cms-core/src/reducers/mediaLibrary.ts
+++ b/packages/netlify-cms-core/src/reducers/mediaLibrary.ts
@@ -71,6 +71,7 @@ const mediaLibrary = (state = Map(defaultState), action: MediaLibraryAction) => 
           privateUpload,
           config: libConfig,
           controlMedia: Map(),
+          displayURLs: Map(),
           field,
         });
       }


### PR DESCRIPTION
Add missing `displayURLs` when using private assets