### PR TITLE
Fix: Hitting Enter key in a list item doesn't create a new list item [NO CHANGING SCHEMA]

### DIFF
--- a/cypress/integration/markdown_widget_list_spec.js
+++ b/cypress/integration/markdown_widget_list_spec.js
@@ -428,31 +428,6 @@ describe('Markdown widget', () => {
           `);
       });
 
-      it('creates a new paragraph in a non-empty paragraph within a list item', () => {
-        cy.clickUnorderedListButton()
-          .type('foo')
-          .enter()
-          .confirmMarkdownEditorContent(`
-            <ul>
-              <li>
-                <p>foo</p>
-                <p></p>
-              </li>
-            </ul>
-          `)
-          .type('bar')
-          .enter()
-          .confirmMarkdownEditorContent(`
-            <ul>
-              <li>
-                <p>foo</p>
-                <p>bar</p>
-                <p></p>
-              </li>
-            </ul>
-          `);
-      });
-
       it('creates a new list item in a non-empty list', () => {
         cy.clickUnorderedListButton()
           .type('foo')

--- a/cypress/integration/markdown_widget_list_spec.js
+++ b/cypress/integration/markdown_widget_list_spec.js
@@ -282,9 +282,9 @@ describe('Markdown widget', () => {
       it('affects only selected list items', () => {
         cy.clickUnorderedListButton()
           .type('foo')
-          .enter({ times: 2 })
+          .enter()
           .type('bar')
-          .enter({ times: 2 })
+          .enter()
           .type('baz')
           .setSelection('bar')
           .clickUnorderedListButton()
@@ -327,14 +327,69 @@ describe('Markdown widget', () => {
           `)
           .setSelection('baz')
           .clickUnorderedListButton()
+          .confirmMarkdownEditorContent(`
+            <ul>
+              <li>
+                <p>foo</p>
+              </li>
+              <li>
+                <p>bar</p>
+                <ul>
+                  <li>
+                    <p>baz</p>
+                  </li>
+                </ul>
+              </li>
+            </ul> 
+          `)
           .setCursorAfter('baz')
           .enter()
-          .clickUnorderedListButton()
+          .tabkey()
           .type('qux')
+          .confirmMarkdownEditorContent(`
+          <ul>
+            <li>
+              <p>foo</p>
+            </li>
+            <li>
+              <p>bar</p>
+              <ul>
+                <li>
+                  <p>baz</p>
+                  <ul>
+                    <li>
+                      <p>qux</p>
+                    </li>
+                  </ul>
+                </li>
+              </ul>
+            </li>
+          </ul>  
+          `)
           .setSelection('baz')
           .clickOrderedListButton()
+          .confirmMarkdownEditorContent(`
+          <ul>
+            <li>
+              <p>foo</p>
+            </li>
+            <li>
+              <p>bar</p>
+              <ol>
+                <li>
+                  <p>baz</p>
+                  <ul>
+                    <li>
+                      <p>qux</p>
+                    </li>
+                  </ul>
+                </li>
+              </ol>
+            </li>
+          </ul>  
+          `)
           .setCursorAfter('qux')
-          .enter({ times: 4 })
+          .enter({ times: 2 })
           .clickUnorderedListButton()
           .confirmMarkdownEditorContent(`
             <ul>

--- a/cypress/integration/markdown_widget_list_spec.js
+++ b/cypress/integration/markdown_widget_list_spec.js
@@ -105,10 +105,10 @@ describe('Markdown widget', () => {
         cy.clickUnorderedListButton()
           .type('foo')
           .enter()
-          .clickUnorderedListButton()
+          .tabkey()
           .type('bar')
           .enter()
-          .clickUnorderedListButton()
+          .tabkey()
           .type('baz')
           .clickUnorderedListButton()
           .confirmMarkdownEditorContent(`

--- a/cypress/integration/markdown_widget_list_spec.js
+++ b/cypress/integration/markdown_widget_list_spec.js
@@ -204,7 +204,7 @@ describe('Markdown widget', () => {
           .up()
           .enter()
           .type('qux')
-          .clickUnorderedListButton()
+          .tabkey()
           .confirmMarkdownEditorContent(`
             <ul>
               <li>
@@ -226,7 +226,6 @@ describe('Markdown widget', () => {
           .up()
           .enter()
           .type('quux')
-          .clickUnorderedListButton()
           .confirmMarkdownEditorContent(`
             <ul>
               <li>

--- a/cypress/integration/markdown_widget_list_spec.js
+++ b/cypress/integration/markdown_widget_list_spec.js
@@ -35,45 +35,6 @@ describe('Markdown widget', () => {
           `);
       });
 
-      it('creates nested list when selection is collapsed in non-first block of list item', () => {
-        cy.clickUnorderedListButton()
-          .type('foo')
-          .enter()
-          .clickUnorderedListButton()
-          .confirmMarkdownEditorContent(`
-            <ul>
-              <li>
-                <p>foo</p>
-                <ul>
-                  <li>
-                    <p></p>
-                  </li>
-                </ul>
-              </li>
-            </ul>
-          `)
-          .type('bar')
-          .enter()
-          .clickUnorderedListButton()
-          .confirmMarkdownEditorContent(`
-            <ul>
-              <li>
-                <p>foo</p>
-                <ul>
-                  <li>
-                    <p>bar</p>
-                    <ul>
-                      <li>
-                        <p></p>
-                      </li>
-                    </ul>
-                  </li>
-                </ul>
-              </li>
-            </ul>
-          `);
-      });
-
       it('converts empty nested list item to empty block in parent list item', () => {
         cy.clickUnorderedListButton()
           .type('foo')

--- a/cypress/integration/markdown_widget_list_spec.js
+++ b/cypress/integration/markdown_widget_list_spec.js
@@ -627,10 +627,10 @@ describe('Markdown widget', () => {
       it('indents and unindents from one level below parent back to document root', () => {
         cy.clickUnorderedListButton()
           .type('foo')
-          .enter({ times: 2 })
+          .enter()
           .tabkey()
           .type('bar')
-          .enter({ times: 2 })
+          .enter()
           .tabkey()
           .type('baz')
           .confirmMarkdownEditorContent(`

--- a/cypress/integration/markdown_widget_list_spec.js
+++ b/cypress/integration/markdown_widget_list_spec.js
@@ -35,6 +35,21 @@ describe('Markdown widget', () => {
           `);
       });
 
+      it('converts a list item to a paragraph block which is a sibling of the parent list', () => {
+        cy.clickUnorderedListButton()
+          .type('foo')
+          .enter()
+          .clickUnorderedListButton()
+          .confirmMarkdownEditorContent(`
+            <ul>
+              <li>
+                <p>foo</p>
+              </li>
+            </ul>
+            <p></p>
+          `)
+      });
+
       it('converts empty nested list item to empty block in parent list item', () => {
         cy.clickUnorderedListButton()
           .type('foo')

--- a/cypress/integration/markdown_widget_list_spec.js
+++ b/cypress/integration/markdown_widget_list_spec.js
@@ -544,7 +544,7 @@ describe('Markdown widget', () => {
       it('indents nested list items', () => {
         cy.clickUnorderedListButton()
           .type('foo')
-          .enter({ times: 2 })
+          .enter()
           .type('bar')
           .tabkey()
           .confirmMarkdownEditorContent(`
@@ -559,7 +559,7 @@ describe('Markdown widget', () => {
               </li>
             </ul>
           `)
-          .enter({ times: 2 })
+          .enter()
           .tabkey()
           .confirmMarkdownEditorContent(`
             <ul>

--- a/cypress/integration/markdown_widget_list_spec.js
+++ b/cypress/integration/markdown_widget_list_spec.js
@@ -483,20 +483,6 @@ describe('Markdown widget', () => {
           `);
       });
 
-      it('removes empty block in non-empty list item', () => {
-        cy.clickUnorderedListButton()
-          .type('foo')
-          .enter()
-          .backspace()
-          .confirmMarkdownEditorContent(`
-            <ul>
-              <li>
-                <p>foo</p>
-              </li>
-            </ul>
-          `);
-      });
-
       it('removes the list item if list not empty', () => {
         cy.clickUnorderedListButton()
           .type('foo')

--- a/cypress/integration/markdown_widget_list_spec.js
+++ b/cypress/integration/markdown_widget_list_spec.js
@@ -452,10 +452,10 @@ describe('Markdown widget', () => {
           `);
       });
 
-      it('creates a new block below list', () => {
+      it('creates a new default block below a list when hitting Enter twice on an empty list item of the list', () => {
         cy.clickUnorderedListButton()
           .type('foo')
-          .enter({ times: 3 })
+          .enter({ times: 2 })
           .confirmMarkdownEditorContent(`
             <ul>
               <li>

--- a/cypress/integration/markdown_widget_list_spec.js
+++ b/cypress/integration/markdown_widget_list_spec.js
@@ -609,7 +609,7 @@ describe('Markdown widget', () => {
       it('unindents nested list items with shift', () => {
         cy.clickUnorderedListButton()
           .type('foo')
-          .enter({ times: 2 })
+          .enter()
           .tabkey()
           .tabkey({ shift: true })
           .confirmMarkdownEditorContent(`

--- a/cypress/integration/markdown_widget_list_spec.js
+++ b/cypress/integration/markdown_widget_list_spec.js
@@ -590,8 +590,8 @@ describe('Markdown widget', () => {
       it('only nests up to one level down from the parent list', () => {
         cy.clickUnorderedListButton()
           .type('foo')
-          .enter({ times: 2 })
-          .tabkey({ times: 5 })
+          .enter()
+          .tabkey()
           .confirmMarkdownEditorContent(`
             <ul>
               <li>

--- a/cypress/integration/markdown_widget_list_spec.js
+++ b/cypress/integration/markdown_widget_list_spec.js
@@ -453,10 +453,10 @@ describe('Markdown widget', () => {
           `);
       });
 
-      it('creates a new list item in an empty paragraph within a non-empty list item', () => {
+      it('creates a new list item in a non-empty list', () => {
         cy.clickUnorderedListButton()
           .type('foo')
-          .enter({ times: 2 })
+          .enter()
           .confirmMarkdownEditorContent(`
             <ul>
               <li>
@@ -476,6 +476,8 @@ describe('Markdown widget', () => {
               </li>
               <li>
                 <p>bar</p>
+              </li>
+              <li>
                 <p></p>
               </li>
             </ul>

--- a/cypress/integration/markdown_widget_list_spec.js
+++ b/cypress/integration/markdown_widget_list_spec.js
@@ -50,14 +50,14 @@ describe('Markdown widget', () => {
           `)
       });
 
-      it('converts empty nested list item to empty block in parent list item', () => {
+      it('converts empty nested list item to empty paragraph block in parent list item', () => {
         cy.clickUnorderedListButton()
           .type('foo')
           .enter()
-          .clickUnorderedListButton()
+          .tabkey()
           .type('bar')
           .enter()
-          .clickUnorderedListButton()
+          .tabkey()
           .confirmMarkdownEditorContent(`
             <ul>
               <li>

--- a/cypress/integration/markdown_widget_list_spec.js
+++ b/cypress/integration/markdown_widget_list_spec.js
@@ -500,7 +500,7 @@ describe('Markdown widget', () => {
       it('removes the list item if list not empty', () => {
         cy.clickUnorderedListButton()
           .type('foo')
-          .enter({ times: 2 })
+          .enter()
           .backspace()
           .confirmMarkdownEditorContent(`
             <ul>

--- a/cypress/integration/markdown_widget_quote_spec.js
+++ b/cypress/integration/markdown_widget_quote_spec.js
@@ -59,8 +59,8 @@ describe('Markdown widget', () => {
           .clickUnorderedListButton()
           .clickHeadingOneButton()
           .type('foo')
-          .enter({ times: 3 })
-          .clickQuoteButton()
+          .enter({ times: 2 }) // First Enter creates new list item. Second Enter turns that list item into a default block.
+          .clickQuoteButton() // Unwrap the quote block.
           .confirmMarkdownEditorContent(`
             <ul>
               <li>

--- a/cypress/integration/markdown_widget_quote_spec.js
+++ b/cypress/integration/markdown_widget_quote_spec.js
@@ -126,7 +126,7 @@ describe('Markdown widget', () => {
         cy.focused()
           .clickUnorderedListButton()
           .type('foo')
-          .enter({ times: 2 })
+          .enter()
           .type('bar')
           .setSelection('foo', 'bar')
           .clickQuoteButton()
@@ -154,7 +154,7 @@ describe('Markdown widget', () => {
             </ul>
           `)
           .setCursorAfter('bar')
-          .enter({ times: 2 })
+          .enter()
           .type('baz')
           .setSelection('bar', 'baz')
           .clickQuoteButton()

--- a/cypress/integration/markdown_widget_quote_spec.js
+++ b/cypress/integration/markdown_widget_quote_spec.js
@@ -185,6 +185,38 @@ describe('Markdown widget', () => {
           .clickUnorderedListButton()
           .clickQuoteButton()
           .type('foo')
+          // Content should contains 4 <blockquote> tags and 3 <ul> tags
+          .confirmMarkdownEditorContent(`
+            <blockquote>
+              <ul>
+                <li>
+                  <blockquote>
+                    <ul>
+                      <li>
+                        <blockquote>
+                          <ul>
+                            <li>
+                              <blockquote>
+                                <p>foo</p>
+                              </blockquote>
+                            </li>
+                          </ul>
+                        </blockquote>
+                      </li>
+                    </ul>
+                  </blockquote>
+                </li>
+              </ul>
+            </blockquote> 
+          `)
+          /*
+           * First Enter creates new paragraph within the innermost block quote.
+           * Second Enter moves that paragraph one level up to become sibling of the previous quote block and direct child of a list item.
+           * Third Enter to turn that paragraph into a list item and move it one level up.
+           * Repeat the circle for three more times to reach the second list item of the outermost list block.
+           * Then Enter again to turn that list item into a paragraph and move it one level up to become sibling of the outermost list and
+           * direct child of the outermost block quote.
+          */
           .enter({ times: 10 })
           .type('bar')
           .confirmMarkdownEditorContent(`
@@ -211,7 +243,16 @@ describe('Markdown widget', () => {
               <p>bar</p>
             </blockquote>
           `)
-          .backspace({ times: 12 })
+          /* The GOAL is to delete all the text content inside this deeply nested block quote and turn it into a default paragraph block on top level.
+           * We need:
+           *  3 Backspace to delete the word “bar”.
+           *  1 Backspace to remove the paragraph that contains bar and bring cursor to the end of the unordered list which is direct child of the outermost block quote.
+           *  3 Backspace to remove the word “foo”.
+           *  1 Backspace to remove the current block quote that the cursor is on, 1 Backspace to remove the list that wraps the block quote. Repeat this step for three times for a total of 6 Backspace until the cursor is on the outermost block quote.
+           * 1 Backspace to remove to toggle off the outermost block quote and turn it into a default paragraph.
+           * Total Backspaces required: 3 + 1 + 3 + ((1 + 1) * 3) + 1 = 14
+          */
+          .backspace({ times: 14 })
       });
     });
 

--- a/packages/netlify-cms-widget-markdown/src/MarkdownControl/plugins/BreakToDefaultBlock.js
+++ b/packages/netlify-cms-widget-markdown/src/MarkdownControl/plugins/BreakToDefaultBlock.js
@@ -3,7 +3,7 @@ import isHotkey from 'is-hotkey';
 function BreakToDefaultBlock({ defaultType }) {
   return {
     onKeyDown(event, editor, next) {
-      const { selection, startBlock } = editor.value;
+      const { selection, startBlock, document } = editor.value;
       const isEnter = isHotkey('enter', event);
       if (!isEnter) {
         return next();
@@ -12,6 +12,11 @@ function BreakToDefaultBlock({ defaultType }) {
         editor.delete();
         return next();
       }
+      /** If the block that receives the Enter key is a child of a list item block, we'll
+        * skip this plugin and create a new list item block underneath instead.
+      */
+      const parent = document.getParent(startBlock.key);
+      if (parent.type === 'list-item') return next();
       if (selection.start.isAtEndOfNode(startBlock) && startBlock.type !== defaultType) {
         return editor.insertBlock(defaultType);
       }

--- a/packages/netlify-cms-widget-markdown/src/MarkdownControl/plugins/BreakToDefaultBlock.js
+++ b/packages/netlify-cms-widget-markdown/src/MarkdownControl/plugins/BreakToDefaultBlock.js
@@ -13,8 +13,8 @@ function BreakToDefaultBlock({ defaultType }) {
         return next();
       }
       /** If the block that receives the Enter key is a child of a list item block, we'll
-        * skip this plugin and create a new list item block underneath instead.
-      */
+       * skip this plugin and create a new list item block underneath instead.
+       */
       const parent = document.getParent(startBlock.key);
       if (parent.type === 'list-item') return next();
       if (selection.start.isAtEndOfNode(startBlock) && startBlock.type !== defaultType) {

--- a/packages/netlify-cms-widget-markdown/src/MarkdownControl/plugins/BreakToDefaultBlock.js
+++ b/packages/netlify-cms-widget-markdown/src/MarkdownControl/plugins/BreakToDefaultBlock.js
@@ -3,7 +3,7 @@ import isHotkey from 'is-hotkey';
 function BreakToDefaultBlock({ defaultType }) {
   return {
     onKeyDown(event, editor, next) {
-      const { selection, startBlock, document } = editor.value;
+      const { selection, startBlock } = editor.value;
       const isEnter = isHotkey('enter', event);
       if (!isEnter) {
         return next();
@@ -12,11 +12,6 @@ function BreakToDefaultBlock({ defaultType }) {
         editor.delete();
         return next();
       }
-      /** If the block that receives the Enter key is a child of a list item block, we'll
-       * skip this plugin and create a new list item block underneath instead.
-       */
-      const parent = document.getParent(startBlock.key);
-      if (parent.type === 'list-item') return next();
       if (selection.start.isAtEndOfNode(startBlock) && startBlock.type !== defaultType) {
         return editor.insertBlock(defaultType);
       }

--- a/packages/netlify-cms-widget-markdown/src/MarkdownControl/plugins/List.js
+++ b/packages/netlify-cms-widget-markdown/src/MarkdownControl/plugins/List.js
@@ -268,7 +268,8 @@ function ListPlugin({ defaultType, unorderedListType, orderedListType }) {
 
         if (listOrListItem.type === 'list-item') {
           const listItem = listOrListItem;
-
+          console.log({listItem})
+          const {value: {document}} = editor;
           // If focus is at start of list item, unwrap the entire list item.
           if (editor.atStartOf(listItem)) {
             return editor.unwrapListItem(listItem);
@@ -285,7 +286,11 @@ function ListPlugin({ defaultType, unorderedListType, orderedListType }) {
               editor.wrapBlockAtRange(range, newListItem).unwrapNodeByKey(newListItem.key);
             });
           }
-
+          const list = document.getParent(listItem.key)
+          if (LIST_TYPES.includes(list.type)) {
+            const newListItem = Block.create({type: 'list-item', nodes: [Block.create('paragraph')]})
+            return editor.insertNodeByKey(list.key, list.nodes.size, newListItem).moveToEndOfDocument()
+          }
           return next();
         } else {
           const list = listOrListItem;

--- a/packages/netlify-cms-widget-markdown/src/MarkdownControl/plugins/List.js
+++ b/packages/netlify-cms-widget-markdown/src/MarkdownControl/plugins/List.js
@@ -292,12 +292,21 @@ function ListPlugin({ defaultType, unorderedListType, orderedListType }) {
              *    </ul>
              *  </li>
              * </ul>
-            */ 
-            const closestAncestorList = document.getClosest(parentList.key, block => block.type === parentList.type);
+             */
+            const closestAncestorList = document.getClosest(
+              parentList.key,
+              block => block.type === parentList.type,
+            );
             if (closestAncestorList) {
               const closestAncestorListItem = document.getParent(parentList.key);
-              const indexOfClosestAncestorListItem = closestAncestorList.nodes.findIndex(node => node.key === closestAncestorListItem.key)
-              return editor.moveNodeByKey(listItem.key, closestAncestorList.key, indexOfClosestAncestorListItem + 1);
+              const indexOfClosestAncestorListItem = closestAncestorList.nodes.findIndex(
+                node => node.key === closestAncestorListItem.key,
+              );
+              return editor.moveNodeByKey(
+                listItem.key,
+                closestAncestorList.key,
+                indexOfClosestAncestorListItem + 1,
+              );
             }
             return editor.unwrapListItem(listItem);
           }
@@ -320,15 +329,17 @@ function ListPlugin({ defaultType, unorderedListType, orderedListType }) {
               nodes: [Block.create('paragraph')],
             });
             // Check if the targeted list item contains a nested list. If it does, insert a new list item in the beginning of that nested list.
-            const nestedList = listItem.findDescendant(block => block.type === LIST_TYPES[0] || block.type === LIST_TYPES[1]);
+            const nestedList = listItem.findDescendant(
+              block => block.type === LIST_TYPES[0] || block.type === LIST_TYPES[1],
+            );
             if (nestedList) {
-              return editor.insertNodeByKey(nestedList.key, 0, newListItem).moveForward(1) // Each list item is separated by a \n character. We need to move the cursor past this character so that it'd be on new list item that has just been inserted
+              return editor.insertNodeByKey(nestedList.key, 0, newListItem).moveForward(1); // Each list item is separated by a \n character. We need to move the cursor past this character so that it'd be on new list item that has just been inserted
             }
             // Find index of the list item block that receives Enter key
-            const previousListItemIndex = list.nodes.findIndex(block => block.key === listItem.key)
+            const previousListItemIndex = list.nodes.findIndex(block => block.key === listItem.key);
             return editor
               .insertNodeByKey(list.key, previousListItemIndex + 1, newListItem) // insert a new list item after the list item above
-              .moveForward(1)
+              .moveForward(1);
           }
           return next();
         } else {

--- a/packages/netlify-cms-widget-markdown/src/MarkdownControl/plugins/List.js
+++ b/packages/netlify-cms-widget-markdown/src/MarkdownControl/plugins/List.js
@@ -293,9 +293,8 @@ function ListPlugin({ defaultType, unorderedListType, orderedListType }) {
              *  </li>
              * </ul>
              */
-            const closestAncestorList = document.getClosest(
-              parentList.key,
-              block => block.type === (LIST_TYPES[0] || LIST_TYPES[1]),
+            const closestAncestorList = document.getClosest(parentList.key, block =>
+              LIST_TYPES.includes(block.type),
             );
             if (closestAncestorList) {
               const closestAncestorListItem = document.getParent(parentList.key);
@@ -329,9 +328,7 @@ function ListPlugin({ defaultType, unorderedListType, orderedListType }) {
               nodes: [Block.create('paragraph')],
             });
             // Check if the targeted list item contains a nested list. If it does, insert a new list item in the beginning of that nested list.
-            const nestedList = listItem.findDescendant(
-              block => block.type === LIST_TYPES[0] || block.type === LIST_TYPES[1],
-            );
+            const nestedList = listItem.findDescendant(block => LIST_TYPES.includes(block.type));
             if (nestedList) {
               return editor.insertNodeByKey(nestedList.key, 0, newListItem).moveForward(1); // Each list item is separated by a \n character. We need to move the cursor past this character so that it'd be on new list item that has just been inserted
             }

--- a/packages/netlify-cms-widget-markdown/src/MarkdownControl/plugins/List.js
+++ b/packages/netlify-cms-widget-markdown/src/MarkdownControl/plugins/List.js
@@ -294,9 +294,11 @@ function ListPlugin({ defaultType, unorderedListType, orderedListType }) {
               type: 'list-item',
               nodes: [Block.create('paragraph')],
             });
+            // Find index of the list item block that receives Enter key
+            const previousListItemIndex = list.nodes.findIndex(block => block.key === listItem.key)
             return editor
-              .insertNodeByKey(list.key, list.nodes.size, newListItem)
-              .moveToEndOfDocument();
+              .insertNodeByKey(list.key, previousListItemIndex + 1, newListItem) // insert a new list item after the list item above
+              .moveForward(1) // Each list item is separated by a \n character. We need to move the cursor past this character so that it'd be on new list item that has just been inserted
           }
           return next();
         } else {

--- a/packages/netlify-cms-widget-markdown/src/MarkdownControl/plugins/List.js
+++ b/packages/netlify-cms-widget-markdown/src/MarkdownControl/plugins/List.js
@@ -295,7 +295,7 @@ function ListPlugin({ defaultType, unorderedListType, orderedListType }) {
              */
             const closestAncestorList = document.getClosest(
               parentList.key,
-              block => block.type === parentList.type,
+              block => block.type === (LIST_TYPES[0] || LIST_TYPES[1]),
             );
             if (closestAncestorList) {
               const closestAncestorListItem = document.getParent(parentList.key);

--- a/packages/netlify-cms-widget-markdown/src/MarkdownControl/plugins/List.js
+++ b/packages/netlify-cms-widget-markdown/src/MarkdownControl/plugins/List.js
@@ -294,11 +294,16 @@ function ListPlugin({ defaultType, unorderedListType, orderedListType }) {
               type: 'list-item',
               nodes: [Block.create('paragraph')],
             });
+            // Check if the targeted list item contains a nested list. If it does, insert a new list item in the beginning of that nested list.
+            const nestedList = listItem.findDescendant(block => block.type === LIST_TYPES[0] || block.type === LIST_TYPES[1]);
+            if (nestedList) {
+              return editor.insertNodeByKey(nestedList.key, 0, newListItem).moveForward(1) // Each list item is separated by a \n character. We need to move the cursor past this character so that it'd be on new list item that has just been inserted
+            }
             // Find index of the list item block that receives Enter key
             const previousListItemIndex = list.nodes.findIndex(block => block.key === listItem.key)
             return editor
               .insertNodeByKey(list.key, previousListItemIndex + 1, newListItem) // insert a new list item after the list item above
-              .moveForward(1) // Each list item is separated by a \n character. We need to move the cursor past this character so that it'd be on new list item that has just been inserted
+              .moveForward(1)
           }
           return next();
         } else {

--- a/packages/netlify-cms-widget-markdown/src/MarkdownControl/plugins/List.js
+++ b/packages/netlify-cms-widget-markdown/src/MarkdownControl/plugins/List.js
@@ -268,8 +268,10 @@ function ListPlugin({ defaultType, unorderedListType, orderedListType }) {
 
         if (listOrListItem.type === 'list-item') {
           const listItem = listOrListItem;
-          console.log({listItem})
-          const {value: {document}} = editor;
+          console.log({ listItem });
+          const {
+            value: { document },
+          } = editor;
           // If focus is at start of list item, unwrap the entire list item.
           if (editor.atStartOf(listItem)) {
             return editor.unwrapListItem(listItem);
@@ -286,10 +288,15 @@ function ListPlugin({ defaultType, unorderedListType, orderedListType }) {
               editor.wrapBlockAtRange(range, newListItem).unwrapNodeByKey(newListItem.key);
             });
           }
-          const list = document.getParent(listItem.key)
+          const list = document.getParent(listItem.key);
           if (LIST_TYPES.includes(list.type)) {
-            const newListItem = Block.create({type: 'list-item', nodes: [Block.create('paragraph')]})
-            return editor.insertNodeByKey(list.key, list.nodes.size, newListItem).moveToEndOfDocument()
+            const newListItem = Block.create({
+              type: 'list-item',
+              nodes: [Block.create('paragraph')],
+            });
+            return editor
+              .insertNodeByKey(list.key, list.nodes.size, newListItem)
+              .moveToEndOfDocument();
           }
           return next();
         } else {

--- a/packages/netlify-cms-widget-markdown/src/MarkdownControl/plugins/List.js
+++ b/packages/netlify-cms-widget-markdown/src/MarkdownControl/plugins/List.js
@@ -273,37 +273,35 @@ function ListPlugin({ defaultType, unorderedListType, orderedListType }) {
           } = editor;
           // If focus is at start of list item, unwrap the entire list item.
           if (editor.atStartOf(listItem)) {
-            const parentList = document.getParent(listItem.key);
             /* If the list item in question has a grandparent list, this means it is a child of a nested list.
-             * Htting Enter key on an empty nested list item like this should move that list item out of the nested list
-             * and into the gradparent list. The targeted list item becomes direct child of its grandparent list
+             * Hitting Enter key on an empty nested list item like this should move that list item out of the nested list
+             * and into the grandparent list. The targeted list item becomes direct child of its grandparent list
              * Example
-             * <ul> ----- CLOSEST ANCESTOR LIST
-             *  <li> ------ CLOESET ANCESTOR LIST ITEM
+             * <ul> ----- GRANDPARENT LIST
+             *  <li> ------ GRANDPARENT LIST ITEM
              *    <p>foo</p>
              *    <ul> ----- PARENT LIST
              *      <li>
              *        <p>bar</p>
              *      </li>
-             *      <li>
+             *      <li> ------ LIST ITEM
              *        <p></p> ----- WHERE THE ENTER KEY HAPPENS
              *      </li>
              *    </ul>
              *  </li>
              * </ul>
              */
-            const closestAncestorList = document.getClosest(parentList.key, block =>
-              LIST_TYPES.includes(block.type),
-            );
-            if (closestAncestorList) {
-              const closestAncestorListItem = document.getParent(parentList.key);
-              const indexOfClosestAncestorListItem = closestAncestorList.nodes.findIndex(
-                node => node.key === closestAncestorListItem.key,
+            const parentList = document.getParent(listItem.key);
+            const grandparentListItem = document.getParent(parentList.key);
+            if (grandparentListItem.type === 'list-item') {
+              const grandparentList = document.getParent(grandparentListItem.key);
+              const indexOfGrandparentListItem = grandparentList.nodes.findIndex(
+                node => node.key === grandparentListItem.key,
               );
               return editor.moveNodeByKey(
                 listItem.key,
-                closestAncestorList.key,
-                indexOfClosestAncestorListItem + 1,
+                grandparentList.key,
+                indexOfGrandparentListItem + 1,
               );
             }
             return editor.unwrapListItem(listItem);

--- a/packages/netlify-cms-widget-markdown/src/MarkdownControl/plugins/List.js
+++ b/packages/netlify-cms-widget-markdown/src/MarkdownControl/plugins/List.js
@@ -268,7 +268,6 @@ function ListPlugin({ defaultType, unorderedListType, orderedListType }) {
 
         if (listOrListItem.type === 'list-item') {
           const listItem = listOrListItem;
-          console.log({ listItem });
           const {
             value: { document },
           } = editor;

--- a/packages/netlify-cms-widget-markdown/src/MarkdownControl/plugins/List.js
+++ b/packages/netlify-cms-widget-markdown/src/MarkdownControl/plugins/List.js
@@ -274,6 +274,31 @@ function ListPlugin({ defaultType, unorderedListType, orderedListType }) {
           } = editor;
           // If focus is at start of list item, unwrap the entire list item.
           if (editor.atStartOf(listItem)) {
+            const parentList = document.getParent(listItem.key);
+            /* If the list item in question has a grandparent list, this means it is a child of a nested list.
+             * Htting Enter key on an empty nested list item like this should move that list item out of the nested list
+             * and into the gradparent list. The targeted list item becomes direct child of its grandparent list
+             * Example
+             * <ul> ----- CLOSEST ANCESTOR LIST
+             *  <li> ------ CLOESET ANCESTOR LIST ITEM
+             *    <p>foo</p>
+             *    <ul> ----- PARENT LIST
+             *      <li>
+             *        <p>bar</p>
+             *      </li>
+             *      <li>
+             *        <p></p> ----- WHERE THE ENTER KEY HAPPENS
+             *      </li>
+             *    </ul>
+             *  </li>
+             * </ul>
+            */ 
+            const closestAncestorList = document.getClosest(parentList.key, block => block.type === parentList.type);
+            if (closestAncestorList) {
+              const closestAncestorListItem = document.getParent(parentList.key);
+              const indexOfClosestAncestorListItem = closestAncestorList.nodes.findIndex(node => node.key === closestAncestorListItem.key)
+              return editor.moveNodeByKey(listItem.key, closestAncestorList.key, indexOfClosestAncestorListItem + 1);
+            }
             return editor.unwrapListItem(listItem);
           }
 


### PR DESCRIPTION
fixes #3474 
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines.

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first two fields are mandatory:
-->

## Summary
A different approach to the above issue without changing the underlying schema.
<!--
Explain the **motivation** for making this change.
What existing problem does the pull request solve?
-->

## To-dos

- [x] Create a new list item below when hitting Enter key on a list item.
- [x] Fix tests for toolbar button
- [x] Fix tests for Enter key
- [x] Insert a new list item at the beginning of a nested list when pressing Enter key on parent list
- [x] Modify Enter key handler to account for case when the list item is not the last child in its parent list
- [x] Fix Enter key on nested list item
- [x] Fix tests for Backspace key
- [x] Fix tests for Tab key

## Test plan

### Setting up
1. After running the app, go to http://localhost:8080.
2. Click on any of the pre-created blog post.
3. Toggle the text editor to rich text.
4. Place cursor at the end of the last line in the text editor and press Enter or Return key to create a new empty paragraph block.
5. Type anything in the new block.

### Toggling list block
1. With the cursor in any block you want, click the Bulleted List button to turn a block into a bulleted list.
2. Move cursor to the end of the bulleted list item block and hit Enter.
3. *Expect*: A new list item underneath, marked by a bullet icon.
4. Inspect the element in the Developer Tools. *Expect*: Under the block that receives the Enter key is a new `<li> element containing a `<p>` element that wraps a text node .

![insert-list-item-with-old-schema](https://user-images.githubusercontent.com/28924121/123774758-f0003800-d8f7-11eb-94d1-35fb140b529b.gif)


<!--
Demonstrate the code is solid.
Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.
-->
