### PR TITLE
fix(netlify-cms-widget-markdown): quote and list toolbar buttons not highlighted when clicking the corresponding blocks

### DIFF
--- a/packages/netlify-cms-widget-markdown/src/MarkdownControl/Toolbar.js
+++ b/packages/netlify-cms-widget-markdown/src/MarkdownControl/Toolbar.js
@@ -108,6 +108,7 @@ export default class Toolbar extends React.Component {
       hasMark = () => {},
       hasInline = () => {},
       hasBlock = () => {},
+      hasQuote = () => {},
       editorComponents,
       t,
     } = this.props;
@@ -211,7 +212,7 @@ export default class Toolbar extends React.Component {
               label={t('editor.editorWidgets.markdown.quote')}
               icon="quote"
               onClick={this.handleBlockClick}
-              isActive={hasBlock('quote')}
+              isActive={hasQuote('quote')}
               disabled={disabled}
             />
           )}

--- a/packages/netlify-cms-widget-markdown/src/MarkdownControl/VisualEditor.js
+++ b/packages/netlify-cms-widget-markdown/src/MarkdownControl/VisualEditor.js
@@ -164,6 +164,7 @@ export default class Editor extends React.Component {
   hasMark = type => this.editor && this.editor.hasMark(type);
   hasInline = type => this.editor && this.editor.hasInline(type);
   hasBlock = type => this.editor && this.editor.hasBlock(type);
+  hasQuote = type => this.editor && this.editor.hasQuote(type);
 
   handleToggleMode = () => {
     this.props.onMode('raw');
@@ -218,6 +219,7 @@ export default class Editor extends React.Component {
             hasMark={this.hasMark}
             hasInline={this.hasInline}
             hasBlock={this.hasBlock}
+            hasQuote={this.hasQuote}
             isShowModeToggle={isShowModeToggle}
             t={t}
             disabled={isDisabled}

--- a/packages/netlify-cms-widget-markdown/src/MarkdownControl/plugins/CommandsAndQueries.js
+++ b/packages/netlify-cms-widget-markdown/src/MarkdownControl/plugins/CommandsAndQueries.js
@@ -71,6 +71,18 @@ function CommandsAndQueries({ defaultType }) {
       hasInline(editor, type) {
         return editor.value.inlines.some(node => node.type === type);
       },
+      hasQuote(editor, quoteLabel) {
+        const { value } = editor;
+        const { document, blocks } = value;
+        return blocks.some(node => {
+          const { key: descendantNodeKey } = node;
+          const parent = document.getClosest(
+            descendantNodeKey,
+            parentNode => parentNode.type === quoteLabel,
+          );
+          return !!parent;
+        });
+      },
     },
     commands: {
       toggleBlock(editor, type) {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines.

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first two fields are mandatory:
-->
fixes #5338 

## Summary

This PR attempts to fix the problem with Netlify Markdown widget wherein the quote button is not highlighted when clicking on a quote block. For now, it only includes 16 additions and 1 deletion, but it took me a while to wrap my head around the ecosystem of the Slate editor used in Netlify CMS, so please bear with my lengthy description.

## Notes

All files mentioned are located inside packages/netlify-cms-widget-markdown/src/MarkdownControl.
When referencing Slate's documentation, please visit the 0.47 version. Netlify CMS app uses Slate 0.47, and Slate was rewritten from the ground up after this version. Most of the functionalities mentioned below don't apply to versions after 0.47.

## Why the quote toolbar button is not highlighted?

Here is a tree diagram starting from the `<VisualEditor>` component.

![visual-editor-component-tree](https://user-images.githubusercontent.com/28924121/118255783-da18ee00-b4d6-11eb-9b85-9604372bdaf8.jpg)


The Quote toolbar button is just a presentation component. It has several props, one of which is  isActive whose bolean value determines the color of button. If true, the button color is #1e2532. This is what end users see as being highlighted. If false, the button color is inherited from its parent, the <Toolbar> component.

```
// ToolbarButton.js
const StyledToolbarButton = styled.button`
  /* ... */
  color: ${props => (props.isActive ? '#1e2532' : 'inherit')}
  /* ... */
`

function ToolbarButton({ isActive }) {
  return (
    <StyledToolbarButton
      isActive={isActive}
    >
      {...}
    </StyledToolbarButton>
  )
}
```

And what determines the value of this prop? It is passed from `<Toolbar>` , and equal to the what is returned from calling function hasBlock(type) , setting type=quote.

This function hasBlock(type) is in turn a prop of `<Toolbar>` component passed down from `<VisualEditor>`.

```
// Toolbar.js
export default class Toolbar extends React.Component {
  render() {
    const { hasBlock = () => {} } = this.props
    return (
      <ToolbarContainer>
        <div>
          {isVisible('quote') && (
            <ToolbarButton 
              isActive={hasBlock('quote')}
            />
          )}
        </div>
      </ToolbarContainer>
    )
  }
}
```

Here is what `hasBlock` method do in <VisualEditor> class:

```
// VisualEditor.js
export default class Editor extends React.Component {
  // ...
  hasBlock = type => this.editor && this.editor.hasBlock(type);
  render() {
    return ()
  }
}
```

The property `editor` here is a top-level controller that holds the data inside the Slate editor, and all the handlers that determine its behavior.

Here, we can see that this controller has a first-class method named `hasBlock`. But where does this `hasBlock` come from?

It turns out that this handler comes from a plugin we add to our editor. 

Slate editor takes a prop called plugins whose value is an array of plugins. 

```
// VisualEditor.js
// ...
import plugins from './plugins/visual';
// ...
export default class Editor extends React.Component {
  constructor(props) {
    // ...
    this.plugins = plugins({
      // ...
    })
  }
  render() {
    return (
      <div>
        {...}
        <Slate plugins={this.plugins}/>
      </div>
    )
  }
}
```

Each plugin is just a plain Javascript object containing one or more functions that control the logic of our editor.

```
// plugins/visual.js
import CommandsAndQueries from './CommandsAndQueries';

function plugins({ getAsset, resolveWidget, t}) {
  return [
    // ...
    CommandsAndQueries({ defaultType }) // defaultType here is 'paragraph'
    // ...
  ]
}
```

In this case, the hasBlock handler of the editor comes from a plugin object called CommandsAndQueries.

```
// plugins/CommandsAndQueries.js
function CommandsAndQueries({ defaultType }) {
  return {
    queries: {
      // ...
      hasBlock(editor, type) {
        return editor.value.blocks.some(node => node.type === type);
      }
    }
  }
}
```

When we define `hasBlock` inside the `queries` property, it will be made available as a method on the editor object. That's why we can call this.editor.hasBlock directly from the VisualEditor component.

Let's add `console.log` to the `hasBlock` function to see what it does.

```
hasBlock(editor, type) {
        return editor.value.blocks.some(node => {
          console.log({ node });
          return node.type === type;
        });
      },
```

Go to the Netlify CMS admin, click on an existing blog post or create a new one. Click on any paragraph block, then click the Quote button.

The block node that receives the click has a type paragraph. In order for the Quote button to be highlighted, it has to be of type quote.

![quoteblock-paragraph](https://user-images.githubusercontent.com/28924121/118254104-ebf99180-b4d4-11eb-84f3-9300075f6283.gif)

What happened? Inspecting the DOM tree, we can see that our quote block is actually a p element wrapped inside a blockquote element.

The reason is `editor.value` gets the current data in the Slate editor. `editor.value.block` retrieves the lowest depth block node in the current selection, or the `<p>` element in this case, not `<blockquote>`.

This means calling `hasBlock('quote')` will aways returns false, thereby setting isActive prop in the `<ToolbarButton>` component to false. As a result, the quote toolbar button is never highlighted.

## Resolution

To check if a node is child of a blockquote , we need to go up and check its parent node type.

But first, let's create a new query for checking quote block. The reason is hasBlock function is also called in six other buttons: heading 1 to 6. Determining if a block node is a heading is straightforward and doesn't require checking its parent node.

```
// plugins/CommandsAndQueries .js
function CommandsAndQueries({ defaultType }) {
  return {
    queries: {
      hasQuote(editor, quoteLabel) {
        const { value } = editor;
        const { document, blocks } = value;
        return blocks.some(node => {
          const { key: descendantNodeKey } = node;
          const parent = document.getClosest(
            descendantNodeKey,
            parentNode => parentNode.type === quoteLabel,
          );
          console.log({ parent });
          return !!parent;
        });
      },
    }
  }
}
```

Then, in the <VisualEditor> component, add a hasQuote method, and pass it as prop to the <Toolbar> component.

```
// VisualEditor.js
export default class Editor extends React.Component {
  // ...
  hasQuote = type => this.editor && this.editor.hasQuote(type);
  render() {
    return (
      // ...
        <Toolbar hasQuote={this.hasQuote} />
      // ...
    )
  }
}
```

Finally, in the <Toolbar> component, extract the hasQuote prop. Then look for the <ToolbarButton> component for quote and call hasQuote in the isActive prop.

```
// Toolbar.js
export default class Toolbar extends React.Component {
  render() {
    const { hasQuote = () => {} } = this.props
  }
  return (
    {isVisible('quote') && (
      <Toolbarbutton
        // ...
        isActive={hasQuote('quote')}
      />
    )}
  )
}
```

<!--
Explain the **motivation** for making this change.
What existing problem does the pull request solve?
-->

**Test plan**
1. Go to Netlify admin, create a new post or click on an existing one.
2. If the editor is empty, type a string which contains at least one character. Keep the cursor in the line you've just typed. Otherwise, place it on an existing paragraph block. 
3. Click the Quote button. It should turn into a darker color.

![highlighting-quote-block-button](https://user-images.githubusercontent.com/28924121/118254899-c620bc80-b4d5-11eb-8e2f-de2bcb4fc39a.gif)

<!--
Demonstrate the code is solid.
Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.
-->