### PR TITLE
feat: add instruction for authenticating Netlify CMS users

### DIFF
--- a/website/content/docs/jekyll.md
+++ b/website/content/docs/jekyll.md
@@ -63,31 +63,7 @@ collections:
 
 Netlify CMS stores content in your online Git repository. Therefore, to make content changes, users need to authenticate with the corresponding Git provider to prove that they have read and write access to that content.
 
-Apps deployed with Netlify can leverage the following two authentication services: Netlify Identity and Git Gateway.
-
-Netlify Identity allows us to manage and authenticate users on the Netlify CMS app without requiring them to be users of Netlify or any other serivce. Git Gateway lets them edit our site conten through Netlify CMS without having accounts on GitHub or GitLab. Our content editors won't even know that they are pushing changes to a Github repository.
-
-1. Visit your Netlify dashboard. Select the site and navigate to **Site Settings > Identity** and select **Enable Identity service**.
-2. Under **Registration preferences**, select either **Open** or **Invite only**. For the purpose of this tutorial, leave it open for convenience.
-3. If you like to allow a one-click login process through a third-party services like Google, Github etc, choose the services you'd like to use under **External providers**.
-4. Scroll down to **Services > Git Gateway** and click **Enable Git Gateway**. Leave everything else as default.
-
-### Add Netlify Identity widget
-
-In the `admin/index.html`, add the script for loading the Netlify Identity widget inside the `<head>` tag. This widget requires visitors to the `/admin` route to log in or sign up before they can access Netlify CMS.
-
-```
-<!DOCTYPE html>
-<html>
-  <head>
-    <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Content Manager</title>
-    <script src="https://identity.netlify.com/v1/netlify-identity-widget.js"></script>
-  </head>
-  <!-- -->
-</html>
-```
+Follow the directions in the Introduction section to [enable Netlify Identity and Git Gateway services](https://www.netlifycms.org/docs/add-to-your-site/#enable-identity-and-git-gateway) for the backend, then [add the Identity widget](https://www.netlifycms.org/docs/add-to-your-site/#add-the-netlify-identity-widget) to render a login portal on the frontend.
 
 ## CMS Configuration
 

--- a/website/content/docs/jekyll.md
+++ b/website/content/docs/jekyll.md
@@ -3,6 +3,7 @@ group: Guides
 weight: 30
 title: Jekyll
 ---
+
 ## Introduction
 
 This section will help you integrate Netlify CMS with a new or existing Jekyll project.
@@ -60,7 +61,11 @@ collections:
 
 ### Enable authentication for CMS users
 
-We are going to use the following two services to manage our Netlify CMS users: Netlify Identity and Git Gateway. Netlify Identity allows us to manage and authenticate users on the Netlify CMS app without requiring them to be users of Netlify or any other serivce. Git Gateway lets them edit our site conten through Netlify CMS without having accounts on GitHub or GitLab. Our content editors won't even know that they are pushing changes to a Github repository.
+Netlify CMS stores content in your online Git repository. Therefore, to make content changes, users need to authenticate with the corresponding Git provider to prove that they have read and write access to that content.
+
+Apps deployed with Netlify can leverage the following two authentication services: Netlify Identity and Git Gateway.
+
+Netlify Identity allows us to manage and authenticate users on the Netlify CMS app without requiring them to be users of Netlify or any other serivce. Git Gateway lets them edit our site conten through Netlify CMS without having accounts on GitHub or GitLab. Our content editors won't even know that they are pushing changes to a Github repository.
 
 1. Visit your Netlify dashboard. Select the site and navigate to **Site Settings > Identity** and select **Enable Identity service**.
 2. Under **Registration preferences**, select either **Open** or **Invite only**. For the purpose of this tutorial, leave it open for convenience.
@@ -108,14 +113,14 @@ collections:
 
 A few things to note.
 
-* We set the `slug` to `'{{year}}-{{month}}-{{day}}-{{slug}}'` because [Jekyll requires this format for blog posts](https://jekyllrb.com/docs/posts/#creating-posts). `year`, `month`, and `day` will be extracted from the `date` field, and `slug` will be generated from the `title` field.
-* We added `editor` configuration with a field `preview: false`. This will eliminate the preview pane. Because Jekyll uses Liquid templates, there currently isn't a good way to provide a preview of pages as you update the content.
-* The `layout` field default is set to `post` so Jekyll knows to use `_layouts/post.html` when it renders a post. This field is hidden because we want all posts to use the same layout.
-* The `date` and `title` field will be used by the `slug` - as noted above, Jekyll relies on the filename to determine a post's publish date, but Netlify CMS does not pull date information from the filename and requires a frontmatter `date` field. **Note** Changing the `date` or `title` fields in Netlify CMS will not update the filename. This has a few implications:
+- We set the `slug` to `'{{year}}-{{month}}-{{day}}-{{slug}}'` because [Jekyll requires this format for blog posts](https://jekyllrb.com/docs/posts/#creating-posts). `year`, `month`, and `day` will be extracted from the `date` field, and `slug` will be generated from the `title` field.
+- We added `editor` configuration with a field `preview: false`. This will eliminate the preview pane. Because Jekyll uses Liquid templates, there currently isn't a good way to provide a preview of pages as you update the content.
+- The `layout` field default is set to `post` so Jekyll knows to use `_layouts/post.html` when it renders a post. This field is hidden because we want all posts to use the same layout.
+- The `date` and `title` field will be used by the `slug` - as noted above, Jekyll relies on the filename to determine a post's publish date, but Netlify CMS does not pull date information from the filename and requires a frontmatter `date` field. **Note** Changing the `date` or `title` fields in Netlify CMS will not update the filename. This has a few implications:
 
-  * If you change the `date` or `title` fields in Netlify CMS, Jekyll won't notice
-  * You don't necessarily need to change the `date` and `title` fields for existing posts, but if you don't the filenames and frontmatter will disagree in a way that might be confusing
-  * If you want to avoid these issues, use a regular Jekyll collection instead of the special `_posts` directory
+  - If you change the `date` or `title` fields in Netlify CMS, Jekyll won't notice
+  - You don't necessarily need to change the `date` and `title` fields for existing posts, but if you don't the filenames and frontmatter will disagree in a way that might be confusing
+  - If you want to avoid these issues, use a regular Jekyll collection instead of the special `_posts` directory
 
 ### Author Collection
 
@@ -148,8 +153,8 @@ then update `_layouts/author.html`, `_layouts/post.html` and `staff.html` accord
 
 <h2>Posts</h2>
 <ul>
-  {% assign filtered_posts = site.posts | where: 'author', page.name %} {% for
-  post in filtered_posts %}
+  {% assign filtered_posts = site.posts | where: 'author', page.name %} {% for post in
+  filtered_posts %}
   <li>
     <a href="{{ site.baseurl }}{{ post.url }}">{{ post.title }}</a>
   </li>
@@ -164,10 +169,8 @@ then update `_layouts/author.html`, `_layouts/post.html` and `staff.html` accord
 <h1>{{ page.title }}</h1>
 
 <p>
-  {{ page.date | date_to_string }}
-  {% assign author = site.authors | where: 'name', page.author | first %}
-  {% if author %}
-    - <a href="{{ author.url }}">{{ author.display_name }}</a>
+  {{ page.date | date_to_string }} {% assign author = site.authors | where: 'name', page.author |
+  first %} {% if author %} - <a href="{{ author.url }}">{{ author.display_name }}</a>
   {% endif %}
 </p>
 
@@ -299,21 +302,21 @@ You'll need to update `_includes/navigation.html` accordingly. `{% for item in s
 Finally, add the following to the collections array in `config.yml`
 
 ```yaml
-- name: "config"
-  label: "Config"
+- name: 'config'
+  label: 'Config'
   editor:
     preview: false
   files:
-    - label: "Navigation"
-      name: "navigation"
-      file: "_data/navigation.yml"
+    - label: 'Navigation'
+      name: 'navigation'
+      file: '_data/navigation.yml'
       fields:
-        - label: "Navigation Items"
-          name: "items"
-          widget: "list"
+        - label: 'Navigation Items'
+          name: 'items'
+          widget: 'list'
           fields:
-            - {label: Name, name: name, widget: string}
-            - {label: Link, name: link, widget: string}
+            - { label: Name, name: name, widget: string }
+            - { label: Link, name: link, widget: string }
 ```
 
 Now you can add, rename, and rearrange the navigation items on your blog.

--- a/website/content/docs/jekyll.md
+++ b/website/content/docs/jekyll.md
@@ -58,9 +58,31 @@ collections:
       - { name: Title }
 ```
 
-### Setup Backend
+### Enable authentication for CMS users
 
-Follow the directions in the docs [to enable Identity and Git Gateway](https://www.netlifycms.org/docs/add-to-your-site/#enable-identity-and-git-gateway) then add the [Identity Widget](https://www.netlifycms.org/docs/add-to-your-site/#add-the-netlify-identity-widget)
+We are going to use the following two services to manage our Netlify CMS users: Netlify Identity and Git Gateway. Netlify Identity allows us to manage and authenticate users on the Netlify CMS app without requiring them to be users of Netlify or any other serivce. Git Gateway lets them edit our site conten through Netlify CMS without having accounts on GitHub or GitLab. Our content editors won't even know that they are pushing changes to a Github repository.
+
+1. Visit your Netlify dashboard. Select the site and navigate to **Site Settings > Identity** and select **Enable Identity service**.
+2. Under **Registration preferences**, select either **Open** or **Invite only**. For the purpose of this tutorial, leave it open for convenience.
+3. If you like to allow a one-click login process through a third-party services like Google, Github etc, choose the services you'd like to use under **External providers**.
+4. Scroll down to **Services > Git Gateway** and click **Enable Git Gateway**. Leave everything else as default.
+
+### Add Netlify Identity widget
+
+In the `admin/index.html`, add the script for loading the Netlify Identity widget inside the `<head>` tag. This widget requires visitors to the `/admin` route to log in or sign up before they can access Netlify CMS.
+
+```
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Content Manager</title>
+    <script src="https://identity.netlify.com/v1/netlify-identity-widget.js"></script>
+  </head>
+  <!-- -->
+</html>
+```
 
 ## CMS Configuration
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines.

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first two fields are mandatory:
-->

**Summary**
This pull request adds a section about enabling authentication for a Jekyll setup. The instruction contains two major steps:
- Enable Netlify Identity and Git Gateway on the backend.
- Add script to load the Netlify Identity widget at the `/admin` route.

## Motivation
A critical step of integrating Netlify CMS into an existing Jekyll site is authentication. The current doc tells users to visit the related Netlify documentation for instruction. However, it took me a while to wrap my head around Netlify Identity. 

Therefore, I like to help future readers get set up as quickly as possible by including the detailed step-by-step instruction for adding authentication functionality to their sites.
<!--
Explain the **motivation** for making this change.
What existing problem does the pull request solve?
-->