### PR TITLE
Improve UX in Markdown editor - link editing and selected heading underline

### DIFF
--- a/packages/netlify-cms-ui-default/src/Dropdown.js
+++ b/packages/netlify-cms-ui-default/src/Dropdown.js
@@ -65,6 +65,9 @@ function StyledMenuItem({ isActive, isCheckedItem = false, ...props }) {
           color: ${colors.active};
           background-color: ${colors.activeBackground};
         }
+        &.active {
+          text-decoration: underline;
+        }
       `}
       {...props}
     />

--- a/packages/netlify-cms-widget-markdown/src/MarkdownControl/VisualEditor.js
+++ b/packages/netlify-cms-widget-markdown/src/MarkdownControl/VisualEditor.js
@@ -156,8 +156,8 @@ export default class Editor extends React.Component {
   };
 
   handleLinkClick = () => {
-    this.editor.toggleLink(() =>
-      window.prompt(this.props.t('editor.editorWidgets.markdown.linkPrompt')),
+    this.editor.toggleLink(oldUrl =>
+      window.prompt(this.props.t('editor.editorWidgets.markdown.linkPrompt'), oldUrl),
     );
   };
 

--- a/packages/netlify-cms-widget-markdown/src/MarkdownControl/plugins/Link.js
+++ b/packages/netlify-cms-widget-markdown/src/MarkdownControl/plugins/Link.js
@@ -2,24 +2,31 @@ function Link({ type }) {
   return {
     commands: {
       toggleLink(editor, getUrl) {
+        const selection = editor.value.selection;
+        const isCollapsed = selection && selection.isCollapsed;
+
         if (editor.hasInline(type)) {
-          editor.unwrapInline(type);
+          const inlines = editor.value.inlines.toJSON();
+          const link = inlines.find(item => item.type === type);
+
+          const url = getUrl(link.data.url);
+
+          // remove url if it was removed by the user
+          if (url === '') editor.unwrapInline(type);
+
+          // if selection is empty, replace the old link
+          if (url && isCollapsed) editor.setInlines({ data: { url } });
         } else {
           const url = getUrl();
           if (!url) return;
 
-          const selection = editor.value.selection;
-          const isCollapsed = selection && selection.isCollapsed;
-          if (isCollapsed) {
-            // If no text is selected, use the entered URL as text.
-            return editor.insertInline({
-              type,
-              data: { url },
-              nodes: [{ object: 'text', text: url }],
-            });
-          } else {
-            return editor.wrapInline({ type, data: { url } }).moveToEnd();
-          }
+          return isCollapsed
+            ? editor.insertInline({
+                type,
+                data: { url },
+                nodes: [{ object: 'text', text: url }],
+              })
+            : editor.wrapInline({ type, data: { url } }).moveToEnd();
         }
       },
     },

--- a/packages/netlify-cms-widget-markdown/src/MarkdownControl/plugins/Link.js
+++ b/packages/netlify-cms-widget-markdown/src/MarkdownControl/plugins/Link.js
@@ -11,14 +11,18 @@ function Link({ type }) {
 
           const url = getUrl(link.data.url);
 
-          // remove url if it was removed by the user
-          if (url === '') editor.unwrapInline(type);
-
-          // if selection is empty, replace the old link
-          if (url && isCollapsed) editor.setInlines({ data: { url } });
+          if (url) {
+            // replace the old link
+            return editor.setInlines({ data: { url } });
+          } else {
+            // remove url if it was removed by the user
+            return editor.unwrapInline(type);
+          }
         } else {
           const url = getUrl();
-          if (!url) return;
+          if (!url) {
+            return;
+          }
 
           return isCollapsed
             ? editor.insertInline({

--- a/packages/netlify-cms-widget-markdown/src/MarkdownControl/renderers.js
+++ b/packages/netlify-cms-widget-markdown/src/MarkdownControl/renderers.js
@@ -237,9 +237,13 @@ function NumberedList(props) {
 function Link(props) {
   const data = props.node.get('data');
   const url = data.get('url');
-  const title = data.get('title');
+
+  // title doesn't seem to return anything
+  // const title = data.get('title');
+
+  // added url as title for easier url discovery
   return (
-    <StyledA href={url} title={title} {...props.attributes}>
+    <StyledA href={url} title={url} {...props.attributes}>
       {props.children}
     </StyledA>
   );

--- a/packages/netlify-cms-widget-markdown/src/MarkdownControl/renderers.js
+++ b/packages/netlify-cms-widget-markdown/src/MarkdownControl/renderers.js
@@ -97,6 +97,7 @@ const StyledLi = styled.li`
 
 const StyledA = styled.a`
   text-decoration: underline;
+  font-size: inherit;
 `;
 
 const StyledHr = styled.hr`

--- a/packages/netlify-cms-widget-markdown/src/MarkdownControl/renderers.js
+++ b/packages/netlify-cms-widget-markdown/src/MarkdownControl/renderers.js
@@ -237,13 +237,10 @@ function NumberedList(props) {
 function Link(props) {
   const data = props.node.get('data');
   const url = data.get('url');
+  const title = data.get('title') || url;
 
-  // title doesn't seem to return anything
-  // const title = data.get('title');
-
-  // added url as title for easier url discovery
   return (
-    <StyledA href={url} title={url} {...props.attributes}>
+    <StyledA href={url} title={title} {...props.attributes}>
       {props.children}
     </StyledA>
   );


### PR DESCRIPTION
**Summary**

**Links:** Editing a link has a really bad UX. Clicking the link button first removes an existing link and then you have to select the desired text again to actually add another link.

This PR introduces logic to auto-complete the link prompt if the selected text is already a link, editing the link will change it like normal, and it will also prevent removing a link if the prompt is canceled or the input remains the same.

**Headings:** When selecting a heading, there was no way of knowing which type was selected other than the size of the text.

The attached image and video will show both functionalities.

**Test plan**

![headings](https://user-images.githubusercontent.com/9270494/110871032-49efda00-82d6-11eb-83e3-0eb50417ec0e.png)

https://user-images.githubusercontent.com/9270494/110871066-5a07b980-82d6-11eb-9f65-6bcf6482de5a.mp4




**A picture of a cute animal (not mandatory but encouraged)**

![cute animals](https://i.ytimg.com/vi/ynp7O45r0s8/maxresdefault.jpg)
