### PR TITLE
docs: add netlify-cms-backend-* readme for developers

### DIFF
--- a/packages/netlify-cms-backend-azure/README.md
+++ b/packages/netlify-cms-backend-azure/README.md
@@ -6,8 +6,8 @@ An abstraction layer between the CMS and [Azure DevOps](https://docs.microsoft.c
 
 `Implementation` for [File Management System API](https://github.com/netlify/netlify-cms/tree/master/packages/netlify-cms-lib-util/README.md) based on `Api`.
 
-`Api` - A wrapper for Azure REST API.
+`Api` - A wrapper for Azure DevOps REST API.
 
-`AuthenticationPage` - A component facilitates Azure authentication flow. Uses [lib-auth](https://github.com/netlify/netlify-cms/tree/master/packages/netlify-cms-lib-auth/README.md).
+`AuthenticationPage` - facilitates implicit authentication flow. Uses [lib-auth](https://github.com/netlify/netlify-cms/tree/master/packages/netlify-cms-lib-auth/README.md).
 
 Look at tests or types for more info.

--- a/packages/netlify-cms-backend-azure/README.md
+++ b/packages/netlify-cms-backend-azure/README.md
@@ -1,11 +1,18 @@
-# Docs coming soon!
+# Backend Azure
 
-Netlify CMS was recently converted from a single npm package to a "monorepo" of over 20 packages.
-That's over 20 Readme's! We haven't created one for this package yet, but we will soon.
+This is `azure REST-API` file manager.
 
-In the meantime, you can:
+## Has `Api`, `Backend` and `AuthenticationPage`.
 
-1. Check out the [main readme](https://github.com/netlify/netlify-cms/#readme) or the [documentation
-   site](https://www.netlifycms.org) for more info.
-2. Reach out to the [community chat](https://netlifycms.org/chat/) if you need help.
-3. Help out and [write the readme yourself](https://github.com/netlify/netlify-cms/edit/master/packages/netlify-cms-backend-azure/README.md)!
+`Api` - wrapper for azure `REST-API`.
+
+`AuthenticationPage` is component for [lib-auth](https://github.com/netlify/netlify-cms/edit/master/packages/netlify-cms-lib-auth/README.md) login by:
+- azure app endpoint, from `config.backend`.
+
+`Backend` is domain-specific file manager based on `Api`.
+
+Look at tests or types for more info.
+
+## What `domain-specific file manager` mean?
+
+Look at [lib-util](https://github.com/netlify/netlify-cms/edit/master/packages/netlify-cms-lib-util/README.md) for interface description.

--- a/packages/netlify-cms-backend-azure/README.md
+++ b/packages/netlify-cms-backend-azure/README.md
@@ -1,18 +1,13 @@
-# Backend Azure
+# Azure backend
 
-This is `azure REST-API` file manager.
+An abstraction layer between the CMS and [Azure DevOps](https://docs.microsoft.com/en-us/rest/api/azure/devops/git/)
 
-## Has `Api`, `Backend` and `AuthenticationPage`.
+## Code structure
 
-`Api` - wrapper for azure `REST-API`.
+`Implementation` for [File Management System API](https://github.com/netlify/netlify-cms/tree/master/packages/netlify-cms-lib-util/README.md) based on `Api`.
 
-`AuthenticationPage` is component for [lib-auth](https://github.com/netlify/netlify-cms/edit/master/packages/netlify-cms-lib-auth/README.md) login by:
-- azure app endpoint, from `config.backend`.
+`Api` - A wrapper for Azure REST API.
 
-`Backend` is domain-specific file manager based on `Api`.
+`AuthenticationPage` - A component facilitates Azure authentication flow. Uses [lib-auth](https://github.com/netlify/netlify-cms/tree/master/packages/netlify-cms-lib-auth/README.md).
 
 Look at tests or types for more info.
-
-## What `domain-specific file manager` mean?
-
-Look at [lib-util](https://github.com/netlify/netlify-cms/edit/master/packages/netlify-cms-lib-util/README.md) for interface description.

--- a/packages/netlify-cms-backend-bitbucket/README.md
+++ b/packages/netlify-cms-backend-bitbucket/README.md
@@ -8,9 +8,6 @@ An abstraction layer between the CMS and [Bitbucket](https://docs.microsoft.com/
 
 `Api` - A wrapper for Bitbucket REST API.
 
-`AuthenticationPage` - A component uses [lib-auth](https://github.com/netlify/netlify-cms/tree/master/packages/netlify-cms-lib-auth/README.md) and facilitates authentication flows for:
-- bitbucket
-- netlify
-- or custom bitbucket endpoint, from `config.backend`.
+`AuthenticationPage` - uses [lib-auth](https://github.com/netlify/netlify-cms/tree/master/packages/netlify-cms-lib-auth/README.md) to facilitate OAuth and implicit authentication.
 
 Look at tests or types for more info.

--- a/packages/netlify-cms-backend-bitbucket/README.md
+++ b/packages/netlify-cms-backend-bitbucket/README.md
@@ -1,20 +1,16 @@
-# Backend Bitbucket
+# Bitbucket backend
 
-This is `bitbucket REST-API` file manager.
+An abstraction layer between the CMS and [Bitbucket](https://docs.microsoft.com/en-us/rest/api/azure/devops/git/)
 
-## Has `Api`, `Backend` and `AuthenticationPage`.
+## Code structure
 
-`Api` - wrapper for bitbucket `REST-API`.
+`Implementation` for [File Management System API](https://github.com/netlify/netlify-cms/tree/master/packages/netlify-cms-lib-util/README.md) based on `Api` and `LargeMedia(LFS)`. With [Editorial Workflow](https://www.netlifycms.org/docs/beta-features/#gitlab-and-bitbucket-editorial-workflow-support) uses pull requests comments to track unpublished entries statuses.
 
-`AuthenticationPage` is component for [lib-auth](https://github.com/netlify/netlify-cms/tree/master/packages/netlify-cms-lib-auth/README.md) login by:
+`Api` - A wrapper for Bitbucket REST API.
+
+`AuthenticationPage` - A component uses [lib-auth](https://github.com/netlify/netlify-cms/tree/master/packages/netlify-cms-lib-auth/README.md) and facilitates authentication flows for:
 - bitbucket
 - netlify
 - or custom bitbucket endpoint, from `config.backend`.
 
-`Backend` is domain-specific file manager based on `Api` and `LargeMedia(LFS)`.
-
 Look at tests or types for more info.
-
-## What `domain-specific file manager` mean?
-
-Look at [lib-util](https://github.com/netlify/netlify-cms/tree/master/packages/netlify-cms-lib-util/README.md) for interface description.

--- a/packages/netlify-cms-backend-bitbucket/README.md
+++ b/packages/netlify-cms-backend-bitbucket/README.md
@@ -1,11 +1,20 @@
-# Docs coming soon!
+# Backend Bitbucket
 
-Netlify CMS was recently converted from a single npm package to a "monorepo" of over 20 packages.
-That's over 20 Readme's! We haven't created one for this package yet, but we will soon.
+This is `bitbucket REST-API` file manager.
 
-In the meantime, you can:
+## Has `Api`, `Backend` and `AuthenticationPage`.
 
-1. Check out the [main readme](https://github.com/netlify/netlify-cms/#readme) or the [documentation
-   site](https://www.netlifycms.org) for more info.
-2. Reach out to the [community chat](https://netlifycms.org/chat/) if you need help.
-3. Help out and [write the readme yourself](https://github.com/netlify/netlify-cms/edit/master/packages/netlify-cms-backend-bitbucket/README.md)!
+`Api` - wrapper for bitbucket `REST-API`.
+
+`AuthenticationPage` is component for [lib-auth](https://github.com/netlify/netlify-cms/tree/master/packages/netlify-cms-lib-auth/README.md) login by:
+- bitbucket
+- netlify
+- or custom bitbucket endpoint, from `config.backend`.
+
+`Backend` is domain-specific file manager based on `Api` and `LargeMedia(LFS)`.
+
+Look at tests or types for more info.
+
+## What `domain-specific file manager` mean?
+
+Look at [lib-util](https://github.com/netlify/netlify-cms/tree/master/packages/netlify-cms-lib-util/README.md) for interface description.

--- a/packages/netlify-cms-backend-git-gateway/README.md
+++ b/packages/netlify-cms-backend-git-gateway/README.md
@@ -1,11 +1,20 @@
-# Docs coming soon!
+# Git gateway
 
-Netlify CMS was recently converted from a single npm package to a "monorepo" of over 20 packages.
-That's over 20 Readme's! We haven't created one for this package yet, but we will soon.
+This is `all git backends with Netlify` file manager.
 
-In the meantime, you can:
+## Has `Api`, `Backend` and `AuthenticationPage`.
 
-1. Check out the [main readme](https://github.com/netlify/netlify-cms/#readme) or the [documentation
-   site](https://www.netlifycms.org) for more info.
-2. Reach out to the [community chat](https://netlifycms.org/chat/) if you need help.
-3. Help out and [write the readme yourself](https://github.com/netlify/netlify-cms/edit/master/packages/netlify-cms-backend-git-gateway/README.md)!
+`Api` and `Backend` from backend-[github](https://github.com/netlify/netlify-cms/tree/master/packages/netlify-cms-backend-github/README.md)/[gitlab](https://github.com/netlify/netlify-cms/tree/master/packages/netlify-cms-backend-gitlab/README.md)/[bitbacket](https://github.com/netlify/netlify-cms/tree/master/packages/netlify-cms-backend-bitbacket/README.md) extended with Netlify-specific `LargeMedia(LFS)` and `JWT` auth.
+
+`Backend` is domain-specific file manager based on `Api`.
+
+`AuthenticationPage` is component for login by:
+- `window.netlifyIdentity`
+- or [GoTrue](https://github.com/netlify/gotrue-js) with `config.backend.identity_url` from `Backend`.
+
+Look at tests or types for more info.
+
+## What `domain-specific file manager` mean?
+
+Look at [lib-util](https://github.com/netlify/netlify-cms/tree/master/packages/netlify-cms-lib-util/README.md) for interface description.
+

--- a/packages/netlify-cms-backend-git-gateway/README.md
+++ b/packages/netlify-cms-backend-git-gateway/README.md
@@ -1,20 +1,28 @@
-# Git gateway
+# Git Gateway
 
-This is `all git backends with Netlify` file manager.
+Netlify's [gateway](https://github.com/netlify/git-gateway) to hosted git APIs.
 
-## Has `Api`, `Backend` and `AuthenticationPage`.
+## Code structure
 
-`Api` and `Backend` from backend-[github](https://github.com/netlify/netlify-cms/tree/master/packages/netlify-cms-backend-github/README.md)/[gitlab](https://github.com/netlify/netlify-cms/tree/master/packages/netlify-cms-backend-gitlab/README.md)/[bitbacket](https://github.com/netlify/netlify-cms/tree/master/packages/netlify-cms-backend-bitbacket/README.md) extended with Netlify-specific `LargeMedia(LFS)` and `JWT` auth.
+`Implementation` for [File Management System API](https://github.com/netlify/netlify-cms/tree/master/packages/netlify-cms-lib-util/README.md) based on `Api`.
 
-`Backend` is domain-specific file manager based on `Api`.
+`Api` and `Implementation` from backend-[github](https://github.com/netlify/netlify-cms/tree/master/packages/netlify-cms-backend-github/README.md)/[gitlab](https://github.com/netlify/netlify-cms/tree/master/packages/netlify-cms-backend-gitlab/README.md)/[bitbacket](https://github.com/netlify/netlify-cms/tree/master/packages/netlify-cms-backend-bitbacket/README.md) extended with Netlify-specific `LargeMedia(LFS)` and `JWT` auth.
 
-`AuthenticationPage` is component for login by:
+`AuthenticationPage` - A component uses [lib-auth](https://github.com/netlify/netlify-cms/tree/master/packages/netlify-cms-lib-auth/README.md) and facilitates authentication flows for:
 - `window.netlifyIdentity`
-- or [GoTrue](https://github.com/netlify/gotrue-js) with `config.backend.identity_url` from `Backend`.
+- or [GoTrue](https://github.com/netlify/gotrue-js) with `config.backend.identity_url` from `Implementation`.
 
 Look at tests or types for more info.
 
-## What `domain-specific file manager` mean?
+## Debugging
 
-Look at [lib-util](https://github.com/netlify/netlify-cms/tree/master/packages/netlify-cms-lib-util/README.md) for interface description.
+When debugging the CMS with Git Gateway you must:
 
+1. Have a Netlify site with [Git Gateway](https://docs.netlify.com/visitor-access/git-gateway/) and [Netlify Identity](https://docs.netlify.com/visitor-access/identity/) enabled. An easy way to create such a site is to use a [template](https://www.netlifycms.org/docs/start-with-a-template/), for example the [Gatsby template](https://app.netlify.com/start/deploy?repository=https://github.com/AustinGreen/gatsby-starter-netlify-cms&stack=cms)
+2. Tell the CMS the URL of your Netlify site using a local storage item. To do so:
+
+    1. Open `http://localhost:8080/` in the browser
+    2. Write the below command and press enter: `localStorage.setItem('netlifySiteURL', 'https://yourwebsiteurl.netlify.app/')`
+    3. To be sure, you can run this command as well: `localStorage.getItem('netlifySiteURL')`
+    4. Refresh the page
+    5. You should be able to log in via your Netlify Identity email/password

--- a/packages/netlify-cms-backend-git-gateway/README.md
+++ b/packages/netlify-cms-backend-git-gateway/README.md
@@ -8,9 +8,7 @@ Netlify's [gateway](https://github.com/netlify/git-gateway) to hosted git APIs.
 
 `Api` and `Implementation` from backend-[github](https://github.com/netlify/netlify-cms/tree/master/packages/netlify-cms-backend-github/README.md)/[gitlab](https://github.com/netlify/netlify-cms/tree/master/packages/netlify-cms-backend-gitlab/README.md)/[bitbacket](https://github.com/netlify/netlify-cms/tree/master/packages/netlify-cms-backend-bitbacket/README.md) extended with Netlify-specific `LargeMedia(LFS)` and `JWT` auth.
 
-`AuthenticationPage` - A component uses [lib-auth](https://github.com/netlify/netlify-cms/tree/master/packages/netlify-cms-lib-auth/README.md) and facilitates authentication flows for:
-- `window.netlifyIdentity`
-- or [GoTrue](https://github.com/netlify/gotrue-js) with `config.backend.identity_url` from `Implementation`.
+`AuthenticationPage` - uses [lib-auth](https://github.com/netlify/netlify-cms/tree/master/packages/netlify-cms-lib-auth/README.md) and implements Netlify Identity authentication flow.
 
 Look at tests or types for more info.
 

--- a/packages/netlify-cms-backend-github/README.md
+++ b/packages/netlify-cms-backend-github/README.md
@@ -1,4 +1,4 @@
-# Github backend
+# GitHub backend
 
 An abstraction layer between the CMS and [Github](https://docs.github.com/en/rest)
 
@@ -6,14 +6,12 @@ An abstraction layer between the CMS and [Github](https://docs.github.com/en/res
 
 `Implementation` for [File Management System API](https://github.com/netlify/netlify-cms/tree/master/packages/netlify-cms-lib-util/README.md) based on `Api`.
 
-`Api` - A wrapper for Github REST API.
+`Api` - A wrapper for GitHub REST API.
 
 `GraphQLApi` - `Api` with `ApolloClient`. [Api docs](https://docs.github.com/en/graphql) and [netlify docs](https://www.netlifycms.org/docs/beta-features/#github-graphql-api).
 
-`AuthenticationPage` -  A component uses [lib-auth](https://github.com/netlify/netlify-cms/tree/master/packages/netlify-cms-lib-auth/README.md) and facilitates authentication flows for:
-- netlify
-- or fork repo.
+`AuthenticationPage` -  uses [lib-auth](https://github.com/netlify/netlify-cms/tree/master/packages/netlify-cms-lib-auth/README.md) to facilitate OAuth and implicit authentication.
 
-`Scripts` create `src/fragmentTypes.js` by fetch Github graphql schema.
+`scripts` -  use `createFragmentTypes.js` to create GitHub GraphQL API fragment types.
 
 Look at tests or types for more info.

--- a/packages/netlify-cms-backend-github/README.md
+++ b/packages/netlify-cms-backend-github/README.md
@@ -1,11 +1,23 @@
-# Docs coming soon!
+# Backend Github
 
-Netlify CMS was recently converted from a single npm package to a "monorepo" of over 20 packages.
-That's over 20 Readme's! We haven't created one for this package yet, but we will soon.
+This is `github graphql` file manager.
 
-In the meantime, you can:
+## Has `scripts`, `Api`, `GraphQLApi`, `Backend` and `AuthenticationPage`.
 
-1. Check out the [main readme](https://github.com/netlify/netlify-cms/#readme) or the [documentation
-   site](https://www.netlifycms.org) for more info.
-2. Reach out to the [community chat](https://netlifycms.org/chat/) if you need help.
-3. Help out and [write the readme yourself](https://github.com/netlify/netlify-cms/edit/master/packages/netlify-cms-backend-github/README.md)!
+`Api` - wrapper for github `REST-API`.
+
+`GraphQLApi` - `Api` with `ApolloClient`.
+
+`Scripts` create `src/fragmentTypes.js` by fetch github graphql schema.
+
+`AuthenticationPage` is component for [lib-auth](https://github.com/netlify/netlify-cms/tree/master/packages/netlify-cms-lib-auth/README.md) login by:
+- netlify
+- or fork repo.
+
+`Backend` is domain-specific file manager based on `Api`.
+
+Look at tests or types for more info.
+
+## What `domain-specific file manager` mean?
+
+Look at [lib-util](https://github.com/netlify/netlify-cms/tree/master/packages/netlify-cms-lib-util/README.md) for interface description.

--- a/packages/netlify-cms-backend-github/README.md
+++ b/packages/netlify-cms-backend-github/README.md
@@ -1,23 +1,19 @@
-# Backend Github
+# Github backend
 
-This is `github graphql` file manager.
+An abstraction layer between the CMS and [Github](https://docs.github.com/en/rest)
 
-## Has `scripts`, `Api`, `GraphQLApi`, `Backend` and `AuthenticationPage`.
+## Code structure
 
-`Api` - wrapper for github `REST-API`.
+`Implementation` for [File Management System API](https://github.com/netlify/netlify-cms/tree/master/packages/netlify-cms-lib-util/README.md) based on `Api`.
 
-`GraphQLApi` - `Api` with `ApolloClient`.
+`Api` - A wrapper for Github REST API.
 
-`Scripts` create `src/fragmentTypes.js` by fetch github graphql schema.
+`GraphQLApi` - `Api` with `ApolloClient`. [Api docs](https://docs.github.com/en/graphql) and [netlify docs](https://www.netlifycms.org/docs/beta-features/#github-graphql-api).
 
-`AuthenticationPage` is component for [lib-auth](https://github.com/netlify/netlify-cms/tree/master/packages/netlify-cms-lib-auth/README.md) login by:
+`AuthenticationPage` -  A component uses [lib-auth](https://github.com/netlify/netlify-cms/tree/master/packages/netlify-cms-lib-auth/README.md) and facilitates authentication flows for:
 - netlify
 - or fork repo.
 
-`Backend` is domain-specific file manager based on `Api`.
+`Scripts` create `src/fragmentTypes.js` by fetch Github graphql schema.
 
 Look at tests or types for more info.
-
-## What `domain-specific file manager` mean?
-
-Look at [lib-util](https://github.com/netlify/netlify-cms/tree/master/packages/netlify-cms-lib-util/README.md) for interface description.

--- a/packages/netlify-cms-backend-gitlab/README.md
+++ b/packages/netlify-cms-backend-gitlab/README.md
@@ -8,9 +8,6 @@ An abstraction layer between the CMS and [GitLab](https://docs.gitlab.com/ee/api
 
 `Api` - A wrapper for GitLab REST API.
 
-`AuthenticationPage` - A component uses [lib-auth](https://github.com/netlify/netlify-cms/tree/master/packages/netlify-cms-lib-auth/README.md) and facilitates authentication flows for:
-- gitlab
-- netlify
-- or custom gitlab endpoint, from `config.backend`.
+`AuthenticationPage` - A component uses [lib-auth](https://github.com/netlify/netlify-cms/tree/master/packages/netlify-cms-lib-auth/README.md) to facilitate OAuth, PKCE and implicit authentication.
 
 Look at tests or types for more info.

--- a/packages/netlify-cms-backend-gitlab/README.md
+++ b/packages/netlify-cms-backend-gitlab/README.md
@@ -1,20 +1,16 @@
-# Backend Gitlab
+# GitLab backend
 
-This is `gitlab REST-API` file manager.
+An abstraction layer between the CMS and [GitLab](https://docs.gitlab.com/ee/api/README.html)
 
-## Has `Api`, `Backend` and `AuthenticationPage`.
+## Code structure
 
-`Api` - wrapper for gitlab `REST-API`.
+`Implementation` for [File Management System API](https://github.com/netlify/netlify-cms/tree/master/packages/netlify-cms-lib-util/README.md) based on `Api`. With [Editorial Workflow](https://www.netlifycms.org/docs/beta-features/#gitlab-and-bitbucket-editorial-workflow-support) uses merge requests labels to track unpublished entries statuses.
 
-`AuthenticationPage` is component for [lib-auth](https://github.com/netlify/netlify-cms/tree/master/packages/netlify-cms-lib-auth/README.md) login by:
+`Api` - A wrapper for GitLab REST API.
+
+`AuthenticationPage` - A component uses [lib-auth](https://github.com/netlify/netlify-cms/tree/master/packages/netlify-cms-lib-auth/README.md) and facilitates authentication flows for:
 - gitlab
 - netlify
 - or custom gitlab endpoint, from `config.backend`.
 
-`Backend` is domain-specific file manager based on `Api`.
-
 Look at tests or types for more info.
-
-## What `domain-specific file manager` mean?
-
-Look at [lib-util](https://github.com/netlify/netlify-cms/tree/master/packages/netlify-cms-lib-util/README.md) for interface description.

--- a/packages/netlify-cms-backend-gitlab/README.md
+++ b/packages/netlify-cms-backend-gitlab/README.md
@@ -1,11 +1,20 @@
-# Docs coming soon!
+# Backend Gitlab
 
-Netlify CMS was recently converted from a single npm package to a "monorepo" of over 20 packages.
-That's over 20 Readme's! We haven't created one for this package yet, but we will soon.
+This is `gitlab REST-API` file manager.
 
-In the meantime, you can:
+## Has `Api`, `Backend` and `AuthenticationPage`.
 
-1. Check out the [main readme](https://github.com/netlify/netlify-cms/#readme) or the [documentation
-   site](https://www.netlifycms.org) for more info.
-2. Reach out to the [community chat](https://netlifycms.org/chat/) if you need help.
-3. Help out and [write the readme yourself](https://github.com/netlify/netlify-cms/edit/master/packages/netlify-cms-backend-gitlab/README.md)!
+`Api` - wrapper for gitlab `REST-API`.
+
+`AuthenticationPage` is component for [lib-auth](https://github.com/netlify/netlify-cms/tree/master/packages/netlify-cms-lib-auth/README.md) login by:
+- gitlab
+- netlify
+- or custom gitlab endpoint, from `config.backend`.
+
+`Backend` is domain-specific file manager based on `Api`.
+
+Look at tests or types for more info.
+
+## What `domain-specific file manager` mean?
+
+Look at [lib-util](https://github.com/netlify/netlify-cms/tree/master/packages/netlify-cms-lib-util/README.md) for interface description.

--- a/packages/netlify-cms-backend-proxy/README.md
+++ b/packages/netlify-cms-backend-proxy/README.md
@@ -4,6 +4,6 @@ Facilitates [local development](https://www.netlifycms.org/docs/beta-features/#w
 
 ## Code structure
 
-`Implementation` for [File Management System API](https://github.com/netlify/netlify-cms/tree/master/packages/netlify-cms-lib-util/README.md). Just `RPC` wrapper for `proxyUrl`.
+`Implementation` for [File Management System API](https://github.com/netlify/netlify-cms/tree/master/packages/netlify-cms-lib-util/README.md). An `RPC` wrapper for `netlify-cms-proxy-server`.
 
-`AuthenticationPage` - A component, not specific.
+`AuthenticationPage` - a mock authentication page

--- a/packages/netlify-cms-backend-proxy/README.md
+++ b/packages/netlify-cms-backend-proxy/README.md
@@ -1,11 +1,13 @@
-# Docs coming soon!
+# Backend Proxy
 
-Netlify CMS was recently converted from a single npm package to a "monorepo" of over 20 packages.
-That's over 20 Readme's! We haven't created one for this package yet, but we will soon.
+This is `RPC-proxy` file manager.
 
-In the meantime, you can:
+## Has `Backend` and `AuthenticationPage`.
 
-1. Check out the [main readme](https://github.com/netlify/netlify-cms/#readme) or the [documentation
-   site](https://www.netlifycms.org) for more info.
-2. Reach out to the [community chat](https://netlifycms.org/chat/) if you need help.
-3. Help out and [write the readme yourself](https://github.com/netlify/netlify-cms/edit/master/packages/netlify-cms-backend-proxy/README.md)!
+`AuthenticationPage` is component, not specific.
+
+`Backend` is domain-specific file manager. Just `RPC` wrapper for `proxyUrl`.
+
+## What `domain-specific file manager` mean?
+
+Look at [lib-util](https://github.com/netlify/netlify-cms/tree/master/packages/netlify-cms-lib-util/README.md) for interface description.

--- a/packages/netlify-cms-backend-proxy/README.md
+++ b/packages/netlify-cms-backend-proxy/README.md
@@ -1,13 +1,9 @@
-# Backend Proxy
+# Proxy backend
 
-This is `RPC-proxy` file manager.
+Facilitates [local development](https://www.netlifycms.org/docs/beta-features/#working-with-a-local-git-repository).
 
-## Has `Backend` and `AuthenticationPage`.
+## Code structure
 
-`AuthenticationPage` is component, not specific.
+`Implementation` for [File Management System API](https://github.com/netlify/netlify-cms/tree/master/packages/netlify-cms-lib-util/README.md). Just `RPC` wrapper for `proxyUrl`.
 
-`Backend` is domain-specific file manager. Just `RPC` wrapper for `proxyUrl`.
-
-## What `domain-specific file manager` mean?
-
-Look at [lib-util](https://github.com/netlify/netlify-cms/tree/master/packages/netlify-cms-lib-util/README.md) for interface description.
+`AuthenticationPage` - A component, not specific.

--- a/packages/netlify-cms-backend-test/README.md
+++ b/packages/netlify-cms-backend-test/README.md
@@ -1,20 +1,17 @@
-# Backend Test
+# Test backend
 
-This is `in-memory` file manager.
+The backend behind https://cms-demo.netlify.com/.
+Used for demo purposes only.
 
-## Has `Backend` and `AuthenticationPage`.
+## Code structure
 
-`AuthenticationPage` is component which allow skip `login screen` for demo purposes.
-
-`Backend` is domain-specific file manager based on simple JS objects:
+`Implementation` for [File Management System API](https://github.com/netlify/netlify-cms/tree/master/packages/netlify-cms-lib-util/README.md) based on simple JS objects:
 
 ```js
 window.repoFiles // json file-system three
 window.repoFilesUnpublished // flat file list
 ```
 
+`AuthenticationPage` - A component which allow skip `login screen` for demo purposes.
+
 Look at tests or types for more info.
-
-## What `domain-specific file manager` mean?
-
-Look at [lib-util](https://github.com/netlify/netlify-cms/tree/master/packages/netlify-cms-lib-util/README.md) for interface description.

--- a/packages/netlify-cms-backend-test/README.md
+++ b/packages/netlify-cms-backend-test/README.md
@@ -1,11 +1,20 @@
-# Docs coming soon!
+# Backend Test
 
-Netlify CMS was recently converted from a single npm package to a "monorepo" of over 20 packages.
-That's over 20 Readme's! We haven't created one for this package yet, but we will soon.
+This is `in-memory` file manager.
 
-In the meantime, you can:
+## Has `Backend` and `AuthenticationPage`.
 
-1. Check out the [main readme](https://github.com/netlify/netlify-cms/#readme) or the [documentation
-   site](https://www.netlifycms.org) for more info.
-2. Reach out to the [community chat](https://netlifycms.org/chat/) if you need help.
-3. Help out and [write the readme yourself](https://github.com/netlify/netlify-cms/edit/master/packages/netlify-cms-backend-test/README.md)!
+`AuthenticationPage` is component which allow skip `login screen` for demo purposes.
+
+`Backend` is domain-specific file manager based on simple JS objects:
+
+```js
+window.repoFiles // json file-system three
+window.repoFilesUnpublished // flat file list
+```
+
+Look at tests or types for more info.
+
+## What `domain-specific file manager` mean?
+
+Look at [lib-util](https://github.com/netlify/netlify-cms/tree/master/packages/netlify-cms-lib-util/README.md) for interface description.

--- a/packages/netlify-cms-backend-test/README.md
+++ b/packages/netlify-cms-backend-test/README.md
@@ -8,7 +8,7 @@ Used for demo purposes only.
 `Implementation` for [File Management System API](https://github.com/netlify/netlify-cms/tree/master/packages/netlify-cms-lib-util/README.md) based on simple JS objects:
 
 ```js
-window.repoFiles // json file-system three
+window.repoFiles // json file-system tree
 window.repoFilesUnpublished // flat file list
 ```
 

--- a/packages/netlify-cms-lib-auth/README.md
+++ b/packages/netlify-cms-lib-auth/README.md
@@ -1,11 +1,3 @@
-# Docs coming soon!
+# Backend Lib Auth
 
-Netlify CMS was recently converted from a single npm package to a "monorepo" of over 20 packages.
-That's over 20 Readme's! We haven't created one for this package yet, but we will soon.
-
-In the meantime, you can:
-
-1. Check out the [main readme](https://github.com/netlify/netlify-cms/#readme) or the [documentation
-   site](https://www.netlifycms.org) for more info.
-2. Reach out to the [community chat](https://netlifycms.org/chat/) if you need help.
-3. Help out and [write the readme yourself](https://github.com/netlify/netlify-cms/edit/master/packages/netlify-cms-lib-auth/README.md)!
+This is auth router for `AuthenticationPage` in `netlify-cms-backend-*`.

--- a/packages/netlify-cms-lib-auth/README.md
+++ b/packages/netlify-cms-lib-auth/README.md
@@ -1,3 +1,3 @@
-# Backend Lib Auth
+# Lib Auth
 
-This is auth router for `AuthenticationPage` in `netlify-cms-backend-*`.
+Shared components to handle OAuth and implicit authentication flows.

--- a/packages/netlify-cms-lib-util/README.md
+++ b/packages/netlify-cms-lib-util/README.md
@@ -1,15 +1,22 @@
-# Docs coming soon!
+# Lib Util
 
-Netlify CMS was recently converted from a single npm package to a "monorepo" of over 20 packages.
-That's over 20 Readme's! We haven't created one for this package yet, but we will soon.
+Shared utilities to handle various `netlify-cms-backend-*` backends operations.
 
-In the meantime, you can:
+## Code structure
 
-1. Check out the [main readme](https://github.com/netlify/netlify-cms/#readme) or the [documentation
-   site](https://www.netlifycms.org) for more info.
-2. Reach out to the [community chat](https://netlifycms.org/chat/) if you need help.
-3. Help out and [write the readme yourself](https://github.com/netlify/netlify-cms/edit/master/packages/netlify-cms-lib-util/README.md)!
+This structure should be the same for backends.
 
-## Domain-specific file manager
+At first, look at `Implementation`. This is File Management System API and has factory method for `AuthComponent`.
 
-Known as `Implementation` - abstract type for all `Backend` in `netlify-cms-backend-*`. It is a set of high-level methods for managing the Repository and Media files.
+### File Management System API
+
+An abstraction layer between the CMS and Git-repository manager API.
+
+Used as backend in [cms-core](https://github.com/netlify/netlify-cms/tree/master/packages/netlify-cms-core/README.md).
+
+### Low-level abstractions for Git-repository manager API:
+
+- `API` - used for Entry files
+- `git-lfs` - used for Media files
+- and over halpful utilities
+

--- a/packages/netlify-cms-lib-util/README.md
+++ b/packages/netlify-cms-lib-util/README.md
@@ -9,3 +9,7 @@ In the meantime, you can:
    site](https://www.netlifycms.org) for more info.
 2. Reach out to the [community chat](https://netlifycms.org/chat/) if you need help.
 3. Help out and [write the readme yourself](https://github.com/netlify/netlify-cms/edit/master/packages/netlify-cms-lib-util/README.md)!
+
+## Domain-specific file manager
+
+Known as `Implementation` - abstract type for all `Backend` in `netlify-cms-backend-*`. It is a set of high-level methods for managing the Repository and Media files.


### PR DESCRIPTION
**Summary**

Added short readme. It's better than nothing. Now these packages are of no value in and of themselves, so I think the "quick look at the code" format is appropriate.

**Test plan**

I dont know)

**A picture of a cute animal**
![sad dog](https://poncy.ru/media/uploads/dict/d/r/drupi6.jpg)