### PR TITLE
Fix: Hitting Enter key in a list item doesn't create a new list item [CHANGING SCHEMA]

### DIFF
--- a/packages/netlify-cms-widget-markdown/src/MarkdownControl/plugins/BreakToDefaultBlock.js
+++ b/packages/netlify-cms-widget-markdown/src/MarkdownControl/plugins/BreakToDefaultBlock.js
@@ -1,6 +1,6 @@
 import isHotkey from 'is-hotkey';
 
-import {SLATE_LIST_BLOCK_TYPES as listType} from '../../types'
+import { SLATE_LIST_BLOCK_TYPES as listType } from '../../types';
 
 function BreakToDefaultBlock({ defaultType }) {
   return {
@@ -10,12 +10,11 @@ function BreakToDefaultBlock({ defaultType }) {
       if (!isEnter) {
         return next();
       }
-      const isListItem = blocks.some((node) => node.type === listType.children);
-    if (isListItem) {
-      if (startBlock.text.length > 0) return next()
-      return editor.setNodeByKey(startBlock.key, {type: defaultType}); 
-      
-    };
+      const isListItem = blocks.some(node => node.type === listType.children);
+      if (isListItem) {
+        if (startBlock.text.length > 0) return next();
+        return editor.setNodeByKey(startBlock.key, { type: defaultType });
+      }
       if (selection.isExpanded) {
         editor.delete();
         return next();

--- a/packages/netlify-cms-widget-markdown/src/MarkdownControl/plugins/BreakToDefaultBlock.js
+++ b/packages/netlify-cms-widget-markdown/src/MarkdownControl/plugins/BreakToDefaultBlock.js
@@ -1,13 +1,21 @@
 import isHotkey from 'is-hotkey';
 
+import {SLATE_LIST_BLOCK_TYPES as listType} from '../../types'
+
 function BreakToDefaultBlock({ defaultType }) {
   return {
     onKeyDown(event, editor, next) {
-      const { selection, startBlock } = editor.value;
+      const { selection, startBlock, blocks } = editor.value;
       const isEnter = isHotkey('enter', event);
       if (!isEnter) {
         return next();
       }
+      const isListItem = blocks.some((node) => node.type === listType.children);
+    if (isListItem) {
+      if (startBlock.text.length > 0) return next()
+      return editor.setNodeByKey(startBlock.key, {type: defaultType}); 
+      
+    };
       if (selection.isExpanded) {
         editor.delete();
         return next();

--- a/packages/netlify-cms-widget-markdown/src/MarkdownControl/plugins/CommandsAndQueries.js
+++ b/packages/netlify-cms-widget-markdown/src/MarkdownControl/plugins/CommandsAndQueries.js
@@ -1,5 +1,7 @@
 import { isArray, tail, castArray } from 'lodash';
 
+import {SLATE_LIST_BLOCK_TYPES as listTypes} from '../../types'
+
 function CommandsAndQueries({ defaultType }) {
   return {
     queries: {
@@ -84,25 +86,16 @@ function CommandsAndQueries({ defaultType }) {
           return parent.type === quoteLabel;
         });
       },
-      hasListItems(editor, listType) {
-        const { value } = editor;
-        const { document, blocks } = value;
-        return blocks.some(node => {
-          const { key: lowestNodeKey } = node;
-          /* A list block has the following structure:
-          <ol>
-            <li>
-              <p>Coffee</p>
-            </li>
-            <li>
-              <p>Tea</p>
-            </li>
-          </ol>
-          */
-          const parent = document.getParent(lowestNodeKey);
-          const grandparent = document.getParent(parent.key);
-          return parent.type === 'list-item' && grandparent?.type === listType;
-        });
+      hasListItems(editor, type) {
+        let ans = false;
+        const {value: {document, blocks}} = editor;
+        if (blocks.size > 0) {
+          // Check if at least one block node in the block array is of type `list-item`
+          const isListItem = blocks.some(node => node.type === listTypes.children);
+          const parent = document.getParent(blocks.first().key);
+          ans = isListItem && parent && parent.type === type;
+        }
+        return ans;
       },
     },
     commands: {

--- a/packages/netlify-cms-widget-markdown/src/MarkdownControl/plugins/CommandsAndQueries.js
+++ b/packages/netlify-cms-widget-markdown/src/MarkdownControl/plugins/CommandsAndQueries.js
@@ -1,6 +1,6 @@
 import { isArray, tail, castArray } from 'lodash';
 
-import {SLATE_LIST_BLOCK_TYPES as listTypes} from '../../types'
+import { SLATE_LIST_BLOCK_TYPES as listTypes } from '../../types';
 
 function CommandsAndQueries({ defaultType }) {
   return {
@@ -88,7 +88,9 @@ function CommandsAndQueries({ defaultType }) {
       },
       hasListItems(editor, type) {
         let ans = false;
-        const {value: {document, blocks}} = editor;
+        const {
+          value: { document, blocks },
+        } = editor;
         if (blocks.size > 0) {
           // Check if at least one block node in the block array is of type `list-item`
           const isListItem = blocks.some(node => node.type === listTypes.children);

--- a/packages/netlify-cms-widget-markdown/src/MarkdownControl/plugins/List.js
+++ b/packages/netlify-cms-widget-markdown/src/MarkdownControl/plugins/List.js
@@ -1,10 +1,9 @@
 import { List } from 'immutable';
-import { castArray, throttle, get } from 'lodash';
-import { Range, Block } from 'slate';
-import isHotkey from 'is-hotkey';
+import { castArray, throttle } from 'lodash';
+import { Block } from 'slate';
 
 import { assertType } from './util';
-import {SLATE_LIST_BLOCK_TYPES as LIST_SCHEMA} from '../../types'
+import { SLATE_LIST_BLOCK_TYPES as LIST_SCHEMA } from '../../types';
 
 function ListPlugin({ defaultType, unorderedListType, orderedListType }) {
   const LIST_TYPES = [orderedListType, unorderedListType];
@@ -167,19 +166,21 @@ function ListPlugin({ defaultType, unorderedListType, orderedListType }) {
           });
         } else if (isListItem) {
           editor.withoutNormalizing(() => {
-            editor.unwrapBlock(type === LIST_TYPES[0] ? LIST_TYPES[1] : LIST_TYPES[0]).wrapBlock(type)
-          })
+            editor
+              .unwrapBlock(type === LIST_TYPES[0] ? LIST_TYPES[1] : LIST_TYPES[0])
+              .wrapBlock(type);
+          });
         } else {
           editor.withoutNormalizing(() => {
             editor.setBlocks(LIST_SCHEMA.children).wrapBlock(type);
-          }); 
+          });
         }
       },
     },
     /** This onKeyDown handler only applies when a list item block contains a paragraph block, which is no longer the case.
-      * TODO: rewrite the onKeyDown handler for Tab and Backspace key. The Enter key is already handled in
-      * BreakToDefaultBlock plugin because it is loaded after this List plugin and will override whatever behaviour is defined here.
-    */
+     * TODO: rewrite the onKeyDown handler for Tab and Backspace key. The Enter key is already handled in
+     * BreakToDefaultBlock plugin because it is loaded after this List plugin and will override whatever behaviour is defined here.
+     */
     // onKeyDown(event, editor, next) {
     //   // Handle Backspace
     //   if (isHotkey('backspace', event) && editor.value.selection.isCollapsed) {

--- a/packages/netlify-cms-widget-markdown/src/MarkdownControl/plugins/List.js
+++ b/packages/netlify-cms-widget-markdown/src/MarkdownControl/plugins/List.js
@@ -4,6 +4,7 @@ import { Range, Block } from 'slate';
 import isHotkey from 'is-hotkey';
 
 import { assertType } from './util';
+import {SLATE_LIST_BLOCK_TYPES as LIST_SCHEMA} from '../../types'
 
 function ListPlugin({ defaultType, unorderedListType, orderedListType }) {
   const LIST_TYPES = [orderedListType, unorderedListType];

--- a/packages/netlify-cms-widget-markdown/src/MarkdownControl/plugins/List.js
+++ b/packages/netlify-cms-widget-markdown/src/MarkdownControl/plugins/List.js
@@ -198,106 +198,110 @@ function ListPlugin({ defaultType, unorderedListType, orderedListType }) {
         }
       },
     },
-    onKeyDown(event, editor, next) {
-      // Handle Backspace
-      if (isHotkey('backspace', event) && editor.value.selection.isCollapsed) {
-        // If beginning block is not of default type, do nothing
-        if (editor.value.startBlock.type !== defaultType) {
-          return next();
-        }
-        const listOrListItem = editor.getListOrListItem();
-        const isListItem = listOrListItem && listOrListItem.type === 'list-item';
+    /** This onKeyDown handler only applies when a list item block contains a paragraph block, which is no longer the case.
+      * TODO: rewrite the onKeyDown handler for Tab and Backspace key. The Enter key is already handled in
+      * BreakToDefaultBlock plugin because it is loaded after this List plugin and will override whatever behaviour is defined here.
+    */
+    // onKeyDown(event, editor, next) {
+    //   // Handle Backspace
+    //   if (isHotkey('backspace', event) && editor.value.selection.isCollapsed) {
+    //     // If beginning block is not of default type, do nothing
+    //     if (editor.value.startBlock.type !== defaultType) {
+    //       return next();
+    //     }
+    //     const listOrListItem = editor.getListOrListItem();
+    //     const isListItem = listOrListItem && listOrListItem.type === 'list-item';
 
-        // If immediate block is a list item, unwrap it
-        if (isListItem && editor.value.selection.start.isAtStartOfNode(listOrListItem)) {
-          const listItem = listOrListItem;
-          const previousSibling = editor.value.document.getPreviousSibling(listItem.key);
+    //     // If immediate block is a list item, unwrap it
+    //     if (isListItem && editor.value.selection.start.isAtStartOfNode(listOrListItem)) {
+    //       const listItem = listOrListItem;
+    //       const previousSibling = editor.value.document.getPreviousSibling(listItem.key);
 
-          // If this isn't the first item in the list, merge into previous list item
-          if (previousSibling && previousSibling.type === 'list-item') {
-            return editor.mergeNodeByKey(listItem.key);
-          }
-          return editor.unwrapListItem(listItem);
-        }
+    //       // If this isn't the first item in the list, merge into previous list item
+    //       if (previousSibling && previousSibling.type === 'list-item') {
+    //         return editor.mergeNodeByKey(listItem.key);
+    //       }
+    //       return editor.unwrapListItem(listItem);
+    //     }
 
-        return next();
-      }
+    //     return next();
+    //   }
 
-      // Handle Tab
-      if (isHotkey('tab', event) || isHotkey('shift+tab', event)) {
-        const isTab = isHotkey('tab', event);
-        const isShiftTab = !isTab;
-        event.preventDefault();
+    //   // Handle Tab
+    //   if (isHotkey('tab', event) || isHotkey('shift+tab', event)) {
+    //     const isTab = isHotkey('tab', event);
+    //     const isShiftTab = !isTab;
+    //     event.preventDefault();
 
-        const listOrListItem = editor.getListOrListItem({ force: true });
-        if (!listOrListItem) {
-          return next();
-        }
+    //     const listOrListItem = editor.getListOrListItem({ force: true });
+    //     if (!listOrListItem) {
+    //       return next();
+    //     }
 
-        if (listOrListItem.type === 'list-item') {
-          const listItem = listOrListItem;
-          if (isTab) {
-            return editor.indentListItems(listItem);
-          }
-          if (isShiftTab) {
-            return editor.unindentListItems(listItem);
-          }
-        } else {
-          const list = listOrListItem;
-          if (isTab) {
-            const listItems = editor.getSelectedChildren(list);
-            return editor.indentListItems(listItems);
-          }
-          if (isShiftTab) {
-            const listItems = editor.getSelectedChildren(list);
-            return editor.unindentListItems(listItems);
-          }
-        }
-        return next();
-      }
+    //     if (listOrListItem.type === 'list-item') {
+    //       const listItem = listOrListItem;
+    //       if (isTab) {
+    //         return editor.indentListItems(listItem);
+    //       }
+    //       if (isShiftTab) {
+    //         return editor.unindentListItems(listItem);
+    //       }
+    //     } else {
+    //       const list = listOrListItem;
+    //       if (isTab) {
+    //         const listItems = editor.getSelectedChildren(list);
+    //         return editor.indentListItems(listItems);
+    //       }
+    //       if (isShiftTab) {
+    //         const listItems = editor.getSelectedChildren(list);
+    //         return editor.unindentListItems(listItems);
+    //       }
+    //     }
+    //     return next();
+    //   }
 
-      // Handle Enter
-      if (isHotkey('enter', event)) {
-        const listOrListItem = editor.getListOrListItem();
-        if (!listOrListItem) {
-          return next();
-        }
+    //   // Handle Enter
+    //   if (isHotkey('enter', event)) {
+    //     const listOrListItem = editor.getListOrListItem();
+    //     if (!listOrListItem) {
+    //       return next();
+    //     }
 
-        if (editor.value.selection.isExpanded) {
-          editor.delete();
-        }
+    //     if (editor.value.selection.isExpanded) {
+    //       editor.delete();
+    //     }
 
-        if (listOrListItem.type === 'list-item') {
-          const listItem = listOrListItem;
+    //     if (listOrListItem.type === 'list-item') {
+    //       const listItem = listOrListItem;
 
-          // If focus is at start of list item, unwrap the entire list item.
-          if (editor.atStartOf(listItem)) {
-            return editor.unwrapListItem(listItem);
-          }
+    //       // If focus is at start of list item, unwrap the entire list item.
+    //       if (editor.atStartOf(listItem)) {
+    //         return editor.unwrapListItem(listItem);
+    //       }
 
-          // If focus is at start of a subsequent block in the list item, move
-          // everything after the cursor in the current list item to a new list
-          // item.
-          if (editor.atStartOf(editor.value.startBlock)) {
-            const newListItem = Block.create('list-item');
-            const range = Range.create(editor.value.selection).moveEndToEndOfNode(listItem);
+    //       // If focus is at start of a subsequent block in the list item, move
+    //       // everything after the cursor in the current list item to a new list
+    //       // item.
+    //       if (editor.atStartOf(editor.value.startBlock)) {
+    //         const newListItem = Block.create('list-item');
+    //         const range = Range.create(editor.value.selection).moveEndToEndOfNode(listItem);
 
-            return editor.withoutNormalizing(() => {
-              editor.wrapBlockAtRange(range, newListItem).unwrapNodeByKey(newListItem.key);
-            });
-          }
+    //         return editor.withoutNormalizing(() => {
+    //           editor.wrapBlockAtRange(range, newListItem).unwrapNodeByKey(newListItem.key);
+    //         });
+    //       }
 
-          return next();
-        } else {
-          const list = listOrListItem;
-          if (list.nodes.size === 0) {
-            return editor.removeNodeByKey(list.key);
-          }
-        }
-        return next();
-      }
-      return next();
-    },
+    //       return next();
+    //     } else {
+    //       const list = listOrListItem;
+    //       if (list.nodes.size === 0) {
+    //         return editor.removeNodeByKey(list.key);
+    //       }
+    //     }
+    //     return next();
+    //   }
+    //   return next();
+    // },
   };
 }
 

--- a/packages/netlify-cms-widget-markdown/src/MarkdownControl/renderers.js
+++ b/packages/netlify-cms-widget-markdown/src/MarkdownControl/renderers.js
@@ -87,13 +87,7 @@ const StyledUl = styled.ul`
 const StyledOl = StyledUl.withComponent('ol');
 
 const StyledLi = styled.li`
-  & > p:first-child {
-    margin-top: 8px;
-  }
-
-  & > p:last-child {
-    margin-bottom: 8px;
-  }
+  margin-top: 8px;
 `;
 
 const StyledA = styled.a`

--- a/packages/netlify-cms-widget-markdown/src/MarkdownControl/schema.js
+++ b/packages/netlify-cms-widget-markdown/src/MarkdownControl/schema.js
@@ -101,6 +101,7 @@ function schema({ voidCodeBlock } = {}) {
        */
       {
         match: [{ object: 'block', type: 'list-item' }],
+        next: [{ type: 'list-item' }],
         parent: [{ type: 'bulleted-list' }, { type: 'numbered-list' }],
       },
 

--- a/packages/netlify-cms-widget-markdown/src/MarkdownControl/schema.js
+++ b/packages/netlify-cms-widget-markdown/src/MarkdownControl/schema.js
@@ -73,7 +73,6 @@ function schema({ voidCodeBlock } = {}) {
       {
         match: [
           { object: 'block', type: 'quote' },
-          { object: 'block', type: 'list-item' },
         ],
         nodes: [
           {

--- a/packages/netlify-cms-widget-markdown/src/MarkdownControl/schema.js
+++ b/packages/netlify-cms-widget-markdown/src/MarkdownControl/schema.js
@@ -143,7 +143,7 @@ function schema({ voidCodeBlock } = {}) {
       },
 
       /**
-       * Bulleted List
+       * Bulleted List rules. These ensure that a bulleted list can only contain list items and never paragraph, or any other block types.
        */
       {
         match: [{ object: 'block', type: 'bulleted-list' }],

--- a/packages/netlify-cms-widget-markdown/src/MarkdownControl/schema.js
+++ b/packages/netlify-cms-widget-markdown/src/MarkdownControl/schema.js
@@ -71,9 +71,7 @@ function schema({ voidCodeBlock } = {}) {
        * Block Containers
        */
       {
-        match: [
-          { object: 'block', type: 'quote' },
-        ],
+        match: [{ object: 'block', type: 'quote' }],
         nodes: [
           {
             match: [
@@ -104,20 +102,18 @@ function schema({ voidCodeBlock } = {}) {
         next: [{ type: 'list-item' }],
         parent: [{ type: 'bulleted-list' }, { type: 'numbered-list' }],
         normalize: (editor, error) => {
-          const {document} = editor.value;
-          const {child} = error;
-          const sibling = document.getNextSibling(child.key)
-          switch(error.code) {
+          const { document } = editor.value;
+          const { child } = error;
+          const sibling = document.getNextSibling(child.key);
+          switch (error.code) {
             /* When the next sibling node in a list block is not of `list-item` type, move it out of the list block
              and into the top-level document block as a direct child.
             */
             case 'next_sibling_type_invalid':
-              editor.moveNodeByKey(sibling.key, document.key, document.nodes.size)
-              return
+              editor.moveNodeByKey(sibling.key, document.key, document.nodes.size);
+              return;
           }
-          
-          
-        }
+        },
       },
 
       /**

--- a/packages/netlify-cms-widget-markdown/src/MarkdownControl/schema.js
+++ b/packages/netlify-cms-widget-markdown/src/MarkdownControl/schema.js
@@ -103,6 +103,21 @@ function schema({ voidCodeBlock } = {}) {
         match: [{ object: 'block', type: 'list-item' }],
         next: [{ type: 'list-item' }],
         parent: [{ type: 'bulleted-list' }, { type: 'numbered-list' }],
+        normalize: (editor, error) => {
+          const {document} = editor.value;
+          const {child} = error;
+          const sibling = document.getNextSibling(child.key)
+          switch(error.code) {
+            /* When the next sibling node in a list block is not of `list-item` type, move it out of the list block
+             and into the top-level document block as a direct child.
+            */
+            case 'next_sibling_type_invalid':
+              editor.moveNodeByKey(sibling.key, document.key, document.nodes.size)
+              return
+          }
+          
+          
+        }
       },
 
       /**

--- a/packages/netlify-cms-widget-markdown/src/types.js
+++ b/packages/netlify-cms-widget-markdown/src/types.js
@@ -3,6 +3,6 @@ export const SLATE_DEFAULT_BLOCK_TYPE = 'paragraph';
 export const SLATE_BLOCK_PARENT_TYPES = ['list-item', 'quote'];
 
 export const SLATE_LIST_BLOCK_TYPES = {
-    parent: ['bulleted-list', 'numbered-list'],
-    children: 'list-item'
-}
+  parent: ['bulleted-list', 'numbered-list'],
+  children: 'list-item',
+};

--- a/packages/netlify-cms-widget-markdown/src/types.js
+++ b/packages/netlify-cms-widget-markdown/src/types.js
@@ -1,3 +1,8 @@
 export const SLATE_DEFAULT_BLOCK_TYPE = 'paragraph';
 
 export const SLATE_BLOCK_PARENT_TYPES = ['list-item', 'quote'];
+
+export const SLATE_LIST_BLOCK_TYPES = {
+    parent: ['bulleted-list', 'numbered-list'],
+    children: 'list-item'
+}


### PR DESCRIPTION
fixes #3474 
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines.

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first two fields are mandatory:
-->

## Summary
This PR fixes the current issue with list blocks in the rich text version of Netlify CMS editor. Namely, when the cursor is inside a list item of either a bulleted list or numbered list and hitting Enter/Return key, the editor should create another list item underneath, marked by either a dot icon or a number at the beginning.
<!--
Explain the **motivation** for making this change.
What existing problem does the pull request solve?
-->

## Task list

- [x]  Rewrite the schema so that a list item block only contains text node and no other blocks.
- [x]  Rewrite the `toggleList` command in the `List` plugin due to the schema change above.
- [x]  Modify the `BreakToDefaultBlock` plugin because it is called after the `List` plugin and will prevent creating a new list item block when hitting Enter on an existing list item block.
- [x]  Modify the `BreakToDefaultBlock` to set a list item that has no text as a paragraph block when hitting Enter inside it. *This is not mentioned in the issue* but I think this is a commonly expected behaviour with rich text editor.
- [x]  Add a normalize function for `list-item` nodes. When a next sibling node of `list-item` node is invalid, move it out of the current list bloc and into the top-level Document block
- [x]  Rewrite the query for checking for active list blocks due to schema change.

I've also commented out the `onKeyChange` handler in the `List` plugin because the schema has changed. This handler handles three keys: `Tab`, `Backspace` and `Enter`. I think I've covered `Enter` key enough but please tell me how I should rework this handler.

## Test plan

### Setting up
1. After running the app, go to `http://localhost:8080`.
2. Click on any of the pre-created blog post.
3. Toggle the text editor to rich text.
4. Place cursor at the end of the last line in the text editor and press Enter or Return key to create a new empty paragraph block.
5. Type anything in the new block.

### Turn a non-list block into a list block

1. Click the *bulleted-list* button in the toolbar. **Expect**: a bullet icon at the beginning of the block.
2. Inspect the block in the Developer Tool. **Expect**: The block is a `<ul>` element, which contains one `<li>` element whose text is the content you've typed in step 5.
3. With the cursor at the end of the list block just created, hit Enter.  **Expect**: Cursor moves to the next line which also includes a bullet icon at the beginning.

![turn-non-list-block-into-bulleted-list](https://user-images.githubusercontent.com/28924121/122042486-684d0080-ce04-11eb-918f-ccb5861a883d.gif)

Repeat the three steps above, but click the *numbered-list* button instead of *bulleted-list*. **Expect**: The parent block is a `<ol>` element whose children are `<li>` elements. Each `<li>` element is marked by a number in the beginning and the number is auto-incrementing.

![turn-non-list-block-into-numbered-list](https://user-images.githubusercontent.com/28924121/122042570-8581cf00-ce04-11eb-9122-20b3fb8ae4cc.gif)

### Turn a bulleted-list into numbered-list and vice versa

On an existing bulleted list item, click the *numbered-list* button. **Expect**: The bulleted-list item turns into a numbered list item. The parent block changes from `<ul>` to `<ol>`.

![turn-bulleted-list-into-numbered-list](https://user-images.githubusercontent.com/28924121/122042672-a3e7ca80-ce04-11eb-9a6f-08e9dd5af0ff.gif)

Do the same for a numbered list block.

### Turn a bulleted list or numbered list item into a paragraph

On an existing bulleted list item, click the *bulleted-list* button. **Expect**: The parent block changes from `<ul>` to `<p>` and it only contains text node. The `<li>` element disappears.

Do the same for a numbered list item.

### Hitting Enter key on an empty list item block turns it into a paragraph block and moves it out of the parent list block

1. With the cursor at the end of a list item, hit Enter to create another list item above.
2. Without typing anything, hit Enter again. **Expect**: The second list item, rendered as `<li>` element, turns into a `<p>` element, and it is moved out of the parent `<ul>` or `<ol>` element. It becomes a another child of the top-level Document object, and a sibling of the `<ul>` or `<ol>` block.

![hitting-enter-key-on-list-item-block-turns-into-paragraph](https://user-images.githubusercontent.com/28924121/122042846-dd203a80-ce04-11eb-9a8f-36cbe7fce674.gif)

<!--
Demonstrate the code is solid.
Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.
-->

