### PR TITLE
fix(markdown-widget): support arbitrary component order

### DIFF
--- a/packages/netlify-cms-widget-markdown/src/MarkdownControl/index.js
+++ b/packages/netlify-cms-widget-markdown/src/MarkdownControl/index.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import ImmutablePropTypes from 'react-immutable-proptypes';
 import RawEditor from './RawEditor';
 import VisualEditor from './VisualEditor';
-import { List } from 'immutable';
+import { List, Map } from 'immutable';
 
 const MODE_STORAGE_KEY = 'cms.md-mode';
 
@@ -11,7 +11,7 @@ const MODE_STORAGE_KEY = 'cms.md-mode';
 // be handled through Redux and a separate registry store for instances
 let editorControl;
 // eslint-disable-next-line func-style
-let _getEditorComponents = () => [];
+let _getEditorComponents = () => Map();
 
 export function getEditorControl() {
   return editorControl;

--- a/packages/netlify-cms-widget-markdown/src/serializers/__tests__/remarkShortcodes.spec.js
+++ b/packages/netlify-cms-widget-markdown/src/serializers/__tests__/remarkShortcodes.spec.js
@@ -1,3 +1,4 @@
+import { Map, OrderedMap } from 'immutable';
 import { remarkParseShortcodes } from '../remarkShortcodes';
 
 // Stub of Remark Parser
@@ -22,25 +23,37 @@ describe('remarkParseShortcodes', () => {
   describe('pattern matching', () => {
     it('should work', () => {
       const editorComponent = EditorComponent({ pattern: /bar/ });
-      process('foo bar', [editorComponent]);
+      process('foo bar', Map([[editorComponent.id, editorComponent]]));
       expect(editorComponent.fromBlock).toHaveBeenCalledWith(expect.arrayContaining(['bar']));
     });
     it('should match value surrounded in newlines', () => {
       const editorComponent = EditorComponent({ pattern: /^bar$/ });
-      process('foo\n\nbar\n', [editorComponent]);
+      process('foo\n\nbar\n', Map([[editorComponent.id, editorComponent]]));
       expect(editorComponent.fromBlock).toHaveBeenCalledWith(expect.arrayContaining(['bar']));
     });
     it('should match multiline shortcodes', () => {
       const editorComponent = EditorComponent({ pattern: /^foo\nbar$/ });
-      process('foo\nbar', [editorComponent]);
+      process('foo\nbar', Map([[editorComponent.id, editorComponent]]));
       expect(editorComponent.fromBlock).toHaveBeenCalledWith(expect.arrayContaining(['foo\nbar']));
     });
     it('should match multiline shortcodes with empty lines', () => {
       const editorComponent = EditorComponent({ pattern: /^foo\n\nbar$/ });
-      process('foo\n\nbar', [editorComponent]);
+      process('foo\n\nbar', Map([[editorComponent.id, editorComponent]]));
       expect(editorComponent.fromBlock).toHaveBeenCalledWith(
         expect.arrayContaining(['foo\n\nbar']),
       );
+    });
+    it('should match out-of-order shortcodes', () => {
+      const fooEditorComponent = EditorComponent({ id: 'foo', pattern: /foo/ });
+      const barEditorComponent = EditorComponent({ id: 'bar', pattern: /bar/ });
+      process(
+        'foo\n\nbar',
+        OrderedMap([
+          [barEditorComponent.id, barEditorComponent],
+          [fooEditorComponent.id, fooEditorComponent],
+        ]),
+      );
+      expect(fooEditorComponent.fromBlock).toHaveBeenCalledWith(expect.arrayContaining(['foo']));
     });
   });
   describe('output', () => {
@@ -49,7 +62,7 @@ describe('remarkParseShortcodes', () => {
       const shortcodeData = { bar: 'baz' };
       const expectedNode = { type: 'shortcode', data: { shortcode: 'foo', shortcodeData } };
       const editorComponent = EditorComponent({ pattern: /bar/, fromBlock: () => shortcodeData });
-      process('foo bar', [editorComponent], processEat);
+      process('foo bar', Map([[editorComponent.id, editorComponent]]), processEat);
       expect(processEat).toHaveBeenCalledWith(expectedNode);
     });
   });

--- a/packages/netlify-cms-widget-markdown/src/serializers/remarkShortcodes.js
+++ b/packages/netlify-cms-widget-markdown/src/serializers/remarkShortcodes.js
@@ -10,17 +10,16 @@ export function remarkParseShortcodes({ plugins }) {
 
 function createShortcodeTokenizer({ plugins }) {
   return function tokenizeShortcode(eat, value, silent) {
-    let match;
-    const potentialMatchValue = value.split('\n\n')[0].trimEnd();
-    const plugin = plugins.find(plugin => {
-      match = value.match(plugin.pattern);
+    const matches = plugins
+      .toList()
+      .map(plugin => ({
+        match: value.match(plugin.pattern),
+        plugin,
+      }))
+      .filter(({ match }) => !!match)
+      .sort((a, b) => a.match.index - b.match.index);
 
-      if (!match) {
-        match = potentialMatchValue.match(plugin.pattern);
-      }
-
-      return !!match;
-    });
+    const { plugin, match } = matches.get(0) ?? {};
 
     if (match) {
       if (silent) {


### PR DESCRIPTION
Fixes #5258

<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines.

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first two fields are mandatory:
-->

## Summary
Updates `remarkShortcodes` to handle custom editor components occurring in
any order in a given markdown field.

Previously, `remarkShortcodes` (the remark tokenizer plugin in the markdown widget) was relying on [`Map.find`](https://github.com/netlify/netlify-cms/blob/master/packages/netlify-cms-widget-markdown/src/serializers/remarkShortcodes.js#L15-L23) to attempt to match the registered editor components' patterns against the remaining uneaten markdown. Because Map.find returns after the first instance that returns true, some valid shortcode matches can be "skipped" by the plugin, and parsed as plain text instead.

This made it almost impossible to use multiple shortcodes in a single markdown field. At least one of them regularly gets "skipped" by the tokenizer.

This also updates the initial value returned by `getEditorComponents()` to correctly be an instance of `Map`, instead of an empty array.

## Test plan

### Unit Tests

I've updated the unit tests in the following ways:

1. I'm now passing an instance of `Map` as the second argument to `process`, instead of an array, because [that's what is actually passed in the code](https://github.com/netlify/netlify-cms/blob/master/packages/netlify-cms-core/src/lib/registry.js#L27)
2. I've added a new unit test that covers this case, relying on an `OrderedMap` to force a specific coincidental state that would have triggered the bug in the previous code (I verified that this new test does in fact fail under the previous code)

### Manual Inspection

I built this package locally and linked it into the project that I first identified this bug in, and verified that it resolved this issue and that I could not identify any new issues:

Before:
<img width="733" alt="image" src="https://user-images.githubusercontent.com/5354254/114488019-93d22580-9bde-11eb-911e-21028ea78605.png">

After:
<img width="735" alt="image" src="https://user-images.githubusercontent.com/5354254/114487471-a7c95780-9bdd-11eb-93de-b54a7ae8c504.png">

## A picture of a cute animal (not mandatory but encouraged)

Some very tired dogs, as tribute:

![63794410038__8567FE98-D096-4B00-A216-F180FCFCD1F7](https://user-images.githubusercontent.com/5354254/114489204-bd8c4c00-9be0-11eb-996b-572b1ab058ee.jpg)

