### PR TITLE
chore: add document and window to PreviewTemplateComponentProps type

### DIFF
--- a/packages/netlify-cms-core/index.d.ts
+++ b/packages/netlify-cms-core/index.d.ts
@@ -535,6 +535,8 @@ declare module 'netlify-cms-core' {
     config: Map<string, any>;
     fields: List<Map<string, any>>;
     isLoadingAsset: boolean;
+    window: Window
+    document: Document
   };
 
   export interface CMS {

--- a/packages/netlify-cms-core/index.d.ts
+++ b/packages/netlify-cms-core/index.d.ts
@@ -535,8 +535,8 @@ declare module 'netlify-cms-core' {
     config: Map<string, any>;
     fields: List<Map<string, any>>;
     isLoadingAsset: boolean;
-    window: Window
-    document: Document
+    window: Window;
+    document: Document;
   };
 
   export interface CMS {


### PR DESCRIPTION
**Summary**

Preview templates receive the `iframe`'s `window` and `document` - those were missing from the `PreviewTemplateComponentProps` type

**Test plan**

none