### PR TITLE
fix: entry disappears from workflow screen on failing to merge pull request

### DIFF
--- a/packages/netlify-cms-core/src/reducers/editorialWorkflow.ts
+++ b/packages/netlify-cms-core/src/reducers/editorialWorkflow.ts
@@ -128,12 +128,12 @@ function unpublishedEntries(state = Map(), action: EditorialWorkflowAction) {
       );
 
     case UNPUBLISHED_ENTRY_PUBLISH_SUCCESS:
-    case UNPUBLISHED_ENTRY_PUBLISH_FAILURE:
       return state.deleteIn(['entities', `${action.payload!.collection}.${action.payload!.slug}`]);
 
     case UNPUBLISHED_ENTRY_DELETE_SUCCESS:
       return state.deleteIn(['entities', `${action.payload!.collection}.${action.payload!.slug}`]);
 
+    case UNPUBLISHED_ENTRY_PUBLISH_FAILURE:
     default:
       return state;
   }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines.

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first two fields are mandatory:
-->

**Summary**
fix https://github.com/netlify/netlify-cms/issues/4072

the entry should remain on the screen so that the user can publish again.

<!--
Explain the **motivation** for making this change.
What existing problem does the pull request solve?
-->

**Test plan**
yarn test

<!--
Demonstrate the code is solid.
Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.
-->

### Before
https://user-images.githubusercontent.com/35182743/110475698-91ceff80-8124-11eb-9772-2f875044241b.mov

### After
https://user-images.githubusercontent.com/35182743/110475712-95fb1d00-8124-11eb-9135-463910a98847.mov



**A picture of a cute animal (not mandatory but encouraged)**
