### PR TITLE
fix(markdown-widget): support arbitrary component order

### DIFF
--- a/packages/netlify-cms-core/src/valueObjects/EditorComponent.js
+++ b/packages/netlify-cms-core/src/valueObjects/EditorComponent.js
@@ -28,8 +28,15 @@ export default function createEditorComponent(config) {
     type,
     icon,
     widget,
-    // enforce multiline flag, exclude others
-    pattern,
+    // We allow consumers to specify line anchors (^ and $) without a
+    // multiline flag, but we need to be able to match in a multi-line
+    // context. In order to do so, we replace instances of line anchors
+    // with lookarounds that include \n's, so that non-multiline expressions
+    // still work as expected.
+    pattern: new RegExp(
+      pattern.source.replace('^', '(?<=^|\n)').replace('$', '(?=$|\n)'),
+      pattern.flags,
+    ),
     fromBlock: bind(fromBlock) || (() => ({})),
     toBlock: bind(toBlock) || (() => 'Plugin'),
     toPreview: bind(toPreview) || (!widget && (bind(toBlock) || (() => 'Plugin'))),

--- a/packages/netlify-cms-core/src/valueObjects/EditorComponent.js
+++ b/packages/netlify-cms-core/src/valueObjects/EditorComponent.js
@@ -33,8 +33,13 @@ export default function createEditorComponent(config) {
     // context. In order to do so, we replace instances of line anchors
     // with lookarounds that include \n's, so that non-multiline expressions
     // still work as expected.
+    //
+    // Note: This is mocked in packages/netlify-cms-widget-markdown/src/serializers/__tests__/remarkShortcodes.spec.js;
+    // if you change it here, change it there as well!
     pattern: new RegExp(
-      pattern.source.replace('^', '(?<=^|\n)').replace('$', '(?=$|\n)'),
+      // We use a negative lookbehind so that we only replace carets
+      // that aren't a negation in a character set or escaped
+      pattern.source.replace(/(?<!\[|\\)\^/, '(?<=^|\n)').replace(/(?<!\\)\$/, '(?=$|\n)'),
       pattern.flags,
     ),
     fromBlock: bind(fromBlock) || (() => ({})),

--- a/packages/netlify-cms-core/src/valueObjects/EditorComponent.js
+++ b/packages/netlify-cms-core/src/valueObjects/EditorComponent.js
@@ -28,20 +28,7 @@ export default function createEditorComponent(config) {
     type,
     icon,
     widget,
-    // We allow consumers to specify line anchors (^ and $) without a
-    // multiline flag, but we need to be able to match in a multi-line
-    // context. In order to do so, we replace instances of line anchors
-    // with lookarounds that include \n's, so that non-multiline expressions
-    // still work as expected.
-    //
-    // Note: This is mocked in packages/netlify-cms-widget-markdown/src/serializers/__tests__/remarkShortcodes.spec.js;
-    // if you change it here, change it there as well!
-    pattern: new RegExp(
-      // We use a negative lookbehind so that we only replace carets
-      // that aren't a negation in a character set or escaped
-      pattern.source.replace(/(?<!\[|\\)\^/, '(?<=^|\n)').replace(/(?<!\\)\$/, '(?=$|\n)'),
-      pattern.flags,
-    ),
+    pattern,
     fromBlock: bind(fromBlock) || (() => ({})),
     toBlock: bind(toBlock) || (() => 'Plugin'),
     toPreview: bind(toPreview) || (!widget && (bind(toBlock) || (() => 'Plugin'))),

--- a/packages/netlify-cms-widget-markdown/src/MarkdownControl/index.js
+++ b/packages/netlify-cms-widget-markdown/src/MarkdownControl/index.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import ImmutablePropTypes from 'react-immutable-proptypes';
-import { List } from 'immutable';
+import { List, Map } from 'immutable';
 
 import RawEditor from './RawEditor';
 import VisualEditor from './VisualEditor';
@@ -12,7 +12,7 @@ const MODE_STORAGE_KEY = 'cms.md-mode';
 // be handled through Redux and a separate registry store for instances
 let editorControl;
 // eslint-disable-next-line func-style
-let _getEditorComponents = () => [];
+let _getEditorComponents = () => Map();
 
 export function getEditorControl() {
   return editorControl;

--- a/packages/netlify-cms-widget-markdown/src/serializers/__tests__/remarkShortcodes.spec.js
+++ b/packages/netlify-cms-widget-markdown/src/serializers/__tests__/remarkShortcodes.spec.js
@@ -1,3 +1,4 @@
+import { Map, OrderedMap } from 'immutable';
 import { remarkParseShortcodes } from '../remarkShortcodes';
 
 // Stub of Remark Parser
@@ -22,25 +23,37 @@ describe('remarkParseShortcodes', () => {
   describe('pattern matching', () => {
     it('should work', () => {
       const editorComponent = EditorComponent({ pattern: /bar/ });
-      process('foo bar', [editorComponent]);
+      process('foo bar', Map({ [editorComponent.id]: editorComponent }));
       expect(editorComponent.fromBlock).toHaveBeenCalledWith(expect.arrayContaining(['bar']));
     });
     it('should match value surrounded in newlines', () => {
       const editorComponent = EditorComponent({ pattern: /^bar$/ });
-      process('foo\n\nbar\n', [editorComponent]);
+      process('foo\n\nbar\n', Map({ [editorComponent.id]: editorComponent }));
       expect(editorComponent.fromBlock).toHaveBeenCalledWith(expect.arrayContaining(['bar']));
     });
     it('should match multiline shortcodes', () => {
       const editorComponent = EditorComponent({ pattern: /^foo\nbar$/ });
-      process('foo\nbar', [editorComponent]);
+      process('foo\nbar', Map({ [editorComponent.id]: editorComponent }));
       expect(editorComponent.fromBlock).toHaveBeenCalledWith(expect.arrayContaining(['foo\nbar']));
     });
     it('should match multiline shortcodes with empty lines', () => {
       const editorComponent = EditorComponent({ pattern: /^foo\n\nbar$/ });
-      process('foo\n\nbar', [editorComponent]);
+      process('foo\n\nbar', Map({ [editorComponent.id]: editorComponent }));
       expect(editorComponent.fromBlock).toHaveBeenCalledWith(
         expect.arrayContaining(['foo\n\nbar']),
       );
+    });
+    it('should match out-of-order shortcodes', () => {
+      const fooEditorComponent = EditorComponent({ id: 'foo', pattern: /foo/ });
+      const barEditorComponent = EditorComponent({ id: 'bar', pattern: /bar/ });
+      process(
+        'foo\n\nbar',
+        OrderedMap([
+          [barEditorComponent.id, barEditorComponent],
+          [fooEditorComponent.id, fooEditorComponent],
+        ]),
+      );
+      expect(fooEditorComponent.fromBlock).toHaveBeenCalledWith(expect.arrayContaining(['foo']));
     });
   });
   describe('output', () => {
@@ -49,7 +62,7 @@ describe('remarkParseShortcodes', () => {
       const shortcodeData = { bar: 'baz' };
       const expectedNode = { type: 'shortcode', data: { shortcode: 'foo', shortcodeData } };
       const editorComponent = EditorComponent({ pattern: /bar/, fromBlock: () => shortcodeData });
-      process('foo bar', [editorComponent], processEat);
+      process('foo bar', Map({ [editorComponent.id]: editorComponent }), processEat);
       expect(processEat).toHaveBeenCalledWith(expectedNode);
     });
   });

--- a/packages/netlify-cms-widget-markdown/src/serializers/__tests__/remarkShortcodes.spec.js
+++ b/packages/netlify-cms-widget-markdown/src/serializers/__tests__/remarkShortcodes.spec.js
@@ -1,6 +1,6 @@
 import { Map, OrderedMap } from 'immutable';
 
-import { remarkParseShortcodes } from '../remarkShortcodes';
+import { remarkParseShortcodes, getLinesWithOffsets } from '../remarkShortcodes';
 
 // Stub of Remark Parser
 function process(value, plugins, processEat = () => {}) {
@@ -81,5 +81,26 @@ describe('remarkParseShortcodes', () => {
       process('foo bar', Map({ [editorComponent.id]: editorComponent }), processEat);
       expect(processEat).toHaveBeenCalledWith(expectedNode);
     });
+  });
+});
+
+describe('getLinesWithOffsets', () => {
+  test('should split into lines', () => {
+    const value = ' line1\n\nline2 \n\n    line3   \n\n';
+
+    const lines = getLinesWithOffsets(value);
+    expect(lines).toEqual([
+      { line: ' line1', start: 0 },
+      { line: 'line2', start: 8 },
+      { line: '    line3', start: 16 },
+      { line: '', start: 30 },
+    ]);
+  });
+
+  test('should return single item on no match', () => {
+    const value = ' line1    ';
+
+    const lines = getLinesWithOffsets(value);
+    expect(lines).toEqual([{ line: ' line1', start: 0 }]);
   });
 });

--- a/packages/netlify-cms-widget-markdown/src/serializers/__tests__/remarkShortcodes.spec.js
+++ b/packages/netlify-cms-widget-markdown/src/serializers/__tests__/remarkShortcodes.spec.js
@@ -22,7 +22,7 @@ function EditorComponent({ id = 'foo', fromBlock = jest.fn(), pattern }) {
     // The EditorComponent factory (packages/netlify-cms-core/src/valueObjects/EditorComponent.js)
     // modifies incoming regex patterns as follows
     pattern: new RegExp(
-      pattern.source.replace('^', '(?<=^|\n)').replace('$', '(?=$|\n)'),
+      pattern.source.replace(/(?<!\[|\\)\^/, '(?<=^|\n)').replace(/(?<!\\)\$/, '(?=$|\n)'),
       pattern.flags,
     ),
   };

--- a/packages/netlify-cms-widget-markdown/src/serializers/__tests__/remarkShortcodes.spec.js
+++ b/packages/netlify-cms-widget-markdown/src/serializers/__tests__/remarkShortcodes.spec.js
@@ -16,8 +16,7 @@ function process(value, plugins, processEat = () => {}) {
 }
 
 function EditorComponent({ id = 'foo', fromBlock = jest.fn(), pattern }) {
-  // initialize pattern as RegExp as done in the EditorComponent value object
-  return { id, fromBlock, pattern: new RegExp(pattern, 'm') };
+  return { id, fromBlock, pattern };
 }
 
 describe('remarkParseShortcodes', () => {

--- a/packages/netlify-cms-widget-markdown/src/serializers/__tests__/remarkShortcodes.spec.js
+++ b/packages/netlify-cms-widget-markdown/src/serializers/__tests__/remarkShortcodes.spec.js
@@ -1,4 +1,5 @@
 import { Map, OrderedMap } from 'immutable';
+
 import { remarkParseShortcodes } from '../remarkShortcodes';
 
 // Stub of Remark Parser

--- a/packages/netlify-cms-widget-markdown/src/serializers/__tests__/remarkShortcodes.spec.js
+++ b/packages/netlify-cms-widget-markdown/src/serializers/__tests__/remarkShortcodes.spec.js
@@ -19,12 +19,7 @@ function EditorComponent({ id = 'foo', fromBlock = jest.fn(), pattern }) {
   return {
     id,
     fromBlock,
-    // The EditorComponent factory (packages/netlify-cms-core/src/valueObjects/EditorComponent.js)
-    // modifies incoming regex patterns as follows
-    pattern: new RegExp(
-      pattern.source.replace(/(?<!\[|\\)\^/, '(?<=^|\n)').replace(/(?<!\\)\$/, '(?=$|\n)'),
-      pattern.flags,
-    ),
+    pattern,
   };
 }
 
@@ -52,7 +47,7 @@ describe('remarkParseShortcodes', () => {
         expect.arrayContaining(['foo\n\nbar']),
       );
     });
-    it('should match out-of-order shortcodes', () => {
+    it('should match shortcodes based on order of occurrence in value', () => {
       const fooEditorComponent = EditorComponent({ id: 'foo', pattern: /foo/ });
       const barEditorComponent = EditorComponent({ id: 'bar', pattern: /bar/ });
       process(
@@ -64,7 +59,7 @@ describe('remarkParseShortcodes', () => {
       );
       expect(fooEditorComponent.fromBlock).toHaveBeenCalledWith(expect.arrayContaining(['foo']));
     });
-    it('should match out-of-order shortcodes with line-end tokens', () => {
+    it('should match shortcodes based on order of occurrence in value even when some use line anchors', () => {
       const barEditorComponent = EditorComponent({ id: 'bar', pattern: /bar/ });
       const bazEditorComponent = EditorComponent({ id: 'baz', pattern: /^baz$/ });
       process(

--- a/packages/netlify-cms-widget-markdown/src/serializers/remarkShortcodes.js
+++ b/packages/netlify-cms-widget-markdown/src/serializers/remarkShortcodes.js
@@ -57,7 +57,7 @@ function createShortcodeTokenizer({ plugins }) {
     // select the first by its occurrence in `value`. This ensures we won't
     // skip a plugin that occurs later in the plugin registry, but earlier
     // in the `value`.
-    const [{ plugin, match }] = plugins
+    const [{ plugin, match } = {}] = plugins
       .toArray()
       .map(plugin => ({
         match: value.match(plugin.pattern) || matchFromLines({ trimmedLines, plugin }),

--- a/packages/netlify-cms-widget-markdown/src/serializers/remarkShortcodes.js
+++ b/packages/netlify-cms-widget-markdown/src/serializers/remarkShortcodes.js
@@ -10,6 +10,33 @@ export function remarkParseShortcodes({ plugins }) {
 
 function createShortcodeTokenizer({ plugins }) {
   return function tokenizeShortcode(eat, value, silent) {
+    // Plugin patterns may rely on `^` and `$` tokens, even if they don't
+    // use the multiline flag. To support this, we fall back to searching
+    // through each line individually, trimming trailing whitespace and
+    // newlines, if we don't initially match on a pattern. We keep track of
+    // the starting position of each line so that we can sort correctly
+    // across the full multilen matches.
+    const trimmedLines = value
+      .split('\n\n')
+      .reduce((acc, line) => {
+        const [
+          { start: previousLineStart, originalLength: previousLineOriginalLength } = {
+            start: 0,
+            originalLength: 0,
+          },
+        ] = acc;
+        return [
+          {
+            line: line.trimEnd(),
+            start: previousLineStart + previousLineOriginalLength + 2,
+            originalLength: line.length,
+          },
+          ...acc,
+        ];
+      }, [])
+      .reverse()
+      .map(({ line, start }) => ({ line, start }));
+
     // Attempt to find a regex match for each plugin's pattern, and then
     // select the first by its occurence in `value`. This ensures we won't
     // skip a plugin that occurs later in the plugin registry, but earlier
@@ -18,7 +45,17 @@ function createShortcodeTokenizer({ plugins }) {
       plugins
         .toList()
         .map(plugin => ({
-          match: value.match(plugin.pattern),
+          match:
+            value.match(plugin.pattern) ||
+            trimmedLines
+              .map(({ line, start }) => {
+                const match = line.match(plugin.pattern);
+                if (match) {
+                  match.index += start;
+                }
+                return match;
+              })
+              .find(match => !!match),
           plugin,
         }))
         .filter(({ match }) => !!match)

--- a/packages/netlify-cms-widget-markdown/src/serializers/remarkShortcodes.js
+++ b/packages/netlify-cms-widget-markdown/src/serializers/remarkShortcodes.js
@@ -10,12 +10,6 @@ export function remarkParseShortcodes({ plugins }) {
 
 function createShortcodeTokenizer({ plugins }) {
   return function tokenizeShortcode(eat, value, silent) {
-    // Plugin patterns may rely on `^` and `$` tokens, even if they don't
-    // use the multiline flag. To support this, we fall back to searching
-    // through each line individually, trimming trailing whitespace and
-    // newlines, if we don't initially match on a pattern.
-    const trimmedLines = value.split('\n\n').map(line => line.trimEnd());
-
     // Attempt to find a regex match for each plugin's pattern, and then
     // select the first by its occurence in `value`. This ensures we won't
     // skip a plugin that occurs later in the plugin registry, but earlier
@@ -24,9 +18,7 @@ function createShortcodeTokenizer({ plugins }) {
       plugins
         .toList()
         .map(plugin => ({
-          match:
-            value.match(plugin.pattern) ||
-            trimmedLines.map(line => line.match(plugin.pattern)).find(match => !!match),
+          match: value.match(plugin.pattern),
           plugin,
         }))
         .filter(({ match }) => !!match)

--- a/packages/netlify-cms-widget-markdown/src/serializers/remarkShortcodes.js
+++ b/packages/netlify-cms-widget-markdown/src/serializers/remarkShortcodes.js
@@ -57,15 +57,14 @@ function createShortcodeTokenizer({ plugins }) {
     // select the first by its occurrence in `value`. This ensures we won't
     // skip a plugin that occurs later in the plugin registry, but earlier
     // in the `value`.
-    const { plugin, match } =
-      plugins
-        .toList()
-        .map(plugin => ({
-          match: value.match(plugin.pattern) || matchFromLines({ trimmedLines, plugin }),
-          plugin,
-        }))
-        .filter(({ match }) => !!match)
-        .reduce((a, b) => (a.match.index < b.match.index ? a : b)) ?? {};
+    const [{ plugin, match }] = plugins
+      .toArray()
+      .map(plugin => ({
+        match: value.match(plugin.pattern) || matchFromLines({ trimmedLines, plugin }),
+        plugin,
+      }))
+      .filter(({ match }) => !!match)
+      .sort((a, b) => a.match.index - b.match.index);
 
     if (match) {
       if (silent) {

--- a/packages/netlify-cms-widget-markdown/src/serializers/remarkShortcodes.js
+++ b/packages/netlify-cms-widget-markdown/src/serializers/remarkShortcodes.js
@@ -10,17 +10,16 @@ export function remarkParseShortcodes({ plugins }) {
 
 function createShortcodeTokenizer({ plugins }) {
   return function tokenizeShortcode(eat, value, silent) {
-    let match;
-    const potentialMatchValue = value.split('\n\n')[0].trimEnd();
-    const plugin = plugins.find(plugin => {
-      match = value.match(plugin.pattern);
+    const matches = plugins
+      .toList()
+      .map(plugin => ({
+        match: value.match(plugin.pattern),
+        plugin,
+      }))
+      .filter(({ match }) => !!match)
+      .sort((a, b) => a.match.index - b.match.index);
 
-      if (!match) {
-        match = potentialMatchValue.match(plugin.pattern);
-      }
-
-      return !!match;
-    });
+    const { plugin, match } = matches.get(0) ?? {};
 
     if (match) {
       if (silent) {

--- a/packages/netlify-cms-widget-markdown/src/serializers/remarkShortcodes.js
+++ b/packages/netlify-cms-widget-markdown/src/serializers/remarkShortcodes.js
@@ -20,17 +20,17 @@ function createShortcodeTokenizer({ plugins }) {
     // select the first by its occurence in `value`. This ensures we won't
     // skip a plugin that occurs later in the plugin registry, but earlier
     // in the `value`.
-    const { plugin, match } = plugins
-      .toList()
-      .map(plugin => ({
-        match: value.match(plugin.pattern) ||
-          trimmedLines
-            .map(line => line.match(plugin.pattern))
-            .find(match => !!match),
-        plugin,
-      }))
-      .filter(({ match }) => !!match)
-      .reduce((a, b) => a.match.index < b.match.index ? a : b) ?? {};
+    const { plugin, match } =
+      plugins
+        .toList()
+        .map(plugin => ({
+          match:
+            value.match(plugin.pattern) ||
+            trimmedLines.map(line => line.match(plugin.pattern)).find(match => !!match),
+          plugin,
+        }))
+        .filter(({ match }) => !!match)
+        .reduce((a, b) => (a.match.index < b.match.index ? a : b)) ?? {};
 
     if (match) {
       if (silent) {

--- a/packages/netlify-cms-widget-markdown/src/serializers/remarkShortcodes.js
+++ b/packages/netlify-cms-widget-markdown/src/serializers/remarkShortcodes.js
@@ -15,7 +15,7 @@ function createShortcodeTokenizer({ plugins }) {
     // through each line individually, trimming trailing whitespace and
     // newlines, if we don't initially match on a pattern. We keep track of
     // the starting position of each line so that we can sort correctly
-    // across the full multilen matches.
+    // across the full multiline matches.
     const trimmedLines = value
       .split('\n\n')
       .reduce((acc, line) => {
@@ -38,7 +38,7 @@ function createShortcodeTokenizer({ plugins }) {
       .map(({ line, start }) => ({ line, start }));
 
     // Attempt to find a regex match for each plugin's pattern, and then
-    // select the first by its occurence in `value`. This ensures we won't
+    // select the first by its occurrence in `value`. This ensures we won't
     // skip a plugin that occurs later in the plugin registry, but earlier
     // in the `value`.
     const { plugin, match } =

--- a/packages/netlify-cms-widget-markdown/src/serializers/remarkShortcodes.js
+++ b/packages/netlify-cms-widget-markdown/src/serializers/remarkShortcodes.js
@@ -10,16 +10,27 @@ export function remarkParseShortcodes({ plugins }) {
 
 function createShortcodeTokenizer({ plugins }) {
   return function tokenizeShortcode(eat, value, silent) {
-    const matches = plugins
+    // Plugin patterns may rely on `^` and `$` tokens, even if they don't
+    // use the multiline flag. To support this, we fall back to searching
+    // through each line individually, trimming trailing whitespace and
+    // newlines, if we don't initially match on a pattern.
+    const trimmedLines = value.split('\n\n').map(line => line.trimEnd());
+
+    // Attempt to find a regex match for each plugin's pattern, and then
+    // select the first by its occurence in `value`. This ensures we won't
+    // skip a plugin that occurs later in the plugin registry, but earlier
+    // in the `value`.
+    const { plugin, match } = plugins
       .toList()
       .map(plugin => ({
-        match: value.match(plugin.pattern),
+        match: value.match(plugin.pattern) ||
+          trimmedLines
+            .map(line => line.match(plugin.pattern))
+            .find(match => !!match),
         plugin,
       }))
       .filter(({ match }) => !!match)
-      .sort((a, b) => a.match.index - b.match.index);
-
-    const { plugin, match } = matches.get(0) ?? {};
+      .reduce((a, b) => a.match.index < b.match.index ? a : b) ?? {};
 
     if (match) {
       if (silent) {

--- a/packages/netlify-cms-widget-markdown/src/serializers/remarkShortcodes.js
+++ b/packages/netlify-cms-widget-markdown/src/serializers/remarkShortcodes.js
@@ -33,6 +33,16 @@ export function getLinesWithOffsets(value) {
   return trimmedLines;
 }
 
+function matchFromLines({ trimmedLines, plugin }) {
+  for (const { line, start } of trimmedLines) {
+    const match = line.match(plugin.pattern);
+    if (match) {
+      match.index += start;
+      return match;
+    }
+  }
+}
+
 function createShortcodeTokenizer({ plugins }) {
   return function tokenizeShortcode(eat, value, silent) {
     // Plugin patterns may rely on `^` and `$` tokens, even if they don't
@@ -51,17 +61,7 @@ function createShortcodeTokenizer({ plugins }) {
       plugins
         .toList()
         .map(plugin => ({
-          match:
-            value.match(plugin.pattern) ||
-            trimmedLines
-              .map(({ line, start }) => {
-                const match = line.match(plugin.pattern);
-                if (match) {
-                  match.index += start;
-                }
-                return match;
-              })
-              .find(match => !!match),
+          match: value.match(plugin.pattern) || matchFromLines({ trimmedLines, plugin }),
           plugin,
         }))
         .filter(({ match }) => !!match)

--- a/website/content/docs/custom-widgets.md
+++ b/website/content/docs/custom-widgets.md
@@ -143,7 +143,7 @@ CMS.registerEditorComponent({
   //
   // Additionally, it's recommended that you use non-greedy capturing groups (e.g.
   // `(.*?)` vs `(.*)`), especially if matching against newline characters.
-  pattern: /^<details>\s*?<summary>(.*?)<\/summary>\n\n(.*?)\n<\/details>$/ms,
+  pattern: /^<details>$\s*?<summary>(.*?)<\/summary>\n\n(.*?)\n^<\/details>$/ms,
   // Given a RegExp Match object
   // (https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/match#return_value),
   // return an object with one property for each field defined in `fields`.

--- a/website/content/docs/custom-widgets.md
+++ b/website/content/docs/custom-widgets.md
@@ -118,29 +118,69 @@ CMS.registerEditorComponent(definition)
 <script>
 CMS.registerEditorComponent({
   // Internal id of the component
-  id: "youtube",
+  id: "collapsible-note",
   // Visible label
-  label: "Youtube",
+  label: "Collapsible Note",
   // Fields the user need to fill out when adding an instance of the component
-  fields: [{name: 'id', label: 'Youtube Video ID', widget: 'string'}],
-  // Pattern to identify a block as being an instance of this component
-  pattern: /^youtube (\S+)$/,
-  // Function to extract data elements from the regexp match
+  fields: [
+    {
+      name: 'summary',
+      label: 'Summary',
+      widget: 'string'
+    },
+    {
+      name: 'details',
+      label: 'Details',
+      widget: 'markdown'
+    }
+  ],
+  // Regex pattern used to search for instances of this block in the markdown document.
+  // Patterns are run in a multline environment (against the entire markdown document),
+  // and so generally should make use of the multiline flag (`m`). If you need to capture
+  // newlines in your capturing groups, you can either use something like
+  // `([\S\s]*)`, or you can additionally enable the "dot all" flag (`s`),
+  // which will cause `(.*)` to match newlines as well.
+  //
+  // Additionally, it's recommended that you use non-greedy capturing groups (e.g.
+  // `(.*?)` vs `(.*)`), especially if matching against newline characters.
+  pattern: /^<details>\s*?<summary>(.*?)<\/summary>\n\n(.*?)\n<\/details>$/ms,
+  // Given a RegExp Match object
+  // (https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/match#return_value),
+  // return an object with one property for each field defined in `fields`.
+  //
+  // This is used to populate the custom widget in the markdown editor in the CMS.
   fromBlock: function(match) {
     return {
-      id: match[1]
+      summary: match[1],
+      detail: match[2]
     };
   },
-  // Function to create a text block from an instance of this component
-  toBlock: function(obj) {
-    return 'youtube ' + obj.id;
+  // Given an object with one property for each field defined in `fields`,
+  // return the string you wish to be inserted into your markdown.
+  //
+  // This is used to serialize the data from the custom widget to the
+  // markdown document
+  toBlock: function(data) {
+    return `
+<details>
+  <summary>${data.summary}</summary>
+
+  ${data.detail}
+
+</details>
+`;
   },
   // Preview output for this component. Can either be a string or a React component
   // (component gives better render performance)
-  toPreview: function(obj) {
-    return (
-      '<img src="http://img.youtube.com/vi/' + obj.id + '/maxresdefault.jpg" alt="Youtube Video"/>'
-    );
+  toPreview: function(data) {
+    return `
+<details>
+  <summary>${data.summary}</summary>
+
+  ${data.detail}
+
+</details>
+`;
   }
 });
 </script>


### PR DESCRIPTION
Fixes #5258

Reopen of #5259

<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines.

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first two fields are mandatory:
-->

## Summary
Updates `remarkShortcodes` to handle custom editor components occurring in
any order in a given markdown field.

Previously, `remarkShortcodes` (the remark tokenizer plugin in the markdown widget) was relying on [`Map.find`](https://github.com/netlify/netlify-cms/blob/master/packages/netlify-cms-widget-markdown/src/serializers/remarkShortcodes.js#L15-L23) to attempt to match the registered editor components' patterns against the remaining uneaten markdown. Because Map.find returns after the first instance that returns true, some valid shortcode matches can be "skipped" by the plugin, and parsed as plain text instead.

This made it almost impossible to use multiple shortcodes in a single markdown field. At least one of them regularly gets "skipped" by the tokenizer.

This also updates the initial value returned by `getEditorComponents()` to correctly be an instance of `Map`, instead of an empty array.

## Test plan

### Unit Tests

I've updated the unit tests in the following ways:

1. I'm now passing an instance of `Map` as the second argument to `process`, instead of an array, because [that's what is actually passed in the code](https://github.com/netlify/netlify-cms/blob/master/packages/netlify-cms-core/src/lib/registry.js#L27)
2. I've added a new unit test that covers this case, relying on an `OrderedMap` to force a specific coincidental state that would have triggered the bug in the previous code (I verified that this new test does in fact fail under the previous code)

### Manual Inspection

I built this package locally and linked it into the project that I first identified this bug in, and verified that it resolved this issue and that I could not identify any new issues:

Before:
<img width="733" alt="image" src="https://user-images.githubusercontent.com/5354254/114488019-93d22580-9bde-11eb-911e-21028ea78605.png">

After:
<img width="735" alt="image" src="https://user-images.githubusercontent.com/5354254/114487471-a7c95780-9bdd-11eb-93de-b54a7ae8c504.png">

## A picture of a cute animal (not mandatory but encouraged)

Some very tired dogs, as tribute:

![63794410038__8567FE98-D096-4B00-A216-F180FCFCD1F7](https://user-images.githubusercontent.com/5354254/114489204-bd8c4c00-9be0-11eb-996b-572b1ab058ee.jpg)

