### PR TITLE
Add alwaysFork option for open authoring

### DIFF
--- a/packages/netlify-cms-backend-github/src/implementation.tsx
+++ b/packages/netlify-cms-backend-github/src/implementation.tsx
@@ -67,6 +67,7 @@ export default class GitHub implements Implementation {
   repo?: string;
   openAuthoringEnabled: boolean;
   useOpenAuthoring?: boolean;
+  alwaysForkEnabled: boolean;
   branch: string;
   apiRoot: string;
   mediaFolder: string;
@@ -109,6 +110,7 @@ export default class GitHub implements Implementation {
     } else {
       this.repo = this.originRepo = config.backend.repo || '';
     }
+    this.alwaysForkEnabled = config.backend.always_fork || false;
     this.branch = config.backend.branch?.trim() || 'master';
     this.apiRoot = config.backend.api_root || 'https://api.github.com';
     this.token = '';
@@ -268,8 +270,9 @@ export default class GitHub implements Implementation {
     }
     const token = userData.token as string;
 
-    // Origin maintainers should be able to use the CMS normally
-    if (await this.userIsOriginMaintainer({ token })) {
+    // Origin maintainers should be able to use the CMS normally. If alwaysFork
+    // is enabled we always fork (and avoid the origin maintainer check)
+    if (!this.alwaysForkEnabled && await this.userIsOriginMaintainer({ token })) {
       this.repo = this.originRepo;
       this.useOpenAuthoring = false;
       return Promise.resolve();

--- a/packages/netlify-cms-backend-github/src/implementation.tsx
+++ b/packages/netlify-cms-backend-github/src/implementation.tsx
@@ -272,7 +272,7 @@ export default class GitHub implements Implementation {
 
     // Origin maintainers should be able to use the CMS normally. If alwaysFork
     // is enabled we always fork (and avoid the origin maintainer check)
-    if (!this.alwaysForkEnabled && await this.userIsOriginMaintainer({ token })) {
+    if (!this.alwaysForkEnabled && (await this.userIsOriginMaintainer({ token }))) {
       this.repo = this.originRepo;
       this.useOpenAuthoring = false;
       return Promise.resolve();

--- a/packages/netlify-cms-lib-util/src/implementation.ts
+++ b/packages/netlify-cms-lib-util/src/implementation.ts
@@ -93,6 +93,7 @@ export type Config = {
   backend: {
     repo?: string | null;
     open_authoring?: boolean;
+    always_fork?: boolean;
     branch?: string;
     api_root?: string;
     squash_merges?: boolean;


### PR DESCRIPTION
**Summary**

This PR adds a new `always_fork` option to be used with open authoring. When a user has write/admin access to the repo the current behavior is to avoid the fork flow. When `always_fork` is set to true, forking will always be used even when the user has write/admin access. Resolves #5203 

**Test plan**
Still working on testing this.

**A picture of a cute animal (not mandatory but encouraged)**
