### PR TITLE
Fix: Copy Path does not reflect the real path of the object in the media folder

### DIFF
--- a/packages/netlify-cms-core/src/components/MediaLibrary/MediaLibrary.js
+++ b/packages/netlify-cms-core/src/components/MediaLibrary/MediaLibrary.js
@@ -316,6 +316,7 @@ class MediaLibrary extends React.Component {
       privateUpload,
       displayURLs,
       t,
+      mediaFolder,
     } = this.props;
 
     return (
@@ -350,6 +351,7 @@ class MediaLibrary extends React.Component {
         displayURLs={displayURLs}
         loadDisplayURL={this.loadDisplayURL}
         t={t}
+        mediaFolder={mediaFolder}
       />
     );
   }
@@ -357,6 +359,7 @@ class MediaLibrary extends React.Component {
 
 function mapStateToProps(state) {
   const { mediaLibrary } = state;
+  const mediaFolder = state.config.media_folder;
   const field = mediaLibrary.get('field');
   const mediaLibraryProps = {
     isVisible: mediaLibrary.get('isVisible'),
@@ -376,6 +379,7 @@ function mapStateToProps(state) {
     hasNextPage: mediaLibrary.get('hasNextPage'),
     isPaginating: mediaLibrary.get('isPaginating'),
     field,
+    mediaFolder,
   };
   return { ...mediaLibraryProps };
 }

--- a/packages/netlify-cms-core/src/components/MediaLibrary/MediaLibraryButtons.js
+++ b/packages/netlify-cms-core/src/components/MediaLibrary/MediaLibraryButtons.js
@@ -89,7 +89,8 @@ export class CopyToClipBoardButton extends React.Component {
 
   handleCopy = () => {
     clearTimeout(this.timeout);
-    const { path, draft, name } = this.props;
+    const { draft, name } = this.props;
+    const path = `/${this.props.path}`
     copyToClipboard(isAbsolutePath(path) || !draft ? path : name);
     this.setState({ copied: true });
     this.timeout = setTimeout(() => this.mounted && this.setState({ copied: false }), 1500);

--- a/packages/netlify-cms-core/src/components/MediaLibrary/MediaLibraryButtons.js
+++ b/packages/netlify-cms-core/src/components/MediaLibrary/MediaLibraryButtons.js
@@ -94,7 +94,7 @@ export class CopyToClipBoardButton extends React.Component {
     if (isAbsolutePath(path)) {
       copyToClipboard(path);
     } else {
-      path = mediaFolder.charAt(0) === '/' ? `/${path}` : path;
+      path = mediaFolder.charAt(0) === '/' && path.charAt(0) !== '/' ? `/${path}` : path;
       copyToClipboard(!draft ? path : name);
     }
     this.setState({ copied: true });

--- a/packages/netlify-cms-core/src/components/MediaLibrary/MediaLibraryButtons.js
+++ b/packages/netlify-cms-core/src/components/MediaLibrary/MediaLibraryButtons.js
@@ -89,13 +89,13 @@ export class CopyToClipBoardButton extends React.Component {
 
   handleCopy = () => {
     clearTimeout(this.timeout);
-    const { draft, name } = this.props;
+    const { draft, name, mediaFolder } = this.props;
     let path = this.props.path;
     if (isAbsolutePath(path)) {
       copyToClipboard(path);
     } else {
-      path = path.charAt(0) !== '/' ? `/${path}` : path;
-      copyToClipboard( !draft ? path : name);
+      path = mediaFolder.charAt(0) === '/' ? `/${path}` : path;
+      copyToClipboard(!draft ? path : name);
     }
     this.setState({ copied: true });
     this.timeout = setTimeout(() => this.mounted && this.setState({ copied: false }), 1500);

--- a/packages/netlify-cms-core/src/components/MediaLibrary/MediaLibraryButtons.js
+++ b/packages/netlify-cms-core/src/components/MediaLibrary/MediaLibraryButtons.js
@@ -90,7 +90,7 @@ export class CopyToClipBoardButton extends React.Component {
   handleCopy = () => {
     clearTimeout(this.timeout);
     const { draft, name } = this.props;
-    const path = `/${this.props.path}`;
+    const path = this.props.path.charAt(0) !== '/' ? `/${this.props.path}` : this.props.path;
     copyToClipboard(isAbsolutePath(path) || !draft ? path : name);
     this.setState({ copied: true });
     this.timeout = setTimeout(() => this.mounted && this.setState({ copied: false }), 1500);

--- a/packages/netlify-cms-core/src/components/MediaLibrary/MediaLibraryButtons.js
+++ b/packages/netlify-cms-core/src/components/MediaLibrary/MediaLibraryButtons.js
@@ -90,7 +90,7 @@ export class CopyToClipBoardButton extends React.Component {
   handleCopy = () => {
     clearTimeout(this.timeout);
     const { draft, name } = this.props;
-    const path = `/${this.props.path}`
+    const path = `/${this.props.path}`;
     copyToClipboard(isAbsolutePath(path) || !draft ? path : name);
     this.setState({ copied: true });
     this.timeout = setTimeout(() => this.mounted && this.setState({ copied: false }), 1500);

--- a/packages/netlify-cms-core/src/components/MediaLibrary/MediaLibraryButtons.js
+++ b/packages/netlify-cms-core/src/components/MediaLibrary/MediaLibraryButtons.js
@@ -90,8 +90,13 @@ export class CopyToClipBoardButton extends React.Component {
   handleCopy = () => {
     clearTimeout(this.timeout);
     const { draft, name } = this.props;
-    const path = this.props.path.charAt(0) !== '/' ? `/${this.props.path}` : this.props.path;
-    copyToClipboard(isAbsolutePath(path) || !draft ? path : name);
+    let path = this.props.path;
+    if (isAbsolutePath(path)) {
+      copyToClipboard(path);
+    } else {
+      path = path.charAt(0) !== '/' ? `/${path}` : path;
+      copyToClipboard( !draft ? path : name);
+    }
     this.setState({ copied: true });
     this.timeout = setTimeout(() => this.mounted && this.setState({ copied: false }), 1500);
   };

--- a/packages/netlify-cms-core/src/components/MediaLibrary/MediaLibraryModal.js
+++ b/packages/netlify-cms-core/src/components/MediaLibrary/MediaLibraryModal.js
@@ -92,6 +92,7 @@ function MediaLibraryModal({
   loadDisplayURL,
   displayURLs,
   t,
+  mediaFolder,
 }) {
   const filteredFiles = forImage ? handleFilter(files) : files;
   const queriedFiles = !dynamicSearch && query ? handleQuery(query, filteredFiles) : filteredFiles;
@@ -130,6 +131,7 @@ function MediaLibraryModal({
         isPersisting={isPersisting}
         isDeleting={isDeleting}
         selectedFile={selectedFile}
+        mediaFolder={mediaFolder}
       />
       {!shouldShowEmptyMessage ? null : (
         <EmptyMessage content={emptyMessage} isPrivate={privateUpload} />
@@ -195,6 +197,7 @@ MediaLibraryModal.propTypes = {
   loadDisplayURL: PropTypes.func.isRequired,
   t: PropTypes.func.isRequired,
   displayURLs: PropTypes.instanceOf(Map).isRequired,
+  mediaFolder: PropTypes.string,
 };
 
 export default translate()(MediaLibraryModal);

--- a/packages/netlify-cms-core/src/components/MediaLibrary/MediaLibraryTop.js
+++ b/packages/netlify-cms-core/src/components/MediaLibrary/MediaLibraryTop.js
@@ -45,6 +45,7 @@ function MediaLibraryTop({
   isPersisting,
   isDeleting,
   selectedFile,
+  mediaFolder,
 }) {
   const shouldShowButtonLoader = isPersisting || isDeleting;
   const uploadEnabled = !shouldShowButtonLoader;
@@ -78,6 +79,7 @@ function MediaLibraryTop({
             name={selectedFile.name}
             draft={selectedFile.draft}
             t={t}
+            mediaFolder={mediaFolder}
           />
           <DownloadButton onClick={onDownload} disabled={!hasSelection}>
             {downloadButtonLabel}
@@ -138,6 +140,7 @@ MediaLibraryTop.propTypes = {
     }),
     PropTypes.shape({}),
   ]),
+  mediaFolder: PropTypes.string,
 };
 
 export default MediaLibraryTop;


### PR DESCRIPTION
fixes https://github.com/netlify/netlify-cms/issues/5569

<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines.

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first two fields are mandatory:
-->

**Summary**

In the media assets screen, there is a useful Copy Path button. When the user clicks on the button, the path copied does not reflect the path that is specified in the backend. For example, it starts with uploads when it should start with /uploads.

<!--
Explain the **motivation** for making this change.
What existing problem does the pull request solve?
-->

**Test plan**

1. Go to 'Media'
1. Select any image or file
1. Click on Copy Path
1. Use this path in a link
1. The path reflects the path that is specified in the backend

<!--
Demonstrate the code is solid.
Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.
-->
![screenshot](https://user-images.githubusercontent.com/4014583/124186262-73ee2780-da92-11eb-980a-b5f6a61efb43.PNG)

**A picture of a cute animal (not mandatory but encouraged)**
