### PR TITLE
chore: add missing always_fork option to CmsBackend type

### DIFF
--- a/packages/netlify-cms-core/index.d.ts
+++ b/packages/netlify-cms-core/index.d.ts
@@ -347,6 +347,7 @@ declare module 'netlify-cms-core' {
     name: CmsBackendType;
     auth_scope?: CmsAuthScope;
     open_authoring?: boolean;
+    always_fork?: boolean
     repo?: string;
     branch?: string;
     api_root?: string;

--- a/packages/netlify-cms-core/index.d.ts
+++ b/packages/netlify-cms-core/index.d.ts
@@ -347,7 +347,7 @@ declare module 'netlify-cms-core' {
     name: CmsBackendType;
     auth_scope?: CmsAuthScope;
     open_authoring?: boolean;
-    always_fork?: boolean
+    always_fork?: boolean;
     repo?: string;
     branch?: string;
     api_root?: string;


### PR DESCRIPTION
**Summary**

adds `always_fork` option (see https://github.com/netlify/netlify-cms/pull/5204/files) to `CmsBackend` type.

**Test plan**

none

