### PR TITLE
fix: #5143 added types for registerWidget()

### DIFF
--- a/packages/netlify-cms-core/index.d.ts
+++ b/packages/netlify-cms-core/index.d.ts
@@ -441,14 +441,7 @@ declare module 'netlify-cms-core' {
     init: (args: any) => CmsBackendClass;
   }
 
-  export interface CmsWidgetParam {
-    name: string;
-    controlComponent: ComponentType<any>;
-    previewComponent?: ComponentType<any>;
-    globalStyles?: any;
-  }
-
-  export interface CmsWidgetControlProps<T = any> {
+    export interface CmsWidgetControlProps<T = any> {
     value: T;
     field: Map<string, any>;
     onChange: (value: T) => void;
@@ -465,9 +458,16 @@ declare module 'netlify-cms-core' {
     fieldsMetaData: Map<string, any>;
   }
 
+  export interface CmsWidgetParam {
+    name: string;
+    controlComponent: CmsWidgetControlProps;
+    previewComponent?: CmsWidgetPreviewProps;
+    globalStyles?: any;
+  }
+
   export interface CmsWidget {
-    control: ComponentType<any>;
-    preview?: ComponentType<any>;
+    control: CmsWidgetControlProps;
+    preview?: CmsWidgetPreviewProps;
     globalStyles?: any;
   }
 

--- a/packages/netlify-cms-core/index.d.ts
+++ b/packages/netlify-cms-core/index.d.ts
@@ -441,7 +441,7 @@ declare module 'netlify-cms-core' {
     init: (args: any) => CmsBackendClass;
   }
 
-    export interface CmsWidgetControlProps<T = any> {
+  export interface CmsWidgetControlProps<T = any> {
     value: T;
     field: Map<string, any>;
     onChange: (value: T) => void;

--- a/packages/netlify-cms-core/index.d.ts
+++ b/packages/netlify-cms-core/index.d.ts
@@ -448,6 +448,23 @@ declare module 'netlify-cms-core' {
     globalStyles?: any;
   }
 
+  export interface CmsWidgetControlProps<T = any> {
+    value: T;
+    field: Map<string, any>;
+    onChange: (value: T) => void;
+    forID: string;
+    classNameWrapper: string;
+  }
+
+  export interface CmsWidgetPreviewProps<T = any> {
+    value: T;
+    field: Map<string, any>;
+    metadata: Map<string, any>;
+    getAsset: GetAssetFunction;
+    entry: Map<string, any>;
+    fieldsMetaData: Map<string, any>;
+  }
+
   export interface CmsWidget {
     control: ComponentType<any>;
     preview?: ComponentType<any>;
@@ -535,8 +552,8 @@ declare module 'netlify-cms-core' {
     ) => void;
     registerWidget: (
       widget: string | CmsWidgetParam,
-      control?: ComponentType<any>,
-      preview?: ComponentType<any>,
+      control?: ComponentType<CmsWidgetControlProps> | string,
+      preview?: ComponentType<CmsWidgetPreviewProps>,
     ) => void;
     registerWidgetValueSerializer: (
       widgetName: string,


### PR DESCRIPTION
**Summary**

Should resolve #5143

**Test plan**

Call registerWidget() in TypeScript, check if control and preview params are typed. 