### PR TITLE
feat(locale): Make editor interface buttons translatable

### DIFF
--- a/packages/netlify-cms-core/src/components/Editor/EditorInterface.js
+++ b/packages/netlify-cms-core/src/components/Editor/EditorInterface.js
@@ -358,7 +358,7 @@ class EditorInterface extends Component {
                 onClick={this.handleToggleI18n}
                 size="large"
                 type="page"
-                title="Toggle i18n"
+                title={t('editor.editorInterface.toggleI18n')}
                 marginTop="70px"
               />
             )}
@@ -368,7 +368,7 @@ class EditorInterface extends Component {
                 onClick={this.handleTogglePreview}
                 size="large"
                 type="eye"
-                title="Toggle preview"
+                title={t('editor.editorInterface.togglePreview')}
               />
             )}
             {scrollSyncVisible && (
@@ -377,7 +377,7 @@ class EditorInterface extends Component {
                 onClick={this.handleToggleScrollSync}
                 size="large"
                 type="scroll"
-                title="Sync scrolling"
+                title={t('editor.editorInterface.toggleScrollSync')}
               />
             )}
           </ViewControls>

--- a/packages/netlify-cms-locales/src/en/index.js
+++ b/packages/netlify-cms-locales/src/en/index.js
@@ -111,6 +111,11 @@ const en = {
       loadingEntry: 'Loading entry...',
       confirmLoadBackup: 'A local backup was recovered for this entry, would you like to use it?',
     },
+    editorInterface: {
+      toggleI18n: 'Toggle i18n',
+      togglePreview: 'Toggle preview',
+      toggleScrollSync: 'Sync scrolling',
+    },
     editorToolbar: {
       publishing: 'Publishing...',
       publish: 'Publish',

--- a/packages/netlify-cms-locales/src/fr/index.js
+++ b/packages/netlify-cms-locales/src/fr/index.js
@@ -114,6 +114,11 @@ const fr = {
       confirmLoadBackup:
         "Une sauvegarde locale a été trouvée pour cette entrée. Voulez-vous l'utiliser",
     },
+    editorInterface: {
+      toggleI18n: 'Édition multi-langues',
+      togglePreview: 'Aperçu',
+      toggleScrollSync: 'Défilement synchronisé',
+    },
     editorToolbar: {
       publishing: 'Publication...',
       publish: 'Publier',


### PR DESCRIPTION
**Summary**
The buttons at the top-right edge of the editor had hard-coded titles, so it wasn't possible to translate them.

I've added new translation strings, filled them for `en` and `fr`, and used them instead of the hard-coded values.

Concerned buttons are those three:
![concerned buttons](https://user-images.githubusercontent.com/11643685/107250993-5c0afe00-6a34-11eb-8c1f-a35b7b522900.png)

**Test plan**
I ran `yarn test:all` successfully, and checked with `yarn start`, in both `en` and `fr`, that buttons hover values were OK.
If I need to add some tests for this, please tell me!