### PR TITLE
fixes #5557: modify status button to show the current status

### DIFF
--- a/cypress/utils/steps.js
+++ b/cypress/utils/steps.js
@@ -145,8 +145,10 @@ function deleteWorkflowEntry({ title }) {
   assertNotification(notifications.deletedUnpublished);
 }
 
+const STATUS_BUTTON_TEXT = 'Status:';
+
 function assertWorkflowStatusInEditor(status) {
-  cy.contains('[role="button"]', 'Set status').as('setStatusButton');
+  cy.contains('[role="button"]', STATUS_BUTTON_TEXT).as('setStatusButton');
   cy.get('@setStatusButton')
     .parent()
     .within(() => {
@@ -209,7 +211,7 @@ function assertWorkflowStatus({ title }, status) {
 }
 
 function updateWorkflowStatusInEditor(newStatus) {
-  selectDropdownItem('Set status', newStatus);
+  selectDropdownItem(STATUS_BUTTON_TEXT, newStatus);
   assertNotification(notifications.updated);
 }
 

--- a/packages/netlify-cms-core/src/components/Editor/EditorToolbar.js
+++ b/packages/netlify-cms-core/src/components/Editor/EditorToolbar.js
@@ -359,26 +359,22 @@ export class EditorToolbar extends React.Component {
   renderWorkflowStatusControls = () => {
     const { isUpdatingStatus, onChangeStatus, currentStatus, t, useOpenAuthoring } = this.props;
 
-    let buttonText = '';
+    const statusToTranslation = {
+      [status.get('DRAFT')]: t('editor.editorToolbar.draft'),
+      [status.get('PENDING_REVIEW')]: t('editor.editorToolbar.inReview'),
+      [status.get('PENDING_PUBLISH')]: t('editor.editorToolbar.ready'),
+    };
 
-    if (currentStatus === status.get('DRAFT')) {
-      buttonText = t('editor.editorToolbar.draft');
-    } else if (currentStatus === status.get('PENDING_REVIEW')) {
-      buttonText = t('editor.editorToolbar.inReview');
-    } else if (currentStatus === status.get('PENDING_PUBLISH')) {
-      buttonText = t('editor.editorToolbar.ready');
-    } else {
-      buttonText = isUpdatingStatus
-        ? t('editor.editorToolbar.updating')
-        : t('editor.editorToolbar.setStatus');
-    }
+    const buttonText = isUpdatingStatus
+      ? t('editor.editorToolbar.updating')
+      : t('editor.editorToolbar.status', { status: statusToTranslation[currentStatus] });
 
     return (
       <>
         <ToolbarDropdown
           dropdownTopOverlap="40px"
           dropdownWidth="120px"
-          renderButton={() => <StatusButton>{`Current status: ${buttonText}`}</StatusButton>}
+          renderButton={() => <StatusButton>{buttonText}</StatusButton>}
         >
           <StatusDropdownItem
             label={t('editor.editorToolbar.draft')}

--- a/packages/netlify-cms-core/src/components/Editor/EditorToolbar.js
+++ b/packages/netlify-cms-core/src/components/Editor/EditorToolbar.js
@@ -358,18 +358,27 @@ export class EditorToolbar extends React.Component {
 
   renderWorkflowStatusControls = () => {
     const { isUpdatingStatus, onChangeStatus, currentStatus, t, useOpenAuthoring } = this.props;
+
+    let buttonText = '';
+
+    if (currentStatus === status.get('DRAFT')) {
+      buttonText = t('editor.editorToolbar.draft');
+    } else if (currentStatus === status.get('PENDING_REVIEW')) {
+      buttonText = t('editor.editorToolbar.inReview');
+    } else if (currentStatus === status.get('PENDING_PUBLISH')) {
+      buttonText = t('editor.editorToolbar.ready');
+    } else {
+      buttonText = isUpdatingStatus
+        ? t('editor.editorToolbar.updating')
+        : t('editor.editorToolbar.setStatus');
+    }
+
     return (
       <>
         <ToolbarDropdown
           dropdownTopOverlap="40px"
           dropdownWidth="120px"
-          renderButton={() => (
-            <StatusButton>
-              {isUpdatingStatus
-                ? t('editor.editorToolbar.updating')
-                : t('editor.editorToolbar.setStatus')}
-            </StatusButton>
-          )}
+          renderButton={() => <StatusButton>{`Current status: ${buttonText}`}</StatusButton>}
         >
           <StatusDropdownItem
             label={t('editor.editorToolbar.draft')}

--- a/packages/netlify-cms-core/src/components/Editor/__tests__/__snapshots__/EditorToolbar.spec.js.snap
+++ b/packages/netlify-cms-core/src/components/Editor/__tests__/__snapshots__/EditorToolbar.spec.js.snap
@@ -179,7 +179,7 @@ exports[`EditorToolbar should render with default props 1`] = `
     class="emotion-18 emotion-19"
   >
     <mock-link
-      classname="css-1e27f5b-ToolbarSectionBackLink-toolbarSection evqrzhe8"
+      classname="css-i3q6wb-ToolbarSectionBackLink-toolbarSection evqrzhe8"
       to=""
     >
       <div
@@ -469,7 +469,7 @@ exports[`EditorToolbar should render with status=draft,useOpenAuthoring=false 1`
     class="emotion-23 emotion-24"
   >
     <mock-link
-      classname="css-1e27f5b-ToolbarSectionBackLink-toolbarSection evqrzhe8"
+      classname="css-i3q6wb-ToolbarSectionBackLink-toolbarSection evqrzhe8"
       to=""
     >
       <div
@@ -520,7 +520,7 @@ exports[`EditorToolbar should render with status=draft,useOpenAuthoring=false 1`
             role="button"
             tabindex="0"
           >
-            editor.editorToolbar.setStatus
+            editor.editorToolbar.status
           </span>
         </div>
       </div>
@@ -803,7 +803,7 @@ exports[`EditorToolbar should render with status=draft,useOpenAuthoring=true 1`]
     class="emotion-30 emotion-31"
   >
     <mock-link
-      classname="css-1e27f5b-ToolbarSectionBackLink-toolbarSection evqrzhe8"
+      classname="css-i3q6wb-ToolbarSectionBackLink-toolbarSection evqrzhe8"
       to=""
     >
       <div
@@ -849,7 +849,7 @@ exports[`EditorToolbar should render with status=draft,useOpenAuthoring=true 1`]
             role="button"
             tabindex="0"
           >
-            editor.editorToolbar.setStatus
+            editor.editorToolbar.status
           </span>
         </div>
         <div
@@ -1131,7 +1131,7 @@ exports[`EditorToolbar should render with status=pending_publish,useOpenAuthorin
     class="emotion-23 emotion-24"
   >
     <mock-link
-      classname="css-1e27f5b-ToolbarSectionBackLink-toolbarSection evqrzhe8"
+      classname="css-i3q6wb-ToolbarSectionBackLink-toolbarSection evqrzhe8"
       to=""
     >
       <div
@@ -1182,7 +1182,7 @@ exports[`EditorToolbar should render with status=pending_publish,useOpenAuthorin
             role="button"
             tabindex="0"
           >
-            editor.editorToolbar.setStatus
+            editor.editorToolbar.status
           </span>
         </div>
       </div>
@@ -1447,7 +1447,7 @@ exports[`EditorToolbar should render with status=pending_publish,useOpenAuthorin
     class="emotion-28 emotion-29"
   >
     <mock-link
-      classname="css-1e27f5b-ToolbarSectionBackLink-toolbarSection evqrzhe8"
+      classname="css-i3q6wb-ToolbarSectionBackLink-toolbarSection evqrzhe8"
       to=""
     >
       <div
@@ -1493,7 +1493,7 @@ exports[`EditorToolbar should render with status=pending_publish,useOpenAuthorin
             role="button"
             tabindex="0"
           >
-            editor.editorToolbar.setStatus
+            editor.editorToolbar.status
           </span>
         </div>
         <div
@@ -1770,7 +1770,7 @@ exports[`EditorToolbar should render with status=pending_review,useOpenAuthoring
     class="emotion-23 emotion-24"
   >
     <mock-link
-      classname="css-1e27f5b-ToolbarSectionBackLink-toolbarSection evqrzhe8"
+      classname="css-i3q6wb-ToolbarSectionBackLink-toolbarSection evqrzhe8"
       to=""
     >
       <div
@@ -1821,7 +1821,7 @@ exports[`EditorToolbar should render with status=pending_review,useOpenAuthoring
             role="button"
             tabindex="0"
           >
-            editor.editorToolbar.setStatus
+            editor.editorToolbar.status
           </span>
         </div>
       </div>
@@ -2104,7 +2104,7 @@ exports[`EditorToolbar should render with status=pending_review,useOpenAuthoring
     class="emotion-30 emotion-31"
   >
     <mock-link
-      classname="css-1e27f5b-ToolbarSectionBackLink-toolbarSection evqrzhe8"
+      classname="css-i3q6wb-ToolbarSectionBackLink-toolbarSection evqrzhe8"
       to=""
     >
       <div
@@ -2150,7 +2150,7 @@ exports[`EditorToolbar should render with status=pending_review,useOpenAuthoring
             role="button"
             tabindex="0"
           >
-            editor.editorToolbar.setStatus
+            editor.editorToolbar.status
           </span>
         </div>
         <div
@@ -2375,7 +2375,7 @@ exports[`EditorToolbar should render with workflow controls hasUnpublishedChange
     class="emotion-18 emotion-19"
   >
     <mock-link
-      classname="css-1e27f5b-ToolbarSectionBackLink-toolbarSection evqrzhe8"
+      classname="css-i3q6wb-ToolbarSectionBackLink-toolbarSection evqrzhe8"
       to=""
     >
       <div
@@ -2580,7 +2580,7 @@ exports[`EditorToolbar should render with workflow controls hasUnpublishedChange
     class="emotion-16 emotion-17"
   >
     <mock-link
-      classname="css-1e27f5b-ToolbarSectionBackLink-toolbarSection evqrzhe8"
+      classname="css-i3q6wb-ToolbarSectionBackLink-toolbarSection evqrzhe8"
       to=""
     >
       <div
@@ -2805,7 +2805,7 @@ exports[`EditorToolbar should render with workflow controls hasUnpublishedChange
     class="emotion-18 emotion-19"
   >
     <mock-link
-      classname="css-1e27f5b-ToolbarSectionBackLink-toolbarSection evqrzhe8"
+      classname="css-i3q6wb-ToolbarSectionBackLink-toolbarSection evqrzhe8"
       to=""
     >
       <div
@@ -3035,7 +3035,7 @@ exports[`EditorToolbar should render with workflow controls hasUnpublishedChange
     class="emotion-18 emotion-19"
   >
     <mock-link
-      classname="css-1e27f5b-ToolbarSectionBackLink-toolbarSection evqrzhe8"
+      classname="css-i3q6wb-ToolbarSectionBackLink-toolbarSection evqrzhe8"
       to=""
     >
       <div
@@ -3265,7 +3265,7 @@ exports[`EditorToolbar should render with workflow controls hasUnpublishedChange
     class="emotion-18 emotion-19"
   >
     <mock-link
-      classname="css-1e27f5b-ToolbarSectionBackLink-toolbarSection evqrzhe8"
+      classname="css-i3q6wb-ToolbarSectionBackLink-toolbarSection evqrzhe8"
       to=""
     >
       <div
@@ -3495,7 +3495,7 @@ exports[`EditorToolbar should render with workflow controls hasUnpublishedChange
     class="emotion-18 emotion-19"
   >
     <mock-link
-      classname="css-1e27f5b-ToolbarSectionBackLink-toolbarSection evqrzhe8"
+      classname="css-i3q6wb-ToolbarSectionBackLink-toolbarSection evqrzhe8"
       to=""
     >
       <div

--- a/packages/netlify-cms-core/src/reducers/entryDraft.js
+++ b/packages/netlify-cms-core/src/reducers/entryDraft.js
@@ -147,14 +147,14 @@ function entryDraftReducer(state = Map(), action) {
 
     case UNPUBLISHED_ENTRY_STATUS_CHANGE_FAILURE:
     case UNPUBLISHED_ENTRY_STATUS_CHANGE_SUCCESS:
-      return state.setIn(['entry', 'isUpdatingStatus'], false);
+      return state.deleteIn(['entry', 'isUpdatingStatus']);
 
     case UNPUBLISHED_ENTRY_PUBLISH_REQUEST:
       return state.setIn(['entry', 'isPublishing'], true);
 
     case UNPUBLISHED_ENTRY_PUBLISH_SUCCESS:
     case UNPUBLISHED_ENTRY_PUBLISH_FAILURE:
-      return state.setIn(['entry', 'isPublishing'], false);
+      return state.deleteIn(['entry', 'isPublishing']);
 
     case ENTRY_PERSIST_SUCCESS:
     case UNPUBLISHED_ENTRY_PERSIST_SUCCESS:

--- a/packages/netlify-cms-core/src/reducers/entryDraft.js
+++ b/packages/netlify-cms-core/src/reducers/entryDraft.js
@@ -24,6 +24,12 @@ import {
   UNPUBLISHED_ENTRY_PERSIST_REQUEST,
   UNPUBLISHED_ENTRY_PERSIST_SUCCESS,
   UNPUBLISHED_ENTRY_PERSIST_FAILURE,
+  UNPUBLISHED_ENTRY_STATUS_CHANGE_REQUEST,
+  UNPUBLISHED_ENTRY_STATUS_CHANGE_SUCCESS,
+  UNPUBLISHED_ENTRY_STATUS_CHANGE_FAILURE,
+  UNPUBLISHED_ENTRY_PUBLISH_REQUEST,
+  UNPUBLISHED_ENTRY_PUBLISH_SUCCESS,
+  UNPUBLISHED_ENTRY_PUBLISH_FAILURE,
 } from '../actions/editorialWorkflow';
 import { selectFolderEntryExtension, selectHasMetaPath } from './collections';
 import { getDataPath, duplicateI18nFields } from '../lib/i18n';
@@ -135,6 +141,20 @@ function entryDraftReducer(state = Map(), action) {
     case UNPUBLISHED_ENTRY_PERSIST_FAILURE: {
       return state.deleteIn(['entry', 'isPersisting']);
     }
+
+    case UNPUBLISHED_ENTRY_STATUS_CHANGE_REQUEST:
+      return state.setIn(['entry', 'isUpdatingStatus'], true);
+
+    case UNPUBLISHED_ENTRY_STATUS_CHANGE_FAILURE:
+    case UNPUBLISHED_ENTRY_STATUS_CHANGE_SUCCESS:
+      return state.setIn(['entry', 'isUpdatingStatus'], false);
+
+    case UNPUBLISHED_ENTRY_PUBLISH_REQUEST:
+      return state.setIn(['entry', 'isPublishing'], true);
+
+    case UNPUBLISHED_ENTRY_PUBLISH_SUCCESS:
+    case UNPUBLISHED_ENTRY_PUBLISH_FAILURE:
+      return state.setIn(['entry', 'isPublishing'], false);
 
     case ENTRY_PERSIST_SUCCESS:
     case UNPUBLISHED_ENTRY_PERSIST_SUCCESS:

--- a/packages/netlify-cms-locales/src/bg/index.js
+++ b/packages/netlify-cms-locales/src/bg/index.js
@@ -135,7 +135,7 @@ const bg = {
       save: 'Запази',
       deleting: 'Изтриване...',
       updating: 'Актуализиране...',
-      setStatus: 'Задайте състояние',
+      status: 'Cъстояние: %{status}',
       backCollection: 'Записване в %{collectionLabel} колекция',
       unsavedChanges: 'Незапазени Промени',
       changesSaved: 'Запазени промени',

--- a/packages/netlify-cms-locales/src/ca/index.js
+++ b/packages/netlify-cms-locales/src/ca/index.js
@@ -134,7 +134,7 @@ const ca = {
       save: 'Guardar',
       deleting: 'Eliminant...',
       updating: 'Actualizant...',
-      setStatus: 'Actualizar estat',
+      status: 'Estat: %{status}',
       backCollection: ' Escrivint a la colecció %{collectionLabel}',
       unsavedChanges: 'Canvis no guardats',
       changesSaved: 'Canvis guardats',

--- a/packages/netlify-cms-locales/src/cs/index.js
+++ b/packages/netlify-cms-locales/src/cs/index.js
@@ -134,7 +134,7 @@ const cs = {
       save: 'Uložit',
       deleting: 'Vymazávání…',
       updating: 'Aktualizace…',
-      setStatus: 'Změnit status',
+      status: 'Status: %{status}',
       backCollection: ' Píšete v kolekci %{collectionLabel}',
       unsavedChanges: 'Neuložené změny',
       changesSaved: 'Změny uloženy',

--- a/packages/netlify-cms-locales/src/da/index.js
+++ b/packages/netlify-cms-locales/src/da/index.js
@@ -131,7 +131,7 @@ const da = {
       save: 'Gem',
       deleting: 'Sletter...',
       updating: 'Updaterer...',
-      setStatus: 'Sæt status',
+      status: 'Status: %{status}',
       backCollection: ' Skriver til %{collectionLabel} samlingen',
       unsavedChanges: 'Ugemte ændringer',
       changesSaved: 'Ændringer gemt',

--- a/packages/netlify-cms-locales/src/de/index.js
+++ b/packages/netlify-cms-locales/src/de/index.js
@@ -126,7 +126,7 @@ const de = {
       save: 'Speichern',
       deleting: 'Löschen...',
       updating: 'Aktualisieren...',
-      setStatus: 'Status setzen',
+      status: 'Status: %{status}',
       backCollection: 'Zurück zu allen %{collectionLabel}',
       unsavedChanges: 'Ungespeicherte Änderungen',
       changesSaved: 'Änderungen gespeichert',

--- a/packages/netlify-cms-locales/src/en/index.js
+++ b/packages/netlify-cms-locales/src/en/index.js
@@ -137,7 +137,7 @@ const en = {
         'Entry is being reviewed, no further actions are required. However, you can still make additional changes while it is being reviewed.',
       deleting: 'Deleting...',
       updating: 'Updating...',
-      setStatus: 'Set status',
+      status: 'Status: %{status}',
       backCollection: ' Writing in %{collectionLabel} collection',
       unsavedChanges: 'Unsaved Changes',
       changesSaved: 'Changes saved',

--- a/packages/netlify-cms-locales/src/es/index.js
+++ b/packages/netlify-cms-locales/src/es/index.js
@@ -115,7 +115,7 @@ const es = {
       save: 'Guardar',
       deleting: 'Eliminando...',
       updating: 'Actualizando...',
-      setStatus: 'Actualizar estado',
+      status: 'Estado: %{status}',
       backCollection: ' Escribiendo en la colección %{collectionLabel}',
       unsavedChanges: 'Cambios no guardados',
       changesSaved: 'Cambios guardados',

--- a/packages/netlify-cms-locales/src/fr/index.js
+++ b/packages/netlify-cms-locales/src/fr/index.js
@@ -136,7 +136,7 @@ const fr = {
       save: 'Enregistrer',
       deleting: 'Suppression...',
       updating: 'Mise à jour...',
-      setStatus: 'Définir le statut',
+      setStatus: 'Statut: %{status}',
       backCollection: ' Écriture dans la collection %{collectionLabel}',
       unsavedChanges: 'Modifications non enregistrées',
       changesSaved: 'Modifications enregistrées',

--- a/packages/netlify-cms-locales/src/fr/index.js
+++ b/packages/netlify-cms-locales/src/fr/index.js
@@ -136,7 +136,7 @@ const fr = {
       save: 'Enregistrer',
       deleting: 'Suppression...',
       updating: 'Mise à jour...',
-      setStatus: 'Statut: %{status}',
+      status: 'Statut: %{status}',
       backCollection: ' Écriture dans la collection %{collectionLabel}',
       unsavedChanges: 'Modifications non enregistrées',
       changesSaved: 'Modifications enregistrées',

--- a/packages/netlify-cms-locales/src/gr/index.js
+++ b/packages/netlify-cms-locales/src/gr/index.js
@@ -101,7 +101,7 @@ const gr = {
       save: 'Αποθήκευση',
       deleting: 'Διαγραφή...',
       updating: 'Ενημέρωση...',
-      setStatus: 'Ορισμός κατάστασης',
+      status: 'Κατάστασης: %{status}',
       backCollection: ' Εγγραφή στη συλλογή %{collectionLabel}',
       unsavedChanges: 'Μη αποθηκευμένες αλλαγές',
       changesSaved: 'Αλλαγές που αποθηκεύτηκαν',

--- a/packages/netlify-cms-locales/src/hr/index.js
+++ b/packages/netlify-cms-locales/src/hr/index.js
@@ -130,7 +130,7 @@ const hr = {
       save: 'Spremi',
       deleting: 'Brisanje...',
       updating: 'Ažuriranje...',
-      setStatus: 'Postavi status',
+      status: 'Status: %{status}',
       backCollection: 'Pisanje u %{collectionLabel} zbirci',
       unsavedChanges: 'Nespremljene promjene',
       changesSaved: 'Promjene spremljene',

--- a/packages/netlify-cms-locales/src/hu/index.js
+++ b/packages/netlify-cms-locales/src/hu/index.js
@@ -85,7 +85,7 @@ const hu = {
       save: 'Mentés',
       deleting: 'Törlés...',
       updating: 'Frissítés...',
-      setStatus: 'Állapot beállitása',
+      status: 'Beállitása: %{status}',
       backCollection: ' Írás a %{collectionLabel} gyűjteménybe',
       unsavedChanges: 'Nemmentett változtatások',
       changesSaved: 'Változások elmentve',

--- a/packages/netlify-cms-locales/src/it/index.js
+++ b/packages/netlify-cms-locales/src/it/index.js
@@ -98,7 +98,7 @@ const it = {
       save: 'Salva',
       deleting: 'Cancellando...',
       updating: 'Aggiornando...',
-      setStatus: 'Imposta status',
+      status: 'Status: %{status}',
       backCollection: ' Scrivendo nella sezione %{collectionLabel}',
       unsavedChanges: 'Modifiche non salvate',
       changesSaved: 'Modifiche salvate',

--- a/packages/netlify-cms-locales/src/ja/index.js
+++ b/packages/netlify-cms-locales/src/ja/index.js
@@ -134,7 +134,7 @@ const ja = {
       save: '保存',
       deleting: '削除しています...',
       updating: '更新しています...',
-      setStatus: 'ステータスを変更する',
+      status: 'ステータスを: %{status}',
       backCollection: '%{collectionLabel}のエントリを作成中',
       unsavedChanges: '未保存',
       changesSaved: '保存済',

--- a/packages/netlify-cms-locales/src/ko/index.js
+++ b/packages/netlify-cms-locales/src/ko/index.js
@@ -122,7 +122,7 @@ const ko = {
       save: '저장',
       deleting: '삭제 중...',
       updating: '업데이트 중...',
-      setStatus: '상태 설정',
+      status: '상태: %{status}',
       backCollection: '%{collectionLabel} 컬랙션에 작성하는 중',
       unsavedChanges: '변경사항 저장되지 않음',
       changesSaved: '변경사항 저장됨',

--- a/packages/netlify-cms-locales/src/lt/index.js
+++ b/packages/netlify-cms-locales/src/lt/index.js
@@ -132,7 +132,7 @@ const lt = {
       save: 'Išsaugoti',
       deleting: 'Trinama...',
       updating: 'Atnaujinama...',
-      setStatus: 'Nustatyti statusą',
+      status: 'Statusą: %{status}',
       backCollection: ' Rašoma %{collectionLabel} kolekcijoje',
       unsavedChanges: 'Neišsaugoti pakeitimai',
       changesSaved: 'Pakeitimai išsauogti',

--- a/packages/netlify-cms-locales/src/nb_no/index.js
+++ b/packages/netlify-cms-locales/src/nb_no/index.js
@@ -112,7 +112,7 @@ const nb_no = {
       save: 'Lagre',
       deleting: 'Sletter...',
       updating: 'Oppdaterer...',
-      setStatus: 'Sett status',
+      status: 'Status: %{status}',
       backCollection: ' Skriver i samlingen %{collectionLabel}',
       unsavedChanges: 'Ulagrede endringer',
       changesSaved: 'Endringer lagret',

--- a/packages/netlify-cms-locales/src/nl/index.js
+++ b/packages/netlify-cms-locales/src/nl/index.js
@@ -133,7 +133,7 @@ const nl = {
       save: 'Opslaan',
       deleting: 'Verwijderen...',
       updating: 'Bijwerken...',
-      setStatus: 'Stel status in',
+      status: 'Status: %{status}',
       backCollection: ' Terug naar %{collectionLabel}',
       unsavedChanges: 'Niet-opgeslagen wijzigingen',
       changesSaved: 'Wijzigingen opgeslagen',

--- a/packages/netlify-cms-locales/src/nn_no/index.js
+++ b/packages/netlify-cms-locales/src/nn_no/index.js
@@ -113,7 +113,7 @@ const nn_no = {
       save: 'Lagre',
       deleting: 'Slettar...',
       updating: 'Oppdaterer...',
-      setStatus: 'Sett status',
+      status: 'Status: %{status}',
       backCollection: ' Skriv i samlinga %{collectionLabel}',
       unsavedChanges: 'Ulagra endringar',
       changesSaved: 'Endringar lagret',

--- a/packages/netlify-cms-locales/src/pl/index.js
+++ b/packages/netlify-cms-locales/src/pl/index.js
@@ -113,7 +113,7 @@ const pl = {
       save: 'Zapisz',
       deleting: 'Usuwanie...',
       updating: 'Uaktualnianie...',
-      setStatus: 'Ustaw status',
+      status: 'Status: %{status}',
       backCollection: ' Edycja treści w zbiorze %{collectionLabel}',
       unsavedChanges: 'Niezapisane zmiany',
       changesSaved: 'Zmiany zapisane',

--- a/packages/netlify-cms-locales/src/pt/index.js
+++ b/packages/netlify-cms-locales/src/pt/index.js
@@ -121,7 +121,7 @@ const pt = {
       save: 'Salvar',
       deleting: 'Excluindo...',
       updating: 'Atualizando...',
-      setStatus: 'Definir status',
+      status: 'Status: %{status}',
       backCollection: ' Escrevendo na coleção %{collectionLabel}',
       unsavedChanges: 'Alterações não salvas',
       changesSaved: 'Alterações salvas',

--- a/packages/netlify-cms-locales/src/ro/index.js
+++ b/packages/netlify-cms-locales/src/ro/index.js
@@ -136,7 +136,7 @@ const ro = {
       save: 'Salvează',
       deleting: 'Se șterge...',
       updating: 'Se actualizează...',
-      setStatus: 'Setează status',
+      status: 'Status: %{status}',
       backCollection: ' Scrii în colecția „%{collectionLabel}”',
       unsavedChanges: 'Modificări nesalvate',
       changesSaved: 'Modificări salvate',

--- a/packages/netlify-cms-locales/src/ru/index.js
+++ b/packages/netlify-cms-locales/src/ru/index.js
@@ -131,7 +131,7 @@ const ru = {
       save: 'Сохранить',
       deleting: 'Удаление…',
       updating: 'Обновление…',
-      setStatus: 'Установить статус',
+      status: 'Cтатус: %{status}',
       backCollection: 'Запись в коллекцию %{collectionLabel}',
       unsavedChanges: 'Несохраненные изменения',
       changesSaved: 'Изменения сохранены',

--- a/packages/netlify-cms-locales/src/sv/index.js
+++ b/packages/netlify-cms-locales/src/sv/index.js
@@ -135,7 +135,7 @@ const sv = {
       save: 'Spara',
       deleting: 'Raderar...',
       updating: 'Updaterar...',
-      setStatus: 'Sätt status',
+      status: 'Status: %{status}',
       backCollection: ' Redigerar i samlingen %{collectionLabel}',
       unsavedChanges: 'Osparade ändringar',
       changesSaved: 'Ändringar sparade',

--- a/packages/netlify-cms-locales/src/th/index.js
+++ b/packages/netlify-cms-locales/src/th/index.js
@@ -123,7 +123,7 @@ const th = {
       save: 'บันทึก',
       deleting: 'กำลังลบ...',
       updating: 'กำลังอัปเดต...',
-      setStatus: 'เซ็ตสถานะ',
+      status: 'สถานะ: %{status}',
       backCollection: ' เขียนในกลุ่ม %{collectionLabel}',
       unsavedChanges: 'การเปลี่ยนแปลงยังไม่ได้บันทึก',
       changesSaved: 'การเปลี่ยนเปลงถูกบันทึกแล้ว',

--- a/packages/netlify-cms-locales/src/tr/index.js
+++ b/packages/netlify-cms-locales/src/tr/index.js
@@ -103,7 +103,7 @@ const tr = {
       save: 'Kayıt Et',
       deleting: 'Siliniyor...',
       updating: 'Güncelleniyor...',
-      setStatus: 'Durumu ayarla',
+      status: 'Durumu: %{status}',
       backCollection: '%{collectionLabel} koleksiyonunda yazılı',
       unsavedChanges: 'Kaydedilmemiş Değişiklikler',
       changesSaved: 'Değişiklikler kaydedildi',

--- a/packages/netlify-cms-locales/src/uk/index.js
+++ b/packages/netlify-cms-locales/src/uk/index.js
@@ -79,7 +79,7 @@ const uk = {
       save: 'Зберегти',
       deleting: 'Видалення...',
       updating: 'Оновлення...',
-      setStatus: 'Змінити стан',
+      status: 'Cтан: %{status}',
       backCollection: ' Робота над %{collectionLabel} колекцією',
       unsavedChanges: 'Незбережені зміни',
       changesSaved: 'Зміни збережено',

--- a/packages/netlify-cms-locales/src/vi/index.js
+++ b/packages/netlify-cms-locales/src/vi/index.js
@@ -121,7 +121,7 @@ const vi = {
       save: 'Lưu',
       deleting: 'Đang xoá...',
       updating: 'Đang cập nhật...',
-      setStatus: 'Đặt trạng thái',
+      status: 'Trạng: %{status}',
       backCollection: ' Đang viết trong bộ sưu tập %{collectionLabel}',
       unsavedChanges: 'Thay đổi chưa được lưu',
       changesSaved: 'Thay đổi đã được lưu',

--- a/packages/netlify-cms-locales/src/zh_Hans/index.js
+++ b/packages/netlify-cms-locales/src/zh_Hans/index.js
@@ -131,7 +131,7 @@ const zh_Hans = {
       save: '保存',
       deleting: '正在删除...',
       updating: '正在更新...',
-      setStatus: '设置状态',
+      status: '状态: %{status}',
       backCollection: '正在集合“%{collectionLabel}”中编写',
       unsavedChanges: '含未保存的修改',
       changesSaved: '修改已保存',

--- a/packages/netlify-cms-locales/src/zh_Hant/index.js
+++ b/packages/netlify-cms-locales/src/zh_Hant/index.js
@@ -120,7 +120,7 @@ const zh_Hant = {
       save: '儲存',
       deleting: '刪除中...',
       updating: '更新中...',
-      setStatus: '設定狀態',
+      status: '狀態: %{status}',
       backCollection: '在集合 %{collectionLabel} 新增內容',
       unsavedChanges: '未儲存變更',
       changesSaved: '已儲存變更',


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines.

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first two fields are mandatory:
-->

**Summary**
The set status dropdown is confusing for users becuase they cannot see what the current status is without opening the dropdown. To solve this issue I take the option two that mention in issue #5557 because add another component to the toolbar would cause a mess. To do this I only change the way that Status Menu Button shows the current status of the post and I add a text that says "Current Status:", that maybe it needs to be added to the file where is all the words for translate to another language.

<!--
Explain the **motivation** for making this change.
What existing problem does the pull request solve?
-->

**Test plan**
well, I add some if conditionals to evaluate the status of the post and depending of that status is the name that will be appear in the dropdown button with an addition of the sentence "Current Status:" And the result you can see it in the following picture.


<!--
Demonstrate the code is solid.
Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.
-->

**A picture of a cute animal (not mandatory but encouraged)**
<img width="1432" alt="Screen Shot 2021-07-02 at 1 16 16 PM" src="https://user-images.githubusercontent.com/37887903/124320038-68553c00-db38-11eb-9b32-56e0cab6a32b.png">
