### PR TITLE
custom editorComponents name is cut by <ul> width #4894

### DIFF
--- a/packages/netlify-cms-widget-markdown/src/MarkdownControl/Toolbar.js
+++ b/packages/netlify-cms-widget-markdown/src/MarkdownControl/Toolbar.js
@@ -105,9 +105,9 @@ export default class Toolbar extends React.Component {
       plugins,
       disabled,
       onSubmit,
-      hasMark = () => { },
-      hasInline = () => { },
-      hasBlock = () => { },
+      hasMark = () => {},
+      hasInline = () => {},
+      hasBlock = () => {},
       editorComponents,
       t,
     } = this.props;

--- a/packages/netlify-cms-widget-markdown/src/MarkdownControl/Toolbar.js
+++ b/packages/netlify-cms-widget-markdown/src/MarkdownControl/Toolbar.js
@@ -105,9 +105,9 @@ export default class Toolbar extends React.Component {
       plugins,
       disabled,
       onSubmit,
-      hasMark = () => {},
-      hasInline = () => {},
-      hasBlock = () => {},
+      hasMark = () => { },
+      hasInline = () => { },
+      hasBlock = () => { },
       editorComponents,
       t,
     } = this.props;
@@ -235,7 +235,7 @@ export default class Toolbar extends React.Component {
             <ToolbarDropdownWrapper>
               <Dropdown
                 dropdownTopOverlap="36px"
-                dropdownWidth="110px"
+                dropdownWidth="max-content"
                 renderButton={() => (
                   <DropdownButton>
                     <ToolbarButton


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines.

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first two fields are mandatory:
-->
closes #4894
**Summary**

The custom editor components name is hiding by ul width
I have added dropdownWidth="max-content", so that solve the problem. 
**Test plan**

<!--
Demonstrate the code is solid.
Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.
-->
![Screenshot from 2021-02-09 00-23-02](https://user-images.githubusercontent.com/32347879/107267569-16b6f280-6a6d-11eb-9004-51b7a5bc5b03.png)

**A picture of a cute animal (not mandatory but encouraged)**
![Thinking-of-getting-a-cat](https://user-images.githubusercontent.com/32347879/107268435-2256e900-6a6e-11eb-90d7-80192fd3068f.png)

