### PR TITLE
fix: i18n regex logic

### DIFF
--- a/packages/netlify-cms-core/src/lib/__tests__/i18n.spec.js
+++ b/packages/netlify-cms-core/src/lib/__tests__/i18n.spec.js
@@ -130,23 +130,40 @@ describe('i18n', () => {
   });
 
   describe('getFilePath', () => {
-    const args = ['md', 'src/content/index.md', 'index', 'de'];
     it('should return directory path based on locale when structure is I18N_STRUCTURE.MULTIPLE_FOLDERS', () => {
-      expect(i18n.getFilePath(i18n.I18N_STRUCTURE.MULTIPLE_FOLDERS, ...args)).toEqual(
-        'src/content/de/index.md',
-      );
+      expect(
+        i18n.getFilePath(
+          i18n.I18N_STRUCTURE.MULTIPLE_FOLDERS,
+          'md',
+          'src/content/index.md',
+          'index',
+          'de',
+        ),
+      ).toEqual('src/content/de/index.md');
     });
 
     it('should return file path based on locale when structure is I18N_STRUCTURE.MULTIPLE_FILES', () => {
-      expect(i18n.getFilePath(i18n.I18N_STRUCTURE.MULTIPLE_FILES, ...args)).toEqual(
-        'src/content/index.de.md',
-      );
+      expect(
+        i18n.getFilePath(
+          i18n.I18N_STRUCTURE.MULTIPLE_FILES,
+          'md',
+          'src/content/file-with-md-in-the-name.md',
+          'file-with-md-in-the-name',
+          'de',
+        ),
+      ).toEqual('src/content/file-with-md-in-the-name.de.md');
     });
 
     it('should not modify path when structure is I18N_STRUCTURE.SINGLE_FILE', () => {
-      expect(i18n.getFilePath(i18n.I18N_STRUCTURE.SINGLE_FILE, ...args)).toEqual(
-        'src/content/index.md',
-      );
+      expect(
+        i18n.getFilePath(
+          i18n.I18N_STRUCTURE.SINGLE_FILE,
+          'md',
+          'src/content/index.md',
+          'index',
+          'de',
+        ),
+      ).toEqual('src/content/index.md');
     });
   });
 

--- a/packages/netlify-cms-core/src/lib/i18n.ts
+++ b/packages/netlify-cms-core/src/lib/i18n.ts
@@ -79,7 +79,7 @@ export function getFilePath(
     case I18N_STRUCTURE.MULTIPLE_FOLDERS:
       return path.replace(`/${slug}`, `/${locale}/${slug}`);
     case I18N_STRUCTURE.MULTIPLE_FILES:
-      return path.replace(extension, `${locale}.${extension}`);
+      return path.replace(new RegExp(`${extension}$`), `${locale}.${extension}`);
     case I18N_STRUCTURE.SINGLE_FILE:
     default:
       return path;

--- a/packages/netlify-cms-core/src/lib/i18n.ts
+++ b/packages/netlify-cms-core/src/lib/i18n.ts
@@ -1,5 +1,5 @@
 import { Map, List } from 'immutable';
-import { set, trimEnd, groupBy } from 'lodash';
+import { set, trimEnd, groupBy, escapeRegExp } from 'lodash';
 import { Collection, Entry, EntryDraft, EntryField, EntryMap } from '../types/redux';
 import { selectEntrySlug } from '../reducers/collections';
 import { EntryValue } from '../valueObjects/Entry';
@@ -79,7 +79,7 @@ export function getFilePath(
     case I18N_STRUCTURE.MULTIPLE_FOLDERS:
       return path.replace(`/${slug}`, `/${locale}/${slug}`);
     case I18N_STRUCTURE.MULTIPLE_FILES:
-      return path.replace(new RegExp(`${extension}$`), `${locale}.${extension}`);
+      return path.replace(new RegExp(`${escapeRegExp(extension)}$`), `${locale}.${extension}`);
     case I18N_STRUCTURE.SINGLE_FILE:
     default:
       return path;


### PR DESCRIPTION
**Summary**
Fixes #5049 where files with "md" (or other extensions) within the name is mistaken for file extension.

**Test Plan**
Described in the mentioned issue.

My first time contributing. I think a test could be added as well, but not sure how. Thanks!