### PR TITLE
test: fix cypress tests

### DIFF
--- a/packages/netlify-cms-backend-bitbucket/src/API.ts
+++ b/packages/netlify-cms-backend-bitbucket/src/API.ts
@@ -653,8 +653,8 @@ export default class API {
       params: {
         pagelen: 50,
         q: oneLine`
-        source.repository.full_name = "${this.repo}"
-        AND state = "${BitBucketPullRequestState.OPEN}"
+        source.repository.full_name = "${this.repo}" 
+        AND state = "${BitBucketPullRequestState.OPEN}" 
         AND destination.branch.name = "${this.branch}"
         AND comment_count > 0
         AND ${sourceQuery}

--- a/packages/netlify-cms-proxy-server/src/middlewares/localGit/index.ts
+++ b/packages/netlify-cms-proxy-server/src/middlewares/localGit/index.ts
@@ -155,7 +155,7 @@ async function getDiffs(git: simpleGit.SimpleGit, source: string, dest: string) 
 }
 
 export async function validateRepo({ repoPath }: { repoPath: string }) {
-  const git = simpleGit(repoPath).silent(false);
+  const git = simpleGit(repoPath);
   const isRepo = await git.checkIsRepo();
   if (!isRepo) {
     throw Error(`${repoPath} is not a valid git repository`);
@@ -168,7 +168,7 @@ export function getSchema({ repoPath }: { repoPath: string }) {
 }
 
 export function localGitMiddleware({ repoPath, logger }: GitOptions) {
-  const git = simpleGit(repoPath).silent(false);
+  const git = simpleGit(repoPath);
 
   // we can only perform a single git operation at any given time
   const mutex = withTimeout(new Mutex(), 3000, new Error('Request timed out'));


### PR DESCRIPTION
Fixes our Cypress tests (we use prerecorded data so string changes in the URL break the tests).
Also remove the very verbose log of `simpleGit`