### PR TITLE
chore: don't run tests on tags

### DIFF
--- a/.github/workflows/docslint.yml
+++ b/.github/workflows/docslint.yml
@@ -3,8 +3,6 @@ on:
   push:
     branches:
       - master
-    tags:
-      - '*'
 
     paths:
       - '.github/workflows/docslint.yml'

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -4,8 +4,6 @@ on:
   push:
     branches:
       - master
-    tags:
-      - '*'
 
     paths-ignore:
       - 'website/**'


### PR DESCRIPTION
We tags releases when we publish and we also push to `master` at the same time.
We don't need to waste CI machines on tags:
![image](https://user-images.githubusercontent.com/26760571/111911664-2ca5d300-8a6f-11eb-8bc2-74e05a9d80bf.png)
