### PR TITLE
fix(docs-external-auth-client): use correct casing for GitHub, GitLab and TypeScript

### DIFF
--- a/website/content/docs/external-oauth-clients.md
+++ b/website/content/docs/external-oauth-clients.md
@@ -18,6 +18,6 @@ If you would like to facilitate your own OAuth authentication rather than use Ne
 | [@bericp1](https://github.com/bericp1)                       | GitHub, GitHub Enterprise         | Node.js, Vercel Serverless        | [Repo](https://github.com/bericp1/netlify-cms-oauth-provider-node)                                                                                           |
 | [@mcdeck](https://github.com/mcdeck)                         | GitHub, GitHub Enterprise, GitLab | PHP                               | [Repo](https://github.com/mcdeck/netlify-cms-oauth-provider-php), [Blog](https://www.van-porten.de/blog/2021/01/netlify-auth-provider/)                      |
 | [@deepbass](https://github.com/deepbass)                     | GitHub, GitHub Enterprise         | Node.js Azure Functions           | [Repo](https://github.com/deepbass/serverless-cms-azure), [Blog](https://www.danielbass.dev/building-a-serverless-cms-on-azure-with-netlify-cms-and-gatsby/) |
-| [@adrian-ub](https://github.com/adrian-ub) | Github, Gitlab | Typescript | [Repo](https://github.com/ublabs/netlify-cms-oauth) |
+| [@adrian-ub](https://github.com/adrian-ub) | GitHub, GitLab | TypeScript | [Repo](https://github.com/ublabs/netlify-cms-oauth) |
 
 Check each project's documentation for instructions on installation and usage.


### PR DESCRIPTION
Follow up on https://github.com/netlify/netlify-cms/pull/5237