### PR TITLE
Fixes user-facing config types in netlify-cms-core

### DIFF
--- a/packages/netlify-cms-core/index.d.ts
+++ b/packages/netlify-cms-core/index.d.ts
@@ -292,7 +292,6 @@ declare module 'netlify-cms-core' {
     label: string;
     field: string;
     pattern: string;
-    id: string;
   }
 
   export interface CmsCollection {

--- a/packages/netlify-cms-core/index.d.ts
+++ b/packages/netlify-cms-core/index.d.ts
@@ -286,7 +286,6 @@ declare module 'netlify-cms-core' {
     label: string;
     field: string;
     pattern: string;
-    id: string;
   }
 
   export interface ViewGroup {

--- a/packages/netlify-cms-core/index.d.ts
+++ b/packages/netlify-cms-core/index.d.ts
@@ -2,7 +2,6 @@
 declare module 'netlify-cms-core' {
   import React, { ComponentType } from 'react';
   import { List, Map } from 'immutable';
-  import { FILES, FOLDER } from 'netlify-cms-core/src/constants/collectionTypes';
 
   export type CmsBackendType =
     | 'azure'
@@ -318,7 +317,6 @@ declare module 'netlify-cms-core' {
     nested?: {
       depth: number;
     };
-    type: typeof FOLDER | typeof FILES;
     meta?: { path?: { label: string; widget: string; index_file: string } };
 
     /**

--- a/packages/netlify-cms-core/index.d.ts
+++ b/packages/netlify-cms-core/index.d.ts
@@ -291,7 +291,7 @@ declare module 'netlify-cms-core' {
   export interface ViewGroup {
     label: string;
     field: string;
-    pattern: string;
+    pattern?: string;
   }
 
   export interface CmsCollection {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines.

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first two fields are mandatory:
-->

**Summary**

Fixes #4984 wherein fixing TypeScript type errors introduced in #4950 would result in a config-loading runtime error. These changes fix those unexpected type errors and bring the public facing config types (`packages/netlify-cms-core/index.d.ts`) more in line with user expectations.

<!--
Explain the **motivation** for making this change.
What existing problem does the pull request solve?
-->

**Test plan**

No new code or tests have been added. All existing tests pass after these changes to `packages/netlify-cms-core/index.d.ts`.

I believe that is expected and _okay_ because afaik `index.d.ts` is kind of a facade (i.e. not generated from the actual implementation). At the very least, this PR gets rid of a few type errors for TypeScript users and doesn’t knock anything over.

A future, worthwhile test may be to type-check a kitchen-sink config object—like one that would be used in a manual CMS initialization. However, I’m not sure where to begin, and it’s likely part of a larger conversation on type congruency in this project that I’m not privy to.

<!--
Demonstrate the code is solid.
Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.
-->

**A picture of a cute animal (not mandatory but encouraged)**

![PXL_20210203_161415169_2](https://user-images.githubusercontent.com/5232237/108634709-7683a500-7440-11eb-8d5e-f47579e390f3.jpg)

