### PR TITLE
fixes: buttons using browser font-family, not the font-stack

### DIFF
--- a/packages/netlify-cms-ui-default/src/styles.js
+++ b/packages/netlify-cms-ui-default/src/styles.js
@@ -492,6 +492,10 @@ function GlobalStyles() {
           text-decoration: none;
         }
 
+        button {
+          font-family: inherit;
+        }
+
         img {
           max-width: 100%;
         }


### PR DESCRIPTION
**Summary**

Button elements don't inherit the font-stack, they use the browser's default, which in the case of Firefox/Windows at least is terrible.

Before: ![image](https://user-images.githubusercontent.com/3504434/117198186-99d3b480-ade0-11eb-9948-aa15c4e5c80e.png)

After: ![image](https://user-images.githubusercontent.com/3504434/117198115-81fc3080-ade0-11eb-85a1-014f17506756.png)

Very minor, I just noticed while looking at another issue.

**Test plan**

Didn't run any tests, purely cosmetic.

**A picture of a cute animal (not mandatory but encouraged)**
![image](https://user-images.githubusercontent.com/3504434/117198344-d30c2480-ade0-11eb-8f95-756ac3d5e442.png)

