### PR TITLE
#4897: fix code widget resize on focus bug

### DIFF
--- a/packages/netlify-cms-widget-code/src/CodeControl.js
+++ b/packages/netlify-cms-widget-code/src/CodeControl.js
@@ -275,7 +275,7 @@ export default class CodeControl extends React.Component {
                 overflow: hidden;
 
                 .CodeMirror {
-                  height: auto;
+                  height: auto !important;
                   cursor: text;
                   min-height: 300px;
                 }


### PR DESCRIPTION
**Summary**

The code widget resizes to a maximum of *300px* whenever you focus into it, no matter how much code there is.

This PR partially fixes #4897 , however I think the other problem is related to code mirror.

**Test plan**

The only addition is an `!important` tag:

```css
/* ... */
.CodeMirror {
  height: auto !important;
}
/* ... */
```

<details>
<summary>
Before
</summary>

https://user-images.githubusercontent.com/9270494/111359028-afa3e380-8693-11eb-9130-3606a5297665.mp4

</details>

<details>
<summary>
After
</summary>

https://user-images.githubusercontent.com/9270494/111359258-f5f94280-8693-11eb-9e51-d48852395d81.mp4

</details>


