### PR TITLE
fix spelling of the norwegian deleteEntry translation

### DIFF
--- a/packages/netlify-cms-locales/src/nb_no/index.js
+++ b/packages/netlify-cms-locales/src/nb_no/index.js
@@ -107,7 +107,7 @@ const nb_no = {
       deleteUnpublishedChanges: 'Slett upubliserte endringer',
       deleteUnpublishedEntry: 'Slett upublisert innlegg',
       deletePublishedEntry: 'Slett publisert innlegg',
-      deleteEntry: 'Sletter innlegg',
+      deleteEntry: 'Slett innlegg',
       saving: 'Lagrer...',
       save: 'Lagre',
       deleting: 'Sletter...',


### PR DESCRIPTION


<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines.

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first two fields are mandatory:
-->

**Summary**
The translation of the Norwegian `editorToolbar.deleteEntry` was using the wrong inflection, making it sound like it was already deleting the entry.
This PR changes the translation from "deleting" to "delete".

<!--
Explain the **motivation** for making this change.
What existing problem does the pull request solve?
-->

**Test plan**

<!--
Demonstrate the code is solid.
Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.
-->

**A picture of a cute animal (not mandatory but encouraged)**
