### PR TITLE
Fix webpack config in “custom-widgets”

### DIFF
--- a/website/content/docs/custom-widgets.md
+++ b/website/content/docs/custom-widgets.md
@@ -293,6 +293,7 @@ Here is the content of `package.json` that you will have at the end:
      output: {
        path: path.resolve(__dirname, 'public'),
      },
+     optimization: { minimize: false },
      module: {
        rules: [
          {
@@ -307,7 +308,7 @@ Here is the content of `package.json` that you will have at the end:
          },
          {
            test: /\.css$/,
-           loader: ['style-loader', 'css-loader'],
+           use: [{ loader: 'style-loader' }, { loader: 'css-loader' }],
          },
        ],
      },


### PR DESCRIPTION
I was following the custom widgets docs, but hit a road bump. I just did exactly what the guide said, but still got a webpack error about the list of loaders. I looked at the webpack docs, found `use` and it seemed to work.

![cat](https://media.giphy.com/media/yFQ0ywscgobJK/giphy.gif)