### PR TITLE
fix: Remove `Unpublish` UI button if  collection has a `delete: false`. (#3887)

### DIFF
--- a/packages/netlify-cms-core/src/components/Editor/EditorToolbar.js
+++ b/packages/netlify-cms-core/src/components/Editor/EditorToolbar.js
@@ -393,7 +393,7 @@ class EditorToolbar extends React.Component {
           </PublishedToolbarButton>
         )}
       >
-        {(canDelete && canPublish) && (
+        {canDelete && canPublish && (
           <DropdownItem
             label={t('editor.editorToolbar.unpublish')}
             icon="arrow"
@@ -537,7 +537,7 @@ class EditorToolbar extends React.Component {
 
     const canCreate = collection.get('create');
     const canPublish = collection.get('publish') && !useOpenAuthoring;
-    const canDelete = collection.get('delete',  true)
+    const canDelete = collection.get('delete', true);
 
     if (currentStatus) {
       return (

--- a/packages/netlify-cms-core/src/components/Editor/EditorToolbar.js
+++ b/packages/netlify-cms-core/src/components/Editor/EditorToolbar.js
@@ -378,7 +378,7 @@ class EditorToolbar extends React.Component {
     );
   };
 
-  renderExistingEntryWorkflowPublishControls = ({ canCreate, canPublish }) => {
+  renderExistingEntryWorkflowPublishControls = ({ canCreate, canPublish, canDelete }) => {
     const { unPublish, onDuplicate, isPersisting, t } = this.props;
 
     return canPublish || canCreate ? (
@@ -393,7 +393,7 @@ class EditorToolbar extends React.Component {
           </PublishedToolbarButton>
         )}
       >
-        {canPublish && (
+        {(canDelete && canPublish) && (
           <DropdownItem
             label={t('editor.editorToolbar.unpublish')}
             icon="arrow"
@@ -537,6 +537,7 @@ class EditorToolbar extends React.Component {
 
     const canCreate = collection.get('create');
     const canPublish = collection.get('publish') && !useOpenAuthoring;
+    const canDelete = collection.get('delete',  true)
 
     if (currentStatus) {
       return (
@@ -555,7 +556,7 @@ class EditorToolbar extends React.Component {
       return (
         <>
           {this.renderDeployPreviewControls(t('editor.editorToolbar.deployButtonLabel'))}
-          {this.renderExistingEntryWorkflowPublishControls({ canCreate, canPublish })}
+          {this.renderExistingEntryWorkflowPublishControls({ canCreate, canPublish, canDelete })}
         </>
       );
     }


### PR DESCRIPTION
Closes #3887 

<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines.

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first two fields are mandatory:
-->

**Summary**
This PR aims to hide the `unpublish` button in the UI when a collection has a `delete: false` flag, Since netlify prevents the `unpublish` action in the backend when `!delete` then it's a good idea to hide the button from the UI in the first place.

Before: 
![Screen Shot 2021-04-28 at 12 49 32](https://user-images.githubusercontent.com/59185227/116406463-382fab00-a820-11eb-90d7-35a134caab6f.png)

After:
![Screen Shot 2021-04-28 at 12 50 02](https://user-images.githubusercontent.com/59185227/116406526-48478a80-a820-11eb-956c-8556023e2743.png)


<!--
Explain the **motivation** for making this change.
What existing problem does the pull request solve?
-->

**Test plan**
I couldn't find a way to test this.
<!--
Demonstrate the code is solid.
Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.
-->

**A picture of a cute animal (not mandatory but encouraged)**
![image](https://user-images.githubusercontent.com/59185227/116406898-affdd580-a820-11eb-818b-a62f465e1878.png)
