### PR TITLE
Fix some block style buttons not highlighted when clicking on the equivalent blocks in the editor

### DIFF
--- a/packages/netlify-cms-widget-markdown/src/MarkdownControl/Toolbar.js
+++ b/packages/netlify-cms-widget-markdown/src/MarkdownControl/Toolbar.js
@@ -109,6 +109,7 @@ export default class Toolbar extends React.Component {
       hasInline = () => {},
       hasBlock = () => {},
       hasQuote = () => {},
+      hasListItems = () => {},
       editorComponents,
       t,
     } = this.props;
@@ -222,7 +223,7 @@ export default class Toolbar extends React.Component {
               label={t('editor.editorWidgets.markdown.bulletedList')}
               icon="list-bulleted"
               onClick={this.handleBlockClick}
-              isActive={hasBlock('bulleted-list')}
+              isActive={hasListItems('bulleted-list')}
               disabled={disabled}
             />
           )}
@@ -232,7 +233,7 @@ export default class Toolbar extends React.Component {
               label={t('editor.editorWidgets.markdown.numberedList')}
               icon="list-numbered"
               onClick={this.handleBlockClick}
-              isActive={hasBlock('numbered-list')}
+              isActive={hasListItems('numbered-list')}
               disabled={disabled}
             />
           )}

--- a/packages/netlify-cms-widget-markdown/src/MarkdownControl/Toolbar.js
+++ b/packages/netlify-cms-widget-markdown/src/MarkdownControl/Toolbar.js
@@ -108,6 +108,7 @@ export default class Toolbar extends React.Component {
       hasMark = () => {},
       hasInline = () => {},
       hasBlock = () => {},
+      hasQuote = () => {},
       editorComponents,
       t,
     } = this.props;
@@ -211,7 +212,7 @@ export default class Toolbar extends React.Component {
               label={t('editor.editorWidgets.markdown.quote')}
               icon="quote"
               onClick={this.handleBlockClick}
-              isActive={hasBlock('quote')}
+              isActive={hasQuote('quote')}
               disabled={disabled}
             />
           )}

--- a/packages/netlify-cms-widget-markdown/src/MarkdownControl/VisualEditor.js
+++ b/packages/netlify-cms-widget-markdown/src/MarkdownControl/VisualEditor.js
@@ -165,6 +165,7 @@ export default class Editor extends React.Component {
   hasInline = type => this.editor && this.editor.hasInline(type);
   hasBlock = type => this.editor && this.editor.hasBlock(type);
   hasQuote = type => this.editor && this.editor.hasQuote(type);
+  hasListItems = type => this.editor && this.editor.hasListItems(type);
 
   handleToggleMode = () => {
     this.props.onMode('raw');
@@ -220,6 +221,7 @@ export default class Editor extends React.Component {
             hasInline={this.hasInline}
             hasBlock={this.hasBlock}
             hasQuote={this.hasQuote}
+            hasListItems={this.hasListItems}
             isShowModeToggle={isShowModeToggle}
             t={t}
             disabled={isDisabled}

--- a/packages/netlify-cms-widget-markdown/src/MarkdownControl/VisualEditor.js
+++ b/packages/netlify-cms-widget-markdown/src/MarkdownControl/VisualEditor.js
@@ -164,6 +164,7 @@ export default class Editor extends React.Component {
   hasMark = type => this.editor && this.editor.hasMark(type);
   hasInline = type => this.editor && this.editor.hasInline(type);
   hasBlock = type => this.editor && this.editor.hasBlock(type);
+  hasQuote = type => this.editor && this.editor.hasQuote(type);
 
   handleToggleMode = () => {
     this.props.onMode('raw');
@@ -218,6 +219,7 @@ export default class Editor extends React.Component {
             hasMark={this.hasMark}
             hasInline={this.hasInline}
             hasBlock={this.hasBlock}
+            hasQuote={this.hasQuote}
             isShowModeToggle={isShowModeToggle}
             t={t}
             disabled={isDisabled}

--- a/packages/netlify-cms-widget-markdown/src/MarkdownControl/plugins/CommandsAndQueries.js
+++ b/packages/netlify-cms-widget-markdown/src/MarkdownControl/plugins/CommandsAndQueries.js
@@ -71,6 +71,18 @@ function CommandsAndQueries({ defaultType }) {
       hasInline(editor, type) {
         return editor.value.inlines.some(node => node.type === type);
       },
+      hasQuote(editor, quoteLabel) {
+        const { value } = editor;
+        const { document, blocks } = value;
+        return blocks.some(node => {
+          const { key: descendantNodeKey } = node;
+          const parent = document.getClosest(
+            descendantNodeKey,
+            parentNode => parentNode.type === quoteLabel,
+          );
+          return !!parent;
+        });
+      },
     },
     commands: {
       toggleBlock(editor, type) {

--- a/packages/netlify-cms-widget-markdown/src/MarkdownControl/plugins/CommandsAndQueries.js
+++ b/packages/netlify-cms-widget-markdown/src/MarkdownControl/plugins/CommandsAndQueries.js
@@ -83,6 +83,25 @@ function CommandsAndQueries({ defaultType }) {
           return !!parent;
         });
       },
+      hasListItems(editor, listType) {
+        const { value } = editor;
+        const { document, blocks } = value;
+        return blocks.some(node => {
+          const { key: lowestNodeKey, type: lowestNodeType } = node;
+          if (lowestNodeType !== 'paragraph') return false;
+          const parent = document.getClosest(
+            lowestNodeKey,
+            parentNode => parentNode.type === 'list-item',
+          );
+          if (!parent) return false;
+          const { key: parentNodeKey } = parent;
+          const grandParent = document.getClosest(
+            parentNodeKey,
+            grandParentNode => grandParentNode.type === listType,
+          );
+          return !!grandParent;
+        });
+      },
     },
     commands: {
       toggleBlock(editor, type) {

--- a/packages/netlify-cms-widget-markdown/src/MarkdownControl/plugins/CommandsAndQueries.js
+++ b/packages/netlify-cms-widget-markdown/src/MarkdownControl/plugins/CommandsAndQueries.js
@@ -97,11 +97,8 @@ function CommandsAndQueries({ defaultType }) {
             <li>
               <p>Tea</p>
             </li>
-          </li>
-          The block that gets the focus is the lowest node, aka paragraph. Hence we need to check if the block in focus
-          is of type `paragraph`. If not, return immediately.
+          </ol>
           */
-          // if (lowestNodeType !== 'paragraph') return false;
           const parent = document.getParent(lowestNodeKey);
           const grandparent = document.getParent(parent.key);
           return parent.type === 'list-item' && grandparent?.type === listType;

--- a/packages/netlify-cms-widget-markdown/src/MarkdownControl/plugins/CommandsAndQueries.js
+++ b/packages/netlify-cms-widget-markdown/src/MarkdownControl/plugins/CommandsAndQueries.js
@@ -88,19 +88,23 @@ function CommandsAndQueries({ defaultType }) {
         const { value } = editor;
         const { document, blocks } = value;
         return blocks.some(node => {
-          const { key: lowestNodeKey, type: lowestNodeType } = node;
-          if (lowestNodeType !== 'paragraph') return false;
-          const parent = document.getClosest(
-            lowestNodeKey,
-            parentNode => parentNode.type === 'list-item',
-          );
-          if (!parent) return false;
-          const { key: parentNodeKey } = parent;
-          const grandParent = document.getClosest(
-            parentNodeKey,
-            grandParentNode => grandParentNode.type === listType,
-          );
-          return !!grandParent;
+          const { key: lowestNodeKey } = node;
+          /* A list block has the following structure:
+          <ol>
+            <li>
+              <p>Coffee</p>
+            </li>
+            <li>
+              <p>Tea</p>
+            </li>
+          </li>
+          The block that gets the focus is the lowest node, aka paragraph. Hence we need to check if the block in focus
+          is of type `paragraph`. If not, return immediately.
+          */
+          // if (lowestNodeType !== 'paragraph') return false;
+          const parent = document.getParent(lowestNodeKey);
+          const grandparent = document.getParent(parent.key);
+          return parent.type === 'list-item' && grandparent?.type === listType;
         });
       },
     },

--- a/packages/netlify-cms-widget-markdown/src/MarkdownControl/plugins/CommandsAndQueries.js
+++ b/packages/netlify-cms-widget-markdown/src/MarkdownControl/plugins/CommandsAndQueries.js
@@ -76,11 +76,12 @@ function CommandsAndQueries({ defaultType }) {
         const { document, blocks } = value;
         return blocks.some(node => {
           const { key: descendantNodeKey } = node;
-          const parent = document.getClosest(
-            descendantNodeKey,
-            parentNode => parentNode.type === quoteLabel,
-          );
-          return !!parent;
+          /* When focusing a quote block, the actual block that gets the focus is the paragraph block whose parent is a `quote` block.
+          Hence, we need to get its parent and check if its type is `quote`. This parent will always be defined because every block in the editor
+          has a Document object as parent by default.
+          */
+          const parent = document.getParent(descendantNodeKey);
+          return parent.type === quoteLabel;
         });
       },
       hasListItems(editor, listType) {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines.

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first two fields are mandatory:
-->
fixes #5338 

**Summary**
## Summary

This PR attempts to fix the problem with Netlify Markdown widget wherein the toolbar buttons for quote, bulleted list and numbered list are not highlighted when clicking on the corresponding block in the editor. 

## Notes

All files mentioned are located inside packages/netlify-cms-widget-markdown/src/MarkdownControl.
When referencing Slate's documentation, please visit the 0.47 version. Netlify CMS app uses Slate 0.47, and Slate was rewritten from the ground up after this version. Most of the functionalities mentioned below don't apply to versions after 0.47.

## Why the quote toolbar button is not highlighted?

Here is a tree diagram starting from the `<VisualEditor>` component.

![visual-editor-component-tree](https://user-images.githubusercontent.com/28924121/118255783-da18ee00-b4d6-11eb-9b85-9604372bdaf8.jpg)


The Quote toolbar button is just a presentation component. It has several props, one of which is  isActive whose boolean value determines the color of button. If true, the button color is #1e2532. This is what end users see as being highlighted. If false, the button color is inherited from its parent, the `<Toolbar>` component.

```
// ToolbarButton.js
const StyledToolbarButton = styled.button`
  /* ... */
  color: ${props => (props.isActive ? '#1e2532' : 'inherit')}
  /* ... */
`

function ToolbarButton({ isActive }) {
  return (
    <StyledToolbarButton
      isActive={isActive}
    >
      {...}
    </StyledToolbarButton>
  )
}
```

And what determines the value of this prop? It is passed from `<Toolbar>` , and equal to the what is returned from calling function `hasBlock(type`) , setting type=quote.

This function `hasBlock(type)` is in turn a prop of `<Toolbar>` component passed down from `<VisualEditor>`.

```
// Toolbar.js
export default class Toolbar extends React.Component {
  render() {
    const { hasBlock = () => {} } = this.props
    return (
      <ToolbarContainer>
        <div>
          {isVisible('quote') && (
            <ToolbarButton 
              isActive={hasBlock('quote')}
            />
          )}
        </div>
      </ToolbarContainer>
    )
  }
}
```

Here is what `hasBlock` method do in `<VisualEditor>` class:

```
// VisualEditor.js
export default class Editor extends React.Component {
  // ...
  hasBlock = type => this.editor && this.editor.hasBlock(type);
  render() {
    return ()
  }
}
```

The property `editor` here is a top-level controller that holds the data inside the Slate editor, and all the handlers that determine its behavior.

Here, we can see that this controller has a first-class method named `hasBlock`. But where does this `hasBlock` come from?

It turns out that this handler comes from a plugin we add to our editor. 

Slate editor takes a prop called plugins whose value is an array of plugins. 

```
// VisualEditor.js
// ...
import plugins from './plugins/visual';
// ...
export default class Editor extends React.Component {
  constructor(props) {
    // ...
    this.plugins = plugins({
      // ...
    })
  }
  render() {
    return (
      <div>
        {...}
        <Slate plugins={this.plugins}/>
      </div>
    )
  }
}
```

Each plugin is just a plain Javascript object containing one or more functions that control the logic of our editor.

```
// plugins/visual.js
import CommandsAndQueries from './CommandsAndQueries';

function plugins({ getAsset, resolveWidget, t}) {
  return [
    // ...
    CommandsAndQueries({ defaultType }) // defaultType here is 'paragraph'
    // ...
  ]
}
```

In this case, the hasBlock handler of the editor comes from a plugin object called CommandsAndQueries.

```
// plugins/CommandsAndQueries.js
function CommandsAndQueries({ defaultType }) {
  return {
    queries: {
      // ...
      hasBlock(editor, type) {
        return editor.value.blocks.some(node => node.type === type);
      }
    }
  }
}
```

When we define `hasBlock` inside the `queries` property, it will be made available as a method on the editor object. That's why we can call this.editor.hasBlock directly from the VisualEditor component.

Let's add `console.log` to the `hasBlock` function to see what it does.

```
hasBlock(editor, type) {
        return editor.value.blocks.some(node => {
          console.log({ node });
          return node.type === type;
        });
      },
```

Go to the Netlify CMS admin, click on an existing blog post or create a new one. Click on any paragraph block, then click the Quote button.

The block node that receives the click has a type paragraph. In order for the Quote button to be highlighted, it has to be of type quote.

![quoteblock-paragraph](https://user-images.githubusercontent.com/28924121/118254104-ebf99180-b4d4-11eb-84f3-9300075f6283.gif)

What happened? Inspecting the DOM tree, we can see that our quote block is actually a p element wrapped inside a blockquote element.

The reason is `editor.value` gets the current data in the Slate editor. `editor.value.block` retrieves the lowest depth block node in the current selection, or the `<p>` element in this case, not `<blockquote>`.

This means calling `hasBlock('quote')` will aways returns false, thereby setting isActive prop in the `<ToolbarButton>` component to false. As a result, the quote toolbar button is never highlighted.

## Resolution

To check if a node is child of a blockquote , we need to go up and check its parent node type.

But first, let's create a new query for checking quote block. The reason is `hasBlock` function is also called in six other buttons: heading 1 to 6. Determining if a block node is a heading is more straightforward and doesn't require checking its parent node.

```
// plugins/CommandsAndQueries .js
function CommandsAndQueries({ defaultType }) {
  return {
    queries: {
      hasQuote(editor, quoteLabel) {
        const { value } = editor;
        const { document, blocks } = value;
        return blocks.some(node => {
          const { key: descendantNodeKey } = node;
          const parent = document.getClosest(
            descendantNodeKey,
            parentNode => parentNode.type === quoteLabel,
          );
          console.log({ parent });
          return !!parent;
        });
      },
    }
  }
}
```

Then, in the `<VisualEditor>` component, add a `hasQuote` method, and pass it as prop to the `<Toolbar>` component.

```
// VisualEditor.js
export default class Editor extends React.Component {
  // ...
  hasQuote = type => this.editor && this.editor.hasQuote(type);
  render() {
    return (
      // ...
        <Toolbar hasQuote={this.hasQuote} />
      // ...
    )
  }
}
```

Finally, in the `<Toolbar>` component, extract the `hasQuote` prop. Then look for the `<ToolbarButton>` component for quote and call hasQuote in the isActive prop.

```
// Toolbar.js
export default class Toolbar extends React.Component {
  render() {
    const { hasQuote = () => {} } = this.props
  }
  return (
    {isVisible('quote') && (
      <Toolbarbutton
        // ...
        isActive={hasQuote('quote')}
      />
    )}
  )
}
```

## What about list blocks
It has almost the same as quote blocks, except that a list block contains three levels:

```
<ul>
  <li>
    <p>Bulleted list 1</p>
  </li>
  <li>
    <p>Bulleted list 2</p>
  </li>
</ul>
```

When clicking on a list block, the node that gets the click is the paragraph element. So we have to travel up twice:
- check if its parent is of type `list-item`
- check if its grandparent is of type `bulleted-list` or `numbered-list`

<!--
Explain the **motivation** for making this change.
What existing problem does the pull request solve?
-->

**Test plan**

<!--
Demonstrate the code is solid.
Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.
-->
