### PR TITLE
show list item label even when it is not collapsed

### DIFF
--- a/packages/netlify-cms-widget-list/src/ListControl.js
+++ b/packages/netlify-cms-widget-list/src/ListControl.js
@@ -32,12 +32,12 @@ const StyledListItemTopBar = styled(ListItemTopBar)`
 `;
 
 const NestedObjectLabel = styled.div`
-  display: ${props => (props.collapsed ? 'block' : 'none')};
+  display: 'block';
   border-top: 0;
   color: ${props => (props.error ? colors.errorText : 'inherit')};
   background-color: ${colors.textFieldBorder};
   padding: 13px;
-  border-radius: 0 0 ${lengths.borderRadius} ${lengths.borderRadius};
+  border-radius: ${props => (props.collapsed ? `0 0 ${lengths.borderRadius} ${lengths.borderRadius}` : '0')};
 `;
 
 const styleStrings = {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines.

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first two fields are mandatory:
-->

**Summary**

<!--
Explain the **motivation** for making this change.
What existing problem does the pull request solve?
-->

This PR solves the problem where the list widget that uses the types setting doesn't show the summary when the item is not collapsed, making it hard to know what type of item you are editing.

**Test plan**

<!--
Demonstrate the code is solid.
Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.
-->

**A picture of a cute animal (not mandatory but encouraged)**
