### PR TITLE
chore: improve cypress runs on forks

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -57,10 +57,8 @@ jobs:
           name: dev-test-website-${{ runner.os }}-node-${{ matrix.node-version }}
           path: dev-test
 
-  # non forked workflow (has access to build secrets)
-  e2e-with-cypress-record:
+  e2e-with-cypress:
     needs: build
-    if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false)
     runs-on: ubuntu-latest
 
     strategy:
@@ -88,54 +86,18 @@ jobs:
         with:
           name: dev-test-website-${{ runner.os }}-node-${{ matrix.node-version }}
           path: dev-test
-      - name: npm install and e2e test
+      - name: npm install
         run: |
           node --version
           npm --version
           yarn --version
           yarn --frozen-lockfile
+      - name: e2e test
+        run: |
           yarn test:e2e:run-ci
         env:
-          CI: true
+          IS_FORK: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == true }}
           CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
           NODE_OPTIONS: --max-old-space-size=4096
-
-  # forked workflow (no access to build secrets)
-  e2e-no-cypress-record:
-    needs: build
-    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == true
-    runs-on: ubuntu-latest
-
-    strategy:
-      matrix:
-        node-version: [15.x]
-
-    steps:
-      - uses: actions/checkout@v2
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v2
-        with:
-          node-version: ${{ matrix.node-version }}
-      - name: Get yarn cache directory path
-        id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn cache dir)"
-      - uses: actions/cache@v2
-        with:
-          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-          key: ${{ runner.os }}-yarn-${{ hashFiles(format('{0}{1}', github.workspace, '/yarn.lock')) }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-
-      - uses: actions/download-artifact@master
-        with:
-          name: dev-test-website-${{ runner.os }}-node-${{ matrix.node-version }}
-          path: dev-test
-      - name: npm install and e2e test
-        run: |
-          node --version
-          npm --version
-          yarn --version
-          yarn --frozen-lockfile
-          yarn test:e2e:run
-        env:
-          CI: true
-          NODE_OPTIONS: --max-old-space-size=4096
+          MACHINE_COUNT: 8
+          MACHINE_INDEX: ${{ matrix.machine }}

--- a/cypress/run.js
+++ b/cypress/run.js
@@ -1,0 +1,41 @@
+const execa = require('execa');
+const globby = require('globby');
+
+const runCypress = async () => {
+  if (process.env.IS_FORK === 'true') {
+    const machineIndex = parseInt(process.env.MACHINE_INDEX);
+    const machineCount = parseInt(process.env.MACHINE_COUNT);
+    const specs = await globby(['cypress/integration/*spec*.js']);
+    const specsPerMachine = Math.floor(specs.length / machineCount);
+    const start = (machineIndex - 1) * specsPerMachine;
+    const machineSpecs =
+      machineIndex === machineCount
+        ? specs.slice(start)
+        : specs.slice(start, start + specsPerMachine);
+
+    await execa(
+      'cypress',
+      ['run', '--browser', 'chrome', '--headless', '--spec', machineSpecs.join(',')],
+      { stdio: 'inherit', preferLocal: true },
+    );
+  } else {
+    await execa(
+      'cypress',
+      [
+        'run',
+        '--browser',
+        'chrome',
+        '--headless',
+        '--record',
+        '--parallel',
+        '--ci-build-id',
+        process.env.GITHUB_SHA,
+        '--group',
+        'GitHub CI',
+      ],
+      { stdio: 'inherit', preferLocal: true },
+    );
+  }
+};
+
+runCypress().catch(error => console.error(error));

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "test:e2e:dev": "run-p clean && start-test develop 8080 test:e2e:exec-dev",
     "test:e2e:serve": "http-server -c-1 dev-test",
     "test:e2e:exec": "cypress run --browser chrome --headless",
-    "test:e2e:exec-ci": "cypress run  --browser chrome --headless --record --parallel --ci-build-id $GITHUB_SHA --group 'GitHub CI' displayName: 'Run Cypress tests'",
+    "test:e2e:exec-ci": "node cypress/run.js",
     "test:e2e:exec-dev": "cypress open",
     "test:e2e:record-fixtures:dev": "HTTP_PROXY=http://localhost:1080 RECORD_FIXTURES=true cypress open",
     "test:e2e:run": "start-test test:e2e:serve 8080 test:e2e:exec",
@@ -132,6 +132,7 @@
     "eslint-plugin-import": "^2.18.2",
     "eslint-plugin-prettier": "^3.1.1",
     "eslint-plugin-react": "^7.17.0",
+    "execa": "^5.0.0",
     "friendly-errors-webpack-plugin": "^1.7.0",
     "fs-extra": "^9.0.0",
     "gitlab": "^14.1.1",
@@ -181,6 +182,7 @@
     "emotion": "^10.0.9",
     "eslint-config-prettier": "^7.0.0",
     "eslint-plugin-babel": "^5.3.0",
+    "globby": "^11.0.2",
     "lerna": "^3.15.0"
   },
   "husky": {


### PR DESCRIPTION
This PR changes Cypress tests to run in parallel also on forked PRs (when the Cypress record secret is not available).