### PR TITLE
fix(netlify-cms-package): remove module field

### DIFF
--- a/packages/netlify-cms/package.json
+++ b/packages/netlify-cms/package.json
@@ -5,7 +5,6 @@
   "homepage": "https://www.netlifycms.org",
   "repository": "https://github.com/netlify/netlify-cms",
   "bugs": "https://github.com/netlify/netlify-cms/issues",
-  "module": "dist/esm/index.js",
   "main": "dist/netlify-cms.js",
   "scripts": {
     "webpack": "node --max_old_space_size=4096 ../../node_modules/webpack/bin/webpack.js",


### PR DESCRIPTION
Small fix to https://github.com/netlify/netlify-cms/pull/5087

We don't generate `esm` for `netlify-cms` so the `module` field is redundant