### PR TITLE
Fixing an issue with public_folder not working with absolute urls

### DIFF
--- a/packages/netlify-cms-core/package.json
+++ b/packages/netlify-cms-core/package.json
@@ -68,6 +68,7 @@
     "semaphore": "^1.0.5",
     "tomlify-j0.4": "^3.0.0-alpha.0",
     "url": "^0.11.0",
+    "url-join": "^4.0.1",
     "what-input": "^5.1.4",
     "yaml": "^1.8.3"
   },
@@ -90,6 +91,7 @@
   "devDependencies": {
     "@types/history": "^4.7.8",
     "@types/redux-mock-store": "^1.0.2",
+    "@types/url-join": "^4.0.0",
     "redux-mock-store": "^1.5.3"
   }
 }

--- a/packages/netlify-cms-core/src/lib/urlHelper.ts
+++ b/packages/netlify-cms-core/src/lib/urlHelper.ts
@@ -118,5 +118,5 @@ export function sanitizeSlug(str: string, options?: CmsSlug) {
 }
 
 export function joinUrlPath(base: string, ...path: string[]) {
-  return urlJoin(base, ...path)
+  return urlJoin(base, ...path);
 }

--- a/packages/netlify-cms-core/src/lib/urlHelper.ts
+++ b/packages/netlify-cms-core/src/lib/urlHelper.ts
@@ -1,4 +1,5 @@
 import url from 'url';
+import urlJoin from 'url-join';
 import diacritics from 'diacritics';
 import sanitizeFilename from 'sanitize-filename';
 import { isString, escapeRegExp, flow, partialRight } from 'lodash';
@@ -114,4 +115,8 @@ export function sanitizeSlug(str: string, options?: CmsSlug) {
     .replace(trailingReplacement, '');
 
   return normalizedSlug;
+}
+
+export function joinUrlPath(base: string, ...path: string[]) {
+  return urlJoin(base, ...path)
 }

--- a/packages/netlify-cms-core/src/reducers/__tests__/entries.spec.js
+++ b/packages/netlify-cms-core/src/reducers/__tests__/entries.spec.js
@@ -439,7 +439,11 @@ describe('entries', () => {
       expect(
         selectMediaFilePublicPath(
           { public_folder: 'https://www.netlify.com/media' },
-          fromJS({ name: 'posts', folder: 'posts', public_folder: 'https://www.netlify.com/media' }),
+          fromJS({
+            name: 'posts',
+            folder: 'posts',
+            public_folder: 'https://www.netlify.com/media',
+          }),
           'image.png',
           undefined,
           undefined,

--- a/packages/netlify-cms-core/src/reducers/__tests__/entries.spec.js
+++ b/packages/netlify-cms-core/src/reducers/__tests__/entries.spec.js
@@ -435,6 +435,18 @@ describe('entries', () => {
       ).toBe('../../static/media/image.png');
     });
 
+    it('should handle absolute public_folder', () => {
+      expect(
+        selectMediaFilePublicPath(
+          { public_folder: 'https://www.netlify.com/media' },
+          fromJS({ name: 'posts', folder: 'posts', public_folder: 'https://www.netlify.com/media' }),
+          'image.png',
+          undefined,
+          undefined,
+        ),
+      ).toBe('https://www.netlify.com/media/image.png');
+    });
+
     it('should compile collection public folder template', () => {
       const slugConfig = {
         encoding: 'unicode',

--- a/packages/netlify-cms-core/src/reducers/entries.ts
+++ b/packages/netlify-cms-core/src/reducers/entries.ts
@@ -59,6 +59,7 @@ import { trim, once, sortBy, set, orderBy, groupBy } from 'lodash';
 import { selectSortDataPath } from './collections';
 import { stringTemplate } from 'netlify-cms-lib-widgets';
 import { VIEW_STYLE_LIST } from '../constants/collectionViews';
+import { joinUrlPath } from '../lib/urlHelper';
 
 const { keyToPathArray } = stringTemplate;
 
@@ -788,6 +789,10 @@ export function selectMediaFilePublicPath(
 
   if (customFolder) {
     publicFolder = evaluateFolder(name, config, collection!, entryMap, field);
+  }
+
+  if (isAbsolutePath(publicFolder)) {
+    return joinUrlPath(publicFolder, basename(mediaPath));
   }
 
   return join(publicFolder, basename(mediaPath));

--- a/website/content/docs/configuration-options.md
+++ b/website/content/docs/configuration-options.md
@@ -73,6 +73,8 @@ public_folder: "/images/uploads"
 
 Based on the settings above, if a user used an image widget field called `avatar` to upload and select an image called `philosoraptor.png`, the image would be saved to the repository at `/static/images/uploads/philosoraptor.png`, and the `avatar` field for the file would be set to `/images/uploads/philosoraptor.png`.
 
+This setting can be set to an absolute url e.g. `https://netlify.com/media` should you wish, however in general this is not advisable as content should have relative paths to other content.
+
 ## Media Library
 
 Media library integrations are configured via the `media_library` property, and its value should be an object with at least a `name` property. A `config` property can also be used for options that should be passed to the library in use.

--- a/website/content/docs/configuration-options.md
+++ b/website/content/docs/configuration-options.md
@@ -73,7 +73,7 @@ public_folder: "/images/uploads"
 
 Based on the settings above, if a user used an image widget field called `avatar` to upload and select an image called `philosoraptor.png`, the image would be saved to the repository at `/static/images/uploads/philosoraptor.png`, and the `avatar` field for the file would be set to `/images/uploads/philosoraptor.png`.
 
-This setting can be set to an absolute url e.g. `https://netlify.com/media` should you wish, however in general this is not advisable as content should have relative paths to other content.
+This setting can be set to an absolute URL e.g. `https://netlify.com/media` should you wish, however in general this is not advisable as content should have relative paths to other content.
 
 ## Media Library
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3688,6 +3688,11 @@
   resolved "https://registry.yarnpkg.com/@types/unist/-/unist-2.0.3.tgz#9c088679876f374eb5983f150d4787aa6fb32d7e"
   integrity sha512-FvUupuM3rlRsRtCN+fDudtmytGO6iHJuuRKS1Ss0pG5z8oX0diNEw94UEL7hgDbpN94rgaK5R7sWm6RrSkZuAQ==
 
+"@types/url-join@^4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/@types/url-join/-/url-join-4.0.0.tgz#72eff71648a429c7d4acf94e03780e06671369bd"
+  integrity sha512-awrJu8yML4E/xTwr2EMatC+HBnHGoDxc2+ImA9QyeUELI1S7dOCIZcyjki1rkwoA8P2D2NVgLAJLjnclkdLtAw==
+
 "@types/uuid@^3.4.6":
   version "3.4.9"
   resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-3.4.9.tgz#fcf01997bbc9f7c09ae5f91383af076d466594e1"
@@ -18366,6 +18371,11 @@ url-join@^2.0.5:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/url-join/-/url-join-2.0.5.tgz#5af22f18c052a000a48d7b82c5e9c2e2feeda728"
   integrity sha1-WvIvGMBSoACkjXuCxenC4v7tpyg=
+
+url-join@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/url-join/-/url-join-4.0.1.tgz#b642e21a2646808ffa178c4c5fda39844e12cde7"
+  integrity sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA==
 
 url-loader@^2.0.1:
   version "2.3.0"


### PR DESCRIPTION
**Summary**

I am trying to use absolute urls in the `public_folder` config for my CMS use case. Essentailly this is because the CMS sits as a standalone CDN for other applications and I wished to make the media uploads accessible from the CDN with absolute urls present all files editable in the CMS.

There is a rather old issue where someone requests this functionality #1668

However clearly in between this issue being created and now this no longer works. What happens when you have an absolute path in the `public_folder` is the second slash at the start of the url is stripped.

``` yaml
public_folder: https://netify.com/images
```

Currently produces: `https:/netlify.com/images/image.png` (note the missing second slash after `https`)
With this PR produces: `https://netlify.com/images/image.png`

The reason for this is that the package `path` is not meant for concatenating URLs and malforms them. I have added `url-join` to support concatenating URLs where appropriate.

I have made a change to the public path function for the media library. When `public_folder` is an absolute url it will do a `url-join` join rather than a `path` join.

Also added a little note in the docs to suggest that this is possible but caveated with the fact that in a typical situations this is a bad idea.

**Test plan**

I have written a new unit test for having a `public_folder` as an absolute URL and as the change checks if the url is absolute before changing how it functions all current unit tests pass.
