### PR TITLE
test(e2e): add retries

### DIFF
--- a/cypress.json
+++ b/cypress.json
@@ -1,5 +1,9 @@
 {
   "baseUrl": "http://localhost:8080",
   "projectId": "dzqjxb",
-  "testFiles": "*spec*.js"
+  "testFiles": "*spec*.js",
+  "retries": {
+    "runMode": 2,
+    "openMode": 0
+  }
 }


### PR DESCRIPTION
Another attempt to stabilize tests.

Retries allows us to later examine flaky tests in the Cypress dashboard. See https://docs.cypress.io/guides/guides/test-retries