### PR TITLE
WIP: feat(open-authoring): add single_branch_per_collection

### DIFF
--- a/packages/netlify-cms-backend-github/src/API.ts
+++ b/packages/netlify-cms-backend-github/src/API.ts
@@ -369,7 +369,6 @@ export default class API {
     }
 
     const { collection } = this.parseContentKey(contentKey);
-
     return `${CMS_BRANCH_PREFIX}/${collection}`;
   }
 

--- a/packages/netlify-cms-backend-github/src/API.ts
+++ b/packages/netlify-cms-backend-github/src/API.ts
@@ -372,7 +372,7 @@ export default class API {
 
     return `${CMS_BRANCH_PREFIX}/${collection}`;
   }
-  
+
   checkMetadataRef() {
     return this.request(`${this.repoURL}/git/refs/meta/_netlify_cms`)
       .then(response => response.object)

--- a/packages/netlify-cms-backend-github/src/implementation.tsx
+++ b/packages/netlify-cms-backend-github/src/implementation.tsx
@@ -68,6 +68,7 @@ export default class GitHub implements Implementation {
   openAuthoringEnabled: boolean;
   useOpenAuthoring?: boolean;
   alwaysForkEnabled: boolean;
+  singleBranchPerCollection: boolean;
   branch: string;
   apiRoot: string;
   mediaFolder: string;
@@ -111,6 +112,7 @@ export default class GitHub implements Implementation {
       this.repo = this.originRepo = config.backend.repo || '';
     }
     this.alwaysForkEnabled = config.backend.always_fork || false;
+    this.singleBranchPerCollection = config.backend.single_branch_per_collection || false;
     this.branch = config.backend.branch?.trim() || 'master';
     this.apiRoot = config.backend.api_root || 'https://api.github.com';
     this.token = '';
@@ -305,6 +307,7 @@ export default class GitHub implements Implementation {
       squashMerges: this.squashMerges,
       cmsLabelPrefix: this.cmsLabelPrefix,
       useOpenAuthoring: this.useOpenAuthoring,
+      singleBranchPerCollection: this.singleBranchPerCollection,
       initialWorkflowStatus: this.options.initialWorkflowStatus,
     });
     const user = await this.api!.user();

--- a/packages/netlify-cms-backend-github/src/implementation.tsx
+++ b/packages/netlify-cms-backend-github/src/implementation.tsx
@@ -610,7 +610,7 @@ export default class GitHub implements Implementation {
 
   getBranch(collection: string, slug: string) {
     const contentKey = this.api!.generateContentKey(collection, slug);
-    const branch = branchFromContentKey(contentKey);
+    const branch = this.api!.branchFromContentKey(contentKey);
     return branch;
   }
 

--- a/packages/netlify-cms-lib-util/src/implementation.ts
+++ b/packages/netlify-cms-lib-util/src/implementation.ts
@@ -94,6 +94,7 @@ export type Config = {
     repo?: string | null;
     open_authoring?: boolean;
     always_fork?: boolean;
+    single_branch_per_collection?: boolean;
     branch?: string;
     api_root?: string;
     squash_merges?: boolean;


### PR DESCRIPTION
**Summary**

This add support for using single branch per collection in open-authoring flows, vs. a branch per entry which is the default. The idea is that for open-authoring flows a public user would make a number of changes all together and they can be reviewed all at once in a single PR.

**Test plan**
yarn test:e2e
