### PR TITLE
feat: image widget insert from url should be optional

### DIFF
--- a/dev-test/config.yml
+++ b/dev-test/config.yml
@@ -47,7 +47,6 @@ collections: # A list of collections the CMS should be able to edit
       - label: 'Cover Image'
         name: 'image'
         widget: 'image'
-        choose_url: true
         required: false
         tagname: ''
 

--- a/dev-test/config.yml
+++ b/dev-test/config.yml
@@ -47,6 +47,7 @@ collections: # A list of collections the CMS should be able to edit
       - label: 'Cover Image'
         name: 'image'
         widget: 'image'
+        choose_url: true
         required: false
         tagname: ''
 

--- a/packages/netlify-cms-widget-file/src/withFileControl.js
+++ b/packages/netlify-cms-widget-file/src/withFileControl.js
@@ -304,9 +304,7 @@ export default function withFileControl({ forImage } = {}) {
               <FileWidgetButton onClick={this.handleUrl(subject)}>
                 {t(`editor.editorWidgets.${subject}.replaceUrl`)}
               </FileWidgetButton>
-            ) : (
-              ''
-            )}
+            ) : null}
             <FileWidgetButtonRemove onClick={this.handleRemove}>
               {t(`editor.editorWidgets.${subject}.remove`)}
             </FileWidgetButtonRemove>
@@ -326,9 +324,7 @@ export default function withFileControl({ forImage } = {}) {
             <FileWidgetButton onClick={this.handleUrl(subject)}>
               {t(`editor.editorWidgets.${subject}.chooseUrl`)}
             </FileWidgetButton>
-          ) : (
-            ''
-          )}
+          ) : null}
         </>
       );
     };

--- a/packages/netlify-cms-widget-file/src/withFileControl.js
+++ b/packages/netlify-cms-widget-file/src/withFileControl.js
@@ -291,7 +291,7 @@ export default function withFileControl({ forImage } = {}) {
     };
 
     renderSelection = subject => {
-      const { t } = this.props;
+      const { t, field } = this.props;
       return (
         <div>
           {forImage ? this.renderImages() : null}
@@ -300,9 +300,13 @@ export default function withFileControl({ forImage } = {}) {
             <FileWidgetButton onClick={this.handleChange}>
               {t(`editor.editorWidgets.${subject}.chooseDifferent`)}
             </FileWidgetButton>
-            <FileWidgetButton onClick={this.handleUrl(subject)}>
-              {t(`editor.editorWidgets.${subject}.replaceUrl`)}
-            </FileWidgetButton>
+            {field.get('choose_url', true) ? (
+              <FileWidgetButton onClick={this.handleUrl(subject)}>
+                {t(`editor.editorWidgets.${subject}.replaceUrl`)}
+              </FileWidgetButton>
+            ) : (
+              ''
+            )}
             <FileWidgetButtonRemove onClick={this.handleRemove}>
               {t(`editor.editorWidgets.${subject}.remove`)}
             </FileWidgetButtonRemove>
@@ -312,15 +316,19 @@ export default function withFileControl({ forImage } = {}) {
     };
 
     renderNoSelection = subject => {
-      const { t } = this.props;
+      const { t, field } = this.props;
       return (
         <>
           <FileWidgetButton onClick={this.handleChange}>
             {t(`editor.editorWidgets.${subject}.choose`)}
           </FileWidgetButton>
-          <FileWidgetButton onClick={this.handleUrl(subject)}>
-            {t(`editor.editorWidgets.${subject}.chooseUrl`)}
-          </FileWidgetButton>
+          {field.get('choose_url', true) ? (
+            <FileWidgetButton onClick={this.handleUrl(subject)}>
+              {t(`editor.editorWidgets.${subject}.chooseUrl`)}
+            </FileWidgetButton>
+          ) : (
+            ''
+          )}
         </>
       );
     };

--- a/website/content/docs/widgets/file.md
+++ b/website/content/docs/widgets/file.md
@@ -17,6 +17,7 @@ The file widget allows editors to upload a file or select an existing one from t
     * `config`: a configuration object that will be passed directly to the media library being
       used - available options are determined by the library
     * `media_folder` (Beta): file path where uploaded files will be saved specific to this control. Paths can be relative to a collection folder (e.g. `files` will add the file to a sub-folder in the collection folder) or absolute with reference to the base of the repo which needs to begin with `/` (e.g `/static/files` will save uploaded files to the `static` folder in a sub folder named `files`)
+    * `choose_url`: *(default: `true`)* when set to `false`, the "Insert from URL" button will be hidden
 * **Example:**
 
   ```yaml

--- a/website/content/docs/widgets/image.md
+++ b/website/content/docs/widgets/image.md
@@ -14,13 +14,15 @@ The image widget allows editors to upload an image or select an existing one fro
     current widget
   * `allow_multiple`: *(default: `true`)* when set to `false`, multiple selection will be disabled even if the media library extension supports it
   * `config`: a configuration object passed directly to the media library; check the documentation of your media library extension for available `config` options
-  * `media_folder` (Beta): file path where uploaded images will be saved specific to this control. Paths can be relative to a collection folder (e.g. `images` will add the image to a sub-folder in the collection folder) or absolute with reference to the base of the repo which needs to begin with `/` (e.g `/static/images` will save uploaded images to the `static` folder in a sub folder named `images`)  
+  * `media_folder` (Beta): file path where uploaded images will be saved specific to this control. Paths can be relative to a collection folder (e.g. `images` will add the image to a sub-folder in the collection folder) or absolute with reference to the base of the repo which needs to begin with `/` (e.g `/static/images` will save uploaded images to the `static` folder in a sub folder named `images`)
+  * `choose_url`: *(default: `true`)* when set to `false`, image widget "Insert from URL" will be disabled so it will not appear in the options.
 * **Example:**
 
 ```yaml
   - label: "Featured Image"
     name: "thumbnail"
     widget: "image"
+    choose_url: true
     default: "/uploads/chocolate-dogecoin.jpg"
     media_library:
       config:

--- a/website/content/docs/widgets/image.md
+++ b/website/content/docs/widgets/image.md
@@ -15,7 +15,7 @@ The image widget allows editors to upload an image or select an existing one fro
   * `allow_multiple`: *(default: `true`)* when set to `false`, multiple selection will be disabled even if the media library extension supports it
   * `config`: a configuration object passed directly to the media library; check the documentation of your media library extension for available `config` options
   * `media_folder` (Beta): file path where uploaded images will be saved specific to this control. Paths can be relative to a collection folder (e.g. `images` will add the image to a sub-folder in the collection folder) or absolute with reference to the base of the repo which needs to begin with `/` (e.g `/static/images` will save uploaded images to the `static` folder in a sub folder named `images`)
-  * `choose_url`: *(default: `true`)* when set to `false`, image widget "Insert from URL" will be disabled so it will not appear in the options.
+  * `choose_url`: *(default: `true`)* when set to `false`, the "Insert from URL" button will be hidden
 * **Example:**
 
 ```yaml


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines.

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first two fields are mandatory:
-->

**Summary**
Fixes: Image widget "Insert From URL" should be optional as requested here: [#5558](https://github.com/netlify/netlify-cms/issues/5532)
<!--
Explain the **motivation** for making this change.
What existing problem does the pull request solve?
-->

**Test plan**
By puting the option choose_url as true:
![image](https://user-images.githubusercontent.com/71785515/124210459-11f0ea80-dab1-11eb-8a4f-39edd94a031b.png)

We see this in the cover image section when creating a new post:
![image](https://user-images.githubusercontent.com/71785515/124210593-4d8bb480-dab1-11eb-8f07-2832a5447a98.png)

By putting false:
![image](https://user-images.githubusercontent.com/71785515/124210731-92175000-dab1-11eb-938a-05a22e127b00.png)

We see that the option of _Insert From URL_ does not appear:
![image](https://user-images.githubusercontent.com/71785515/124210851-c854cf80-dab1-11eb-8660-390b92a7d8cf.png)

<!--
Demonstrate the code is solid.
Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.
-->

**A picture of a cute animal (not mandatory but encouraged)**
![Screenshot_2021-07-01-21-01-52-48_2](https://user-images.githubusercontent.com/71785515/124209883-081ab780-dab0-11eb-8825-65c468f54a8f.jpg)

