### PR TITLE
fix(core): ensure GridCardLink fills entire card

### DIFF
--- a/packages/netlify-cms-core/src/components/Collection/Entries/EntryCard.js
+++ b/packages/netlify-cms-core/src/components/Collection/Entries/EntryCard.js
@@ -36,6 +36,7 @@ const GridCard = styled.li`
 
 const GridCardLink = styled(Link)`
   display: block;
+  height: 100%;
   &,
   &:hover {
     background-color: ${colors.foreground};

--- a/packages/netlify-cms-core/src/components/Collection/Entries/EntryCard.js
+++ b/packages/netlify-cms-core/src/components/Collection/Entries/EntryCard.js
@@ -37,6 +37,7 @@ const GridCard = styled.li`
 const GridCardLink = styled(Link)`
   display: block;
   height: 100%;
+  outline-offset: -2px;
   &,
   &:hover {
     background-color: ${colors.foreground};


### PR DESCRIPTION
**Summary**

(This is tangentially related to #1341.)

When viewing a collection in grid view, if the entries don’t have images (or perhaps a custom summary), the cards are currently usually larger than the summary text. This results in poor UX, because only the upper part of the card actually contains the link element. Clicking in the lower part of the card won’t open the entry.

<img width="1328" alt="Screenshot showing the GridCardLink filling only part of an entry card" src="https://user-images.githubusercontent.com/357379/109087156-39076c00-770d-11eb-9f3c-cb6e3c3e1e2c.png">

This PR adds `height: 100%` to the `GridCardLink` component, ensuring the link element always fills the full card height:

<img width="1324" alt="Screenshot showing the GridCardLink filling the full entry card" src="https://user-images.githubusercontent.com/357379/109087450-ca76de00-770d-11eb-99d2-1241d6416d45.png">

In addition, I have added `outline-offset: -2px` to ensure that outline styling on keyboard focus remains visible. The `GridCard` has `overflow: hidden` and so the default focus outline for the link would otherwise fall entirely outside the card. (Previously it was only visible on the bottom of the link as a horizontal line.) I had a look and couldn’t see any standard focus-styling approach being used, but I’m happy to change this offset approach as preferred.


**Test plan**

I have tested this change manually by running `yarn start` and checking its impact on cards with and without images and it appears to behave as expected. (Screenshots above show the before and after of the link sizing.)

**A picture of a cute animal (not mandatory but encouraged)**

A lynx to help us with these links.

![A lynx](https://upload.wikimedia.org/wikipedia/commons/6/68/Lynx_lynx_poing.jpg)
