### PR TITLE
chore: mark registerEventListener options as optional

### DIFF
--- a/packages/netlify-cms-core/index.d.ts
+++ b/packages/netlify-cms-core/index.d.ts
@@ -550,7 +550,7 @@ declare module 'netlify-cms-core' {
     registerEditorComponent: (options: EditorComponentOptions) => void;
     registerEventListener: (
       eventListener: CmsEventListener,
-      options: CmsEventListenerOptions,
+      options?: CmsEventListenerOptions,
     ) => void;
     registerLocale: (locale: string, phrases: CmsLocalePhrases) => void;
     registerMediaLibrary: (mediaLibrary: CmsMediaLibrary, options?: CmsMediaLibraryOptions) => void;


### PR DESCRIPTION
**Summary**

`CMS.registerEventListener` takes an `options` arg which is currently marked as required, but should be optional

**Test plan**

none
