### PR TITLE
Revert "fix(deps): update dependency react-aria-menubutton to v7

### DIFF
--- a/packages/netlify-cms-ui-default/package.json
+++ b/packages/netlify-cms-ui-default/package.json
@@ -17,7 +17,7 @@
     "build:esm": "cross-env NODE_ENV=esm babel src --out-dir dist/esm --ignore \"**/__tests__\" --root-mode upward"
   },
   "dependencies": {
-    "react-aria-menubutton": "^7.0.0",
+    "react-aria-menubutton": "^6.0.0",
     "react-toggled": "^1.1.2",
     "react-transition-group": "^2.6.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -6682,7 +6682,7 @@ create-react-class@^15.5.2:
     loose-envify "^1.3.1"
     object-assign "^4.1.1"
 
-create-react-context@0.3.0:
+create-react-context@0.3.0, create-react-context@^0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/create-react-context/-/create-react-context-0.3.0.tgz#546dede9dc422def0d3fc2fe03afe0bc0f4f7d8c"
   integrity sha512-dNldIoSuNSvlTJ7slIKC/ZFGKexBMBrrcc+TTe1NdmROnaASuLPvqpwj9v4XS4uXZ8+YPu0sNmShX2rXI5LNsw==
@@ -14760,13 +14760,15 @@ rc@^1.2.8:
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
 
-react-aria-menubutton@^7.0.0:
-  version "7.0.1"
-  resolved "https://registry.yarnpkg.com/react-aria-menubutton/-/react-aria-menubutton-7.0.1.tgz#698e78a56bee33035b7df89180060f4135ec021a"
-  integrity sha512-qhvTJEqnGGw8Seei+0kT6T1vX7maQ3tGRhUqpR9xJ2gJ/v6/YLcJRRvUL9qx/bpQO/7tCihJRgDvH0k+l5OChQ==
+react-aria-menubutton@^6.0.0:
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/react-aria-menubutton/-/react-aria-menubutton-6.3.0.tgz#01acc4322c5271488941270b278b17001031e687"
+  integrity sha512-qlvbPgBDg+YreqrAsT2I0qpQfM7soRxA6dsTacogfCoVajcTEsgIPU3ewS7IzPvm+UMphK5Z8684WA2TNP3Zmg==
   dependencies:
+    create-react-context "^0.3.0"
     focus-group "^0.3.1"
     prop-types "^15.6.0"
+    react-display-name "^0.2.4"
     teeny-tap "^0.2.0"
 
 react-clientside-effect@^1.2.2:
@@ -14834,6 +14836,11 @@ react-dev-utils@^9.0.0:
     sockjs-client "1.4.0"
     strip-ansi "5.2.0"
     text-table "0.2.0"
+
+react-display-name@^0.2.4:
+  version "0.2.5"
+  resolved "https://registry.yarnpkg.com/react-display-name/-/react-display-name-0.2.5.tgz#304c7cbfb59ee40389d436e1a822c17fe27936c6"
+  integrity sha512-I+vcaK9t4+kypiSgaiVWAipqHRXYmZIuAiS8vzFvXHHXVigg/sMKwlRgLy6LH2i3rmP+0Vzfl5lFsFRwF1r3pg==
 
 react-dnd-html5-backend@^7.2.0:
   version "7.7.0"


### PR DESCRIPTION
Looks like https://github.com/netlify/netlify-cms/pull/5378 is causing our tests to be flaky.

Reverting so I can investigate 