### PR TITLE
Generate esm correctly

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -88,7 +88,12 @@ const svgo = {
 function presets() {
   return [
     '@babel/preset-react',
-    '@babel/preset-env',
+    [
+      '@babel/preset-env',
+      {
+        modules: isESM ? false : 'auto',
+      },
+    ],
     [
       '@emotion/babel-preset-css-prop',
       {

--- a/packages/netlify-cms-app/package.json
+++ b/packages/netlify-cms-app/package.json
@@ -5,6 +5,7 @@
   "homepage": "https://www.netlifycms.org",
   "repository": "https://github.com/netlify/netlify-cms/tree/master/packages/netlify-cms-app",
   "bugs": "https://github.com/netlify/netlify-cms/issues",
+  "module": "dist/esm/index.js",
   "main": "dist/netlify-cms-app.js",
   "files": [
     "src/",

--- a/packages/netlify-cms/package.json
+++ b/packages/netlify-cms/package.json
@@ -5,6 +5,7 @@
   "homepage": "https://www.netlifycms.org",
   "repository": "https://github.com/netlify/netlify-cms",
   "bugs": "https://github.com/netlify/netlify-cms/issues",
+  "module": "dist/esm/index.js",
   "main": "dist/netlify-cms.js",
   "scripts": {
     "webpack": "node --max_old_space_size=4096 ../../node_modules/webpack/bin/webpack.js",


### PR DESCRIPTION
**Summary**

Solve #5086 

**Test plan**

Run `npm run build:es` on any package and check that `dist/esm` output is `esm` (export) instead of `commonjs`(module.exports)
