### PR TITLE
chore: remove GitHub cache action

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -28,15 +28,6 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node-version }}
-      - name: Get yarn cache directory path
-        id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn cache dir)"
-      - uses: actions/cache@v2
-        with:
-          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-          key: ${{ runner.os }}-yarn-${{ hashFiles(format('{0}{1}', github.workspace, '/yarn.lock')) }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-
       - name: log versions
         run: node --version && npm --version && yarn --version
       - name: install dependecies


### PR DESCRIPTION
Caching on Windows is super slow and adds more than 7m to the build:
![image](https://user-images.githubusercontent.com/26760571/111976273-1e58c500-8b0a-11eb-8f77-512450ea39b6.png)

See https://github.com/actions/cache/issues/529 and https://github.com/actions/cache/issues/442

On MacOS it's not that great either:
![image](https://user-images.githubusercontent.com/26760571/111976317-2c0e4a80-8b0a-11eb-97fc-91da032ee02d.png)

Ubuntu seems good:
![image](https://user-images.githubusercontent.com/26760571/111976364-36c8df80-8b0a-11eb-8412-301599727ff9.png)

but since we wait for all builds to finish I think it's better to remove caching. 