### PR TITLE
fix(core): typedef: globalStyles should not be required in CmsWidgetParam

### DIFF
--- a/packages/netlify-cms-core/index.d.ts
+++ b/packages/netlify-cms-core/index.d.ts
@@ -429,7 +429,7 @@ declare module 'netlify-cms-core' {
     name: string;
     controlComponent: ComponentType<any>;
     previewComponent?: ComponentType<any>;
-    globalStyles: any;
+    globalStyles?: any;
   }
 
   export interface CmsWidget {


### PR DESCRIPTION
Just a quick fix, unless I've missed something `globalStyles` shouldn't be required in the following case:

```ts
CMS.registerWidget({
  name: 'custom-select',
  controlComponent: SelectWidget,
})
```
