### PR TITLE
docs: clarify i18n configuration for file collections

### DIFF
--- a/website/content/docs/beta-features.md
+++ b/website/content/docs/beta-features.md
@@ -98,6 +98,26 @@ collections:
     i18n: true
 ```
 
+When using a file collection, you must also enable i18n for each individual file:
+
+```yaml
+collections:
+  - name: pages
+    label: Pages
+    # Configure i18n for this collection.
+    i18n:
+      structure: single_file
+      locales: [en, de, fr]
+    files:
+      - name: about
+        label: About Page
+        file: site/content/about.yml
+        # Enable i18n for this file.
+        i18n: true
+        fields:
+          - { label: Title, name: title, widget: string, i18n: true }
+```
+
 ### Field level configuration
 
 ```yaml


### PR DESCRIPTION
**Summary**

I had quite a confusing time debugging i18n with a file collection until I finally found #4844. I had been missing the fact that each file in a file collection also needs its own `i18n` key.

This PR updates the i18n docs to mention this.

[Aside: this is partly confusing because a file collection with i18n enabled shows the side-by-side translation interface for all files, but it is broken for files that don’t themselves have `i18n: true` (as detailed in #4844). I guess to support per-file config like this better, files that don’t have i18n enabled should not show the i18n UI at all.]

**Test plan**

I read through my docs changes several times and tried to make them consistent with the rest of the examples.

**A picture of a cute animal (not mandatory but encouraged)**

Docs ox.

![A grazing white and brown ox](https://upload.wikimedia.org/wikipedia/commons/thumb/5/57/Oxen03_%2814291322101%29.jpg/2880px-Oxen03_%2814291322101%29.jpg)