### PR TITLE
feat(docs): add overview for integrating Netlify CSS with site generators

### DIFF
--- a/website/content/docs/site-generator-overview.md
+++ b/website/content/docs/site-generator-overview.md
@@ -4,26 +4,24 @@ group: Guides
 weight: 1
 ---
 
-## Overview
-
 The process for adding Netlify CMS to a static site can be divided into four main steps:
 
 ### Install Netlify CMS
 
 This is a single page app available at the `/admin` route of your website.
-Check out the [general overview](https://www.netlifycms.org/docs/intro/) to see what the installation process entails.
+Check out the [general overview](/docs/intro/) to see what the installation process entails.
 
-### Set up the backend
+### Set up a backend
 
-This serves two purpose: Secure access to your website's Netlify CMS and allows it to read and update content files in your repo. More information about configuring the backend can be found [here](https://www.netlifycms.org/docs/backends-overview/).
+This serves two purpose: Secure access to your website's Netlify CMS and allows it to read and update content files in your repo. More information about configuring the backend can be found [here](/docs/backends-overview/).
 
-### Add configurations for Netlify CMS through a configuration file
+### Configure Netlify CMS using a configuration file
 
 For starters, you can get by with a basic configuration that includes required information like Git provider, branch and folders to save files to.
 
-Once you've gotten the hang of it, you can use the file to build whatever collections and content modeling you want. Check out the [Account Settings section](https://www.netlifycms.org/docs/configuration-options/#configuration-file) for full details about all the configuration options available.
+Once you've gotten the hang of it, you can use the file to build whatever collections and content modeling you want. Check out the [this section](/docs/configuration-options/#configuration-file) for full details about all available configuration options.
 
-### Render the content provided by Netlify CMS as web pages\*\*
+### Render the content provided by Netlify CMS as web pages
 
 Netlify CMS manages your content, and provides editorial and admin features, but it doesn't deliver content. It only makes your content available through an API.
 
@@ -31,6 +29,6 @@ It is up to developers to determine how to build the raw content into something 
 
 To learn how to query raw content managed by Netlify CMS and reformat them for delivery to end users, please refer the dedicated section for your site generator in the Table of Content.
 
-## Use Netlify CMS for local development
+### Local development
 
-If you are experimenting with Netlify CMS or testing things out, you can connect it to a local Git repository instead of a live one. Learn how to do it [here](https://www.netlifycms.org/docs/beta-features/#working-with-a-local-git-repository).
+If you are experimenting with Netlify CMS or testing things out, you can connect it to a local Git repository instead of a live one. Learn how to do it [here](/docs/beta-features/#working-with-a-local-git-repository).

--- a/website/content/docs/site-generator-overview.md
+++ b/website/content/docs/site-generator-overview.md
@@ -28,7 +28,7 @@ Netlify CMS manages your content, and provides editorial and admin features, but
 It is up to developers to determine how to build the raw content into something useful and delightful on the frontend.
 
 To learn how to query raw content managed by Netlify CMS and reformat them for delivery to end users, please refer the dedicated section for your site generator in the Table of Content.
-
+___
 ### Local development
 
 If you are experimenting with Netlify CMS or testing things out, you can connect it to a local Git repository instead of a live one. Learn how to do it [here](/docs/beta-features/#working-with-a-local-git-repository).

--- a/website/content/docs/site-generator-overview.md
+++ b/website/content/docs/site-generator-overview.md
@@ -71,3 +71,6 @@ It is up to developers to determine how to build the raw content into something 
 
 To learn how to query raw content managed by Netlify CMS and reformat them for delivery to end users, please refer the dedicated section for your site generator in the Table of Content.
 
+## Use Netlify CMS for local development
+
+If you are experimenting with Netlify CMS or testing things out, you can connect it to a local Git repository instead of a live one. Learn how to do it [here](https://www.netlifycms.org/docs/beta-features/#working-with-a-local-git-repository).

--- a/website/content/docs/site-generator-overview.md
+++ b/website/content/docs/site-generator-overview.md
@@ -63,6 +63,11 @@ These are only two of many things you need to inform Netlify CMS, and you do it 
 
 Once you've made your first post with Netlify CMS, head to your site repository and you'll find the latest commit containing the file with your post content.
 
-The integration process doesn't stop. Going back to your published site, you'll notice that even though you have a new file in your repository, it's not anywhere on your site. That's because Netlify CMS doesn't go beyond creating the raw content, which is one reason why it is able to work with many static site generator.
+But the integration process doesn't stop here. Going back to your published site, you'll notice that even though you have a new file in your repository, it's not anywhere on your site. That's because Netlify CMS doesn't go beyond creating the raw content, which is one reason why it is able to work with many static site generator.
 
-It is up to developers to determine how to build the raw content into something useful and delightful on the frontend. To learn how to process raw content from Netlify CMS, go to the section for your site generator in the Table of Content and follow its instructions.
+Netlify CMS manages your content, and provides editorial and admin features, but it doesn't deliver content. It only makes your content available through an API.
+
+It is up to developers to determine how to build the raw content into something useful and delightful on the frontend.
+
+To learn how to query raw content managed by Netlify CMS and reformat them for delivery to end users, please refer the dedicated section for your site generator in the Table of Content.
+

--- a/website/content/docs/site-generator-overview.md
+++ b/website/content/docs/site-generator-overview.md
@@ -4,40 +4,40 @@ group: Guides
 weight: 1
 ---
 
-A common pain point with static site generators is that they are hard to use for non-technical editors. Raw content is stored together with source codes in a Git repository. Making changes to the site content, therefore, requires users to go through a sequence of steps:
+A common pain point with static site generators is that they are hard to use for non-technical editors. Content and source code are stored together in the same Git repository. Making changes to the site content requires editors to go through a sequence of steps:
 
-- Navigate into the site repository
-- Creating or editing files for rendering site content, usually Markdown, JSON, YAML files.
-- Stage and commit changes to the local repository.
-- Push changes to the remote repository, which will trigger site build and deployment.
+1. Navigating to the site repository
+2. Creating or editing content files such as Markdown, JSON, YAML or TOML files
+3. Staging and committing changes to the local repository
+4. Pushing changes to the remote repository, which will trigger a site build and deployment
 
-Netlify CMS was created to fill this gap. You can integrate it into any site built with a common static site generators, including but not limited to Gatsby, Jekyll, Hugo. This allows non-technical editors to create and edit content through a solid user interface. They won't even know that they are pushing commits to a Git repository.
+Netlify CMS fills this gap. You can integrate it into any site built with a common static site generator, including but not limited to Gatsby, Hugo, Jekyll, Next.js, Nuxt.js, Middleman and Gridsome. This allows non-technical editors to create and edit content through a solid user interface, abstracting any Git related operations.
 
-The process for adding Netlify CMS to your site can vary depending on the site generator that was used. However, from a high level, it comprises of three main steps:
+The process for adding Netlify CMS to your site can vary between different generators. As a general approach, it has three main steps:
 
-- Install Netlify CMS as a frontend app at the `/admin` route of the your published site.
-- Setting up the backend to authenticate CMS users with the Git provider which stores your project.
-- Render the Netlify CMS output on the frontend.
+1. Adding Netlify CMS to your site under the `/admin` route of the published site
+2. Setting up a backend to authenticate CMS users with the Git provider that hosts your source code
+3. Rendering the Netlify CMS generated content as web pages
 
-## Installing Netlify CMS on the frontend
+## Adding Netlify CMS to your site
 
 The frontend of the app contains the following major components:
 
-- user authentication form
-- dashboard for managing content reserved for authenticated users only.
-- rich text editor built with [Slate](https://github.com/ianstormtaylor/slate) that also supports Markdown syntax.
+- A dashboard for managing content
+- A rich text editor built with [Slate](https://github.com/ianstormtaylor/slate) that supports Markdown syntax
+- A preview pane that renders the content while it's being edited
 
-Most site generators come with custom plugins that simplies the installation of the Netlify CMS app.
+Some site generators (e.g. Gatsby) come with plugins that simplify the installation of the Netlify CMS app.
 
 ## Authenticate CMS users with a backend
 
-Netlify CMS doesn't store your site content. Think of it as a middleman that allows your CMS users to make changes to your Git repository without having an account with Github, Gitlab etc.
+Netlify CMS doesn't store your site content. Think of it as a middleman that allows your CMS users to make changes to your Git repository without having an account with GitHub, GitLab etc.
 
-To achieve that, Netlify CMS needs to make sure that users have the write access to an online Git repository. This means the backend of the app is just Javascript codes that authenticates users with the Git provider which stores the site project.
+To achieve that, Netlify CMS needs to make sure that users have the write access to an online Git repository. This means the backend of the app is just JavaScript code that authenticates users with the Git provider which stores the site project.
 
-The authentication process requires a server and setting up a backend. You can write your own backend, or deploy your site to Netlify and get two authentication microservices that simplify this process: Netlify Identity and Git Gateway.
+The authentication process requires a server and setting up a backend. You can write your own backend, or deploy your site to Netlify and get two authentication micro-services that simplify this process: Netlify Identity and Git Gateway.
 
-It is also helpful to remember that Netlify CMS is meant to work in production. Every time the repoitory changes, whether in the source codes or raw content, the website is rebuilt and redeployed automatically.
+It is also helpful to remember that Netlify CMS works in production. Every time the repository changes, whether in the source codes or raw content, the website is rebuilt and redeployed automatically.
 
 For experimentation, you can run Netlify CMS locally, albeit with a catch. Each content edit through Netlify CMS results in a new commit to your remote repository. This means that you will need to pull changes from your remote each time to see them in the locally served site.
 
@@ -47,6 +47,6 @@ For more information, read the Authentication section in the [Add to Your Site p
 
 Once you've made your first post with Netlify CMS, head to your site repository and you'll find the latest commit containing the file with your post content.
 
-However, the integration process is not stopped here.Going back to your published site, you'll notice that even though you have a new file in your repository, it's not anywhere on your site. That's because Netlify CMS doesn't go beyond creating the raw content, which is one reason why it is able to work with many static site genetors.
+The integration process doesn't stop. Going back to your published site, you'll notice that even though you have a new file in your repository, it's not anywhere on your site. That's because Netlify CMS doesn't go beyond creating the raw content, which is one reason why it is able to work with many static site generator.
 
 It is up to developers to determine how to build the raw content into something useful and delightful on the frontend. To learn how to process raw content from Netlify CMS, go to the section for your site generator in the Table of Content and follow its instructions.

--- a/website/content/docs/site-generator-overview.md
+++ b/website/content/docs/site-generator-overview.md
@@ -13,11 +13,12 @@ A common pain point with static site generators is that they are hard to use for
 
 Netlify CMS fills this gap. You can integrate it into any site built with a common static site generator, including but not limited to Gatsby, Hugo, Jekyll, Next.js, Nuxt.js, Middleman and Gridsome. This allows non-technical editors to create and edit content through a solid user interface, abstracting any Git related operations.
 
-The process for adding Netlify CMS to your site can vary between different generators. As a general approach, it has three main steps:
+The process for adding Netlify CMS to your site can vary between different generators. As a general approach, it has four main steps:
 
-1. Adding Netlify CMS to your site under the `/admin` route of the published site
-2. Setting up a backend to authenticate CMS users with the Git provider that hosts your source code
-3. Rendering the Netlify CMS generated content as web pages
+1. Install Netlify CMS under the `/admin` route of your website
+2. Secure access to your website's Netlify CMS
+3. Add configurations for Netlify CMS
+4. Render the content provided by Netlify CMS as web pages
 
 ## Adding Netlify CMS to your site
 

--- a/website/content/docs/site-generator-overview.md
+++ b/website/content/docs/site-generator-overview.md
@@ -21,13 +21,19 @@ The process for adding Netlify CMS to your site can vary between different gener
 
 ## Adding Netlify CMS to your site
 
+Netlify CMS is a single page app installed at the `/admin` route of your static site. This means that all actions like authentication, creating, editing and saving posts happen on the `/admin` page powered by Javascript. The app doesn't need to reload during the usage and users can enjoy its fast responsiveness.
+
 The frontend of the app contains the following major components:
 
 - A dashboard for managing content
 - A rich text editor built with [Slate](https://github.com/ianstormtaylor/slate) that supports Markdown syntax
 - A preview pane that renders the content while it's being edited
 
-Some site generators (e.g. Gatsby) come with plugins that simplify the installation of the Netlify CMS app.
+Installing Netlify CMS on your website is straightforward. Some site generators like Gatsby and Gridsome come with custom plugins that simplies this process.
+
+Even if your generator doesn't, installation typically just requires an `index.html` file and a YAML configuration file. The index file contains two scripts: one loads Netlify CMS from a CDN and builds it, and the other enables Netlify Identity, an authentication service.
+
+For more information, please refer to the section for your static site generator in the table of content.
 
 ## Authenticate CMS users with a backend
 

--- a/website/content/docs/site-generator-overview.md
+++ b/website/content/docs/site-generator-overview.md
@@ -36,11 +36,20 @@ Even if your generator doesn't, installation typically just requires an `index.h
 
 For more information, please refer to the section for your static site generator in the table of content.
 
-## Authenticate CMS users with a backend
+## Secure access to Netlify CMS
 
-Netlify CMS doesn't store your site content. Think of it as a middleman that allows your CMS users to make changes to your Git repository without having an account with GitHub, GitLab etc.
+Since Netlify CMS is a frontend app, anyone can visit it at the `/admin` route of your published website. But not everyone should be able to access the admin interface and make changes to your site content.
 
-To achieve that, Netlify CMS needs to make sure that users have the write access to an online Git repository. This means the backend of the app is just JavaScript code that authenticates users with the Git provider which stores the site project.
+Preventing unauthorized access to your CMS is done through authentication, which requires setting up a backend.
+
+You can write your own backend, or deploy your site to Netlify and get two features that simplify this process:
+
+- [Netlify Identity](https://www.netlify.com/docs/identity/), an authentication service
+- [Git Gateway](https://www.netlifycms.org/docs/git-gateway-backend), an intermediary between the CMS and your Git repository. This means you can do things like having your users log into the CMS admin their accounts on popular social platforms instead of requiring them to have a Github account.
+
+Both projects are open source and you can host them yourselves.
+
+If you decide to use Netlify hosting, you can read more aobut how to enable Netlify Identity and Git Gateway [in this section](https://www.netlifycms.org/docs/add-to-your-site/#authentication/).
 
 The authentication process requires a server and setting up a backend. You can write your own backend, or deploy your site to Netlify and get two authentication micro-services that simplify this process: Netlify Identity and Git Gateway.
 

--- a/website/content/docs/site-generator-overview.md
+++ b/website/content/docs/site-generator-overview.md
@@ -51,13 +51,13 @@ Both projects are open source and you can host them yourselves.
 
 If you decide to use Netlify hosting, you can read more aobut how to enable Netlify Identity and Git Gateway [in this section](https://www.netlifycms.org/docs/add-to-your-site/#authentication/).
 
-The authentication process requires a server and setting up a backend. You can write your own backend, or deploy your site to Netlify and get two authentication micro-services that simplify this process: Netlify Identity and Git Gateway.
+## Add configurations for Netlify CMS
 
-It is also helpful to remember that Netlify CMS works in production. Every time the repository changes, whether in the source codes or raw content, the website is rebuilt and redeployed automatically.
+Although at this point you can log in, you can't do much yet! Netlify CMS only manages your content. It has no clue about the Git provider and repository it should use to save your content.
 
-For experimentation, you can run Netlify CMS locally, albeit with a catch. Each content edit through Netlify CMS results in a new commit to your remote repository. This means that you will need to pull changes from your remote each time to see them in the locally served site.
+Netlify CMS also doesn't know about the structure of various content types that your website is going to have, and the relationship between them.
 
-For more information, read the Authentication section in the [Add to Your Site page](https://www.netlifycms.org/docs/add-to-your-site/).
+These are only two of many things you need to inform Netlify CMS, and you do it through a special file at `config.yml`. A CMS is usually highly website-specific, and this file is where you can custom Netlify CMS to the liking of your developers and editors. You can learn how to specify configuration options for Netlify CMS [here](https://www.netlifycms.org/docs/configuration-options/#header).
 
 ## Render Netlify CMS output on the frontend
 

--- a/website/content/docs/site-generator-overview.md
+++ b/website/content/docs/site-generator-overview.md
@@ -4,66 +4,26 @@ group: Guides
 weight: 1
 ---
 
-A common pain point with static site generators is that they are hard to use for non-technical editors. Content and source code are stored together in the same Git repository. Making changes to the site content requires editors to go through a sequence of steps:
+## Overview
 
-1. Navigating to the site repository
-2. Creating or editing content files such as Markdown, JSON, YAML or TOML files
-3. Staging and committing changes to the local repository
-4. Pushing changes to the remote repository, which will trigger a site build and deployment
+The process for adding Netlify CMS to a static site can be divided into four main steps:
 
-Netlify CMS fills this gap. You can integrate it into any site built with a common static site generator, including but not limited to Gatsby, Hugo, Jekyll, Next.js, Nuxt.js, Middleman and Gridsome. This allows non-technical editors to create and edit content through a solid user interface, abstracting any Git related operations.
+### Install Netlify CMS
 
-The process for adding Netlify CMS to your site can vary between different generators. As a general approach, it has four main steps:
+This is a single page app available at the `/admin` route of your website.
+Check out the [general overview](https://www.netlifycms.org/docs/intro/) to see what the installation process entails.
 
-1. Install Netlify CMS under the `/admin` route of your website
-2. Secure access to your website's Netlify CMS
-3. Add configurations for Netlify CMS
-4. Render the content provided by Netlify CMS as web pages
+### Set up the backend
 
-## Adding Netlify CMS to your site
+This serves two purpose: Secure access to your website's Netlify CMS and allows it to read and update content files in your repo. More information about configuring the backend can be found [here](https://www.netlifycms.org/docs/backends-overview/).
 
-Netlify CMS is a single page app installed at the `/admin` route of your static site. This means that all actions like authentication, creating, editing and saving posts happen on the `/admin` page powered by Javascript. The app doesn't need to reload during the usage and users can enjoy its fast responsiveness.
+### Add configurations for Netlify CMS through a configuration file
 
-The frontend of the app contains the following major components:
+For starters, you can get by with a basic configuration that includes required information like Git provider, branch and folders to save files to.
 
-- A dashboard for managing content
-- A rich text editor built with [Slate](https://github.com/ianstormtaylor/slate) that supports Markdown syntax
-- A preview pane that renders the content while it's being edited
+Once you've gotten the hang of it, you can use the file to build whatever collections and content modeling you want. Check out the [Account Settings section](https://www.netlifycms.org/docs/configuration-options/#configuration-file) for full details about all the configuration options available.
 
-Installing Netlify CMS on your website is straightforward. Some site generators like Gatsby and Gridsome come with custom plugins that simplies this process.
-
-Even if your generator doesn't, installation typically just requires an `index.html` file and a YAML configuration file. The index file contains two scripts: one loads Netlify CMS from a CDN and builds it, and the other enables Netlify Identity, an authentication service.
-
-For more information, please refer to the section for your static site generator in the table of content.
-
-## Secure access to Netlify CMS
-
-Since Netlify CMS is a frontend app, anyone can visit it at the `/admin` route of your published website. But not everyone should be able to access the admin interface and make changes to your site content.
-
-Preventing unauthorized access to your CMS is done through authentication, which requires setting up a backend.
-
-You can write your own backend, or deploy your site to Netlify and get two features that simplify this process:
-
-- [Netlify Identity](https://www.netlify.com/docs/identity/), an authentication service
-- [Git Gateway](https://www.netlifycms.org/docs/git-gateway-backend), an intermediary between the CMS and your Git repository. This means you can do things like having your users log into the CMS admin their accounts on popular social platforms instead of requiring them to have a Github account.
-
-Both projects are open source and you can host them yourselves.
-
-If you decide to use Netlify hosting, you can read more aobut how to enable Netlify Identity and Git Gateway [in this section](https://www.netlifycms.org/docs/add-to-your-site/#authentication/).
-
-## Add configurations for Netlify CMS
-
-Although at this point you can log in, you can't do much yet! Netlify CMS only manages your content. It has no clue about the Git provider and repository it should use to save your content.
-
-Netlify CMS also doesn't know about the structure of various content types that your website is going to have, and the relationship between them.
-
-These are only two of many things you need to inform Netlify CMS, and you do it through a special file at `config.yml`. A CMS is usually highly website-specific, and this file is where you can custom Netlify CMS to the liking of your developers and editors. You can learn how to specify configuration options for Netlify CMS [here](https://www.netlifycms.org/docs/configuration-options/#header).
-
-## Render Netlify CMS output on the frontend
-
-Once you've made your first post with Netlify CMS, head to your site repository and you'll find the latest commit containing the file with your post content.
-
-But the integration process doesn't stop here. Going back to your published site, you'll notice that even though you have a new file in your repository, it's not anywhere on your site. That's because Netlify CMS doesn't go beyond creating the raw content, which is one reason why it is able to work with many static site generator.
+### Render the content provided by Netlify CMS as web pages\*\*
 
 Netlify CMS manages your content, and provides editorial and admin features, but it doesn't deliver content. It only makes your content available through an API.
 

--- a/website/content/docs/site-generator-overview.md
+++ b/website/content/docs/site-generator-overview.md
@@ -1,0 +1,52 @@
+---
+title: Overview
+group: Guides
+weight: 1
+---
+
+A common pain point with static site generators is that they are hard to use for non-technical editors. Raw content is stored together with source codes in a Git repository. Making changes to the site content, therefore, requires users to go through a sequence of steps:
+
+- Navigate into the site repository
+- Creating or editing files for rendering site content, usually Markdown, JSON, YAML files.
+- Stage and commit changes to the local repository.
+- Push changes to the remote repository, which will trigger site build and deployment.
+
+Netlify CMS was created to fill this gap. You can integrate it into any site built with a common static site generators, including but not limited to Gatsby, Jekyll, Hugo. This allows non-technical editors to create and edit content through a solid user interface. They won't even know that they are pushing commits to a Git repository.
+
+The process for adding Netlify CMS to your site can vary depending on the site generator that was used. However, from a high level, it comprises of three main steps:
+
+- Install Netlify CMS as a frontend app at the `/admin` route of the your published site.
+- Setting up the backend to authenticate CMS users with the Git provider which stores your project.
+- Render the Netlify CMS output on the frontend.
+
+## Installing Netlify CMS on the frontend
+
+The frontend of the app contains the following major components:
+
+- user authentication form
+- dashboard for managing content reserved for authenticated users only.
+- rich text editor built with [Slate](https://github.com/ianstormtaylor/slate) that also supports Markdown syntax.
+
+Most site generators come with custom plugins that simplies the installation of the Netlify CMS app.
+
+## Authenticate CMS users with a backend
+
+Netlify CMS doesn't store your site content. Think of it as a middleman that allows your CMS users to make changes to your Git repository without having an account with Github, Gitlab etc.
+
+To achieve that, Netlify CMS needs to make sure that users have the write access to an online Git repository. This means the backend of the app is just Javascript codes that authenticates users with the Git provider which stores the site project.
+
+The authentication process requires a server and setting up a backend. You can write your own backend, or deploy your site to Netlify and get two authentication microservices that simplify this process: Netlify Identity and Git Gateway.
+
+It is also helpful to remember that Netlify CMS is meant to work in production. Every time the repoitory changes, whether in the source codes or raw content, the website is rebuilt and redeployed automatically.
+
+For experimentation, you can run Netlify CMS locally, albeit with a catch. Each content edit through Netlify CMS results in a new commit to your remote repository. This means that you will need to pull changes from your remote each time to see them in the locally served site.
+
+For more information, read the Authentication section in the [Add to Your Site page](https://www.netlifycms.org/docs/add-to-your-site/).
+
+## Render Netlify CMS output on the frontend
+
+Once you've made your first post with Netlify CMS, head to your site repository and you'll find the latest commit containing the file with your post content.
+
+However, the integration process is not stopped here.Going back to your published site, you'll notice that even though you have a new file in your repository, it's not anywhere on your site. That's because Netlify CMS doesn't go beyond creating the raw content, which is one reason why it is able to work with many static site genetors.
+
+It is up to developers to determine how to build the raw content into something useful and delightful on the frontend. To learn how to process raw content from Netlify CMS, go to the section for your site generator in the Table of Content and follow its instructions.


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines.

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first two fields are mandatory:
-->

**Summary**
This pull request contains a new Markdown file called Overview that is meant to be added to the Platform Guides in the docs. It is a high-level view of what it means to integrate Netlify CMS with common static site generators without being biased to any framework.

## Motivation
Integrating Netlify CMS into a website built with SSG contains many moving pieces. The process also requires a bit of a mental leap, especially for someone from monolithic CMS. There are already plenty of detailed guides for all the popular SSGs, but none really explains the process from a high level or the rationale behind each step.

With this article, I hope that readers will have a better grasp on the benefits of integrating Netlify CMS with their static sites, why they should do what they are instructed to do before diving head first into a specific SSG.
<!--
Explain the **motivation** for making this change.
What existing problem does the pull request solve?
-->

**Test plan**

<!--
Demonstrate the code is solid.
Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.
-->

**A picture of a cute animal (not mandatory but encouraged)**
