### PR TITLE
Allow registering remark plugins

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,6 +1,7 @@
 module.exports = {
   setupFilesAfterEnv: ['<rootDir>/setupTestFramework.js'],
   moduleNameMapper: {
+    'netlify-cms-core': '<rootDir>/packages/netlify-cms-core/src/index.js',
     'netlify-cms-lib-auth': '<rootDir>/packages/netlify-cms-lib-auth/src/index.js',
     'netlify-cms-lib-util': '<rootDir>/packages/netlify-cms-lib-util/src/index.ts',
     'netlify-cms-ui-default': '<rootDir>/packages/netlify-cms-ui-default/src/index.js',

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,6 +1,7 @@
 module.exports = {
   setupFilesAfterEnv: ['<rootDir>/setupTestFramework.js'],
   moduleNameMapper: {
+    'netlify-cms-core/src/backend': '<rootDir>/packages/netlify-cms-core/src/backend',
     'netlify-cms-core': '<rootDir>/packages/netlify-cms-core/src/index.js',
     'netlify-cms-lib-auth': '<rootDir>/packages/netlify-cms-lib-auth/src/index.js',
     'netlify-cms-lib-util': '<rootDir>/packages/netlify-cms-lib-util/src/index.ts',

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,8 +1,6 @@
 module.exports = {
   setupFilesAfterEnv: ['<rootDir>/setupTestFramework.js'],
   moduleNameMapper: {
-    'netlify-cms-core/src/backend': '<rootDir>/packages/netlify-cms-core/src/backend',
-    'netlify-cms-core': '<rootDir>/packages/netlify-cms-core/src/index.js',
     'netlify-cms-lib-auth': '<rootDir>/packages/netlify-cms-lib-auth/src/index.js',
     'netlify-cms-lib-util': '<rootDir>/packages/netlify-cms-lib-util/src/index.ts',
     'netlify-cms-ui-default': '<rootDir>/packages/netlify-cms-ui-default/src/index.js',

--- a/packages/netlify-cms-core/index.d.ts
+++ b/packages/netlify-cms-core/index.d.ts
@@ -2,6 +2,7 @@
 declare module 'netlify-cms-core' {
   import type { ComponentType } from 'react';
   import type { List, Map } from 'immutable';
+  import type { Pluggable } from 'unified';
 
   export type CmsBackendType =
     | 'azure'
@@ -543,6 +544,7 @@ declare module 'netlify-cms-core' {
   export interface CMS {
     getBackend: (name: string) => CmsRegistryBackend | undefined;
     getEditorComponents: () => Map<string, ComponentType<any>>;
+    getRemarkPlugins: () => Array<Pluggable>;
     getLocale: (locale: string) => CmsLocalePhrases | undefined;
     getMediaLibrary: (name: string) => CmsMediaLibrary | undefined;
     getPreviewStyles: () => PreviewStyle[];
@@ -552,6 +554,7 @@ declare module 'netlify-cms-core' {
     init: (options?: InitOptions) => void;
     registerBackend: (name: string, backendClass: CmsBackendClass) => void;
     registerEditorComponent: (options: EditorComponentOptions) => void;
+    registerRemarkPlugin: (plugin: Pluggable) => void;
     registerEventListener: (
       eventListener: CmsEventListener,
       options?: CmsEventListenerOptions,

--- a/packages/netlify-cms-core/src/components/Editor/EditorControlPane/Widget.js
+++ b/packages/netlify-cms-core/src/components/Editor/EditorControlPane/Widget.js
@@ -4,6 +4,7 @@ import ImmutablePropTypes from 'react-immutable-proptypes';
 import { Map, List } from 'immutable';
 import { oneLine } from 'common-tags';
 
+import { getRemarkPlugins } from '../../../lib/registry';
 import ValidationErrorTypes from '../../../constants/validationErrorTypes';
 
 function truthy() {
@@ -326,6 +327,7 @@ export default class Widget extends Component {
       resolveWidget,
       widget,
       getEditorComponents,
+      getRemarkPlugins,
       query,
       queryHits,
       clearSearch,

--- a/packages/netlify-cms-core/src/components/Editor/EditorPreviewPane/EditorPreviewPane.js
+++ b/packages/netlify-cms-core/src/components/Editor/EditorPreviewPane/EditorPreviewPane.js
@@ -7,7 +7,12 @@ import Frame, { FrameContextConsumer } from 'react-frame-component';
 import { lengths } from 'netlify-cms-ui-default';
 import { connect } from 'react-redux';
 
-import { resolveWidget, getPreviewTemplate, getPreviewStyles } from '../../../lib/registry';
+import registry, {
+  resolveWidget,
+  getPreviewTemplate,
+  getPreviewStyles,
+  getRemarkPlugins,
+} from '../../../lib/registry';
 import { ErrorBoundary } from '../../UI';
 import { selectTemplateName, selectInferedField, selectField } from '../../../reducers/collections';
 import { boundGetAsset } from '../../../actions/media';
@@ -45,6 +50,7 @@ export class PreviewPane extends React.Component {
         entry={entry}
         fieldsMetaData={metadata}
         resolveWidget={resolveWidget}
+        getRemarkPlugins={getRemarkPlugins}
       />
     );
   };

--- a/packages/netlify-cms-core/src/components/Editor/EditorPreviewPane/EditorPreviewPane.js
+++ b/packages/netlify-cms-core/src/components/Editor/EditorPreviewPane/EditorPreviewPane.js
@@ -7,7 +7,7 @@ import Frame, { FrameContextConsumer } from 'react-frame-component';
 import { lengths } from 'netlify-cms-ui-default';
 import { connect } from 'react-redux';
 
-import registry, {
+import {
   resolveWidget,
   getPreviewTemplate,
   getPreviewStyles,

--- a/packages/netlify-cms-core/src/lib/registry.js
+++ b/packages/netlify-cms-core/src/lib/registry.js
@@ -26,6 +26,7 @@ const registry = {
   previewStyles: [],
   widgets: {},
   editorComponents: Map(),
+  remarkPlugins: [],
   widgetValueSerializers: {},
   mediaLibraries: [],
   locales: {},
@@ -43,6 +44,8 @@ export default {
   resolveWidget,
   registerEditorComponent,
   getEditorComponents,
+  registerRemarkPlugin,
+  getRemarkPlugins,
   registerWidgetValueSerializer,
   getWidgetValueSerializer,
   registerBackend,
@@ -161,6 +164,19 @@ export function registerEditorComponent(component) {
 }
 export function getEditorComponents() {
   return registry.editorComponents;
+}
+
+/**
+ * Remark plugins
+ */
+/** @typedef {import('unified').Pluggable} RemarkPlugin */
+/** @type {(plugin: RemarkPlugin) => void} */
+export function registerRemarkPlugin(plugin) {
+  registry.remarkPlugins.push(plugin);
+}
+/** @type {() => Array<RemarkPlugin>} */
+export function getRemarkPlugins() {
+  return registry.remarkPlugins;
 }
 
 /**

--- a/packages/netlify-cms-core/src/lib/registry.js
+++ b/packages/netlify-cms-core/src/lib/registry.js
@@ -46,7 +46,6 @@ export default {
   getEditorComponents,
   registerRemarkPlugin,
   getRemarkPlugins,
-  _clearRemarkPlugins,
   registerWidgetValueSerializer,
   getWidgetValueSerializer,
   registerBackend,
@@ -178,10 +177,6 @@ export function registerRemarkPlugin(plugin) {
 /** @type {() => Array<RemarkPlugin>} */
 export function getRemarkPlugins() {
   return registry.remarkPlugins;
-}
-/** @private */
-export function _clearRemarkPlugins() {
-  registry.remarkPlugins = [];
 }
 
 /**

--- a/packages/netlify-cms-core/src/lib/registry.js
+++ b/packages/netlify-cms-core/src/lib/registry.js
@@ -46,6 +46,7 @@ export default {
   getEditorComponents,
   registerRemarkPlugin,
   getRemarkPlugins,
+  _clearRemarkPlugins,
   registerWidgetValueSerializer,
   getWidgetValueSerializer,
   registerBackend,
@@ -177,6 +178,10 @@ export function registerRemarkPlugin(plugin) {
 /** @type {() => Array<RemarkPlugin>} */
 export function getRemarkPlugins() {
   return registry.remarkPlugins;
+}
+/** @private */
+export function _clearRemarkPlugins() {
+  registry.remarkPlugins = [];
 }
 
 /**

--- a/packages/netlify-cms-widget-markdown/src/MarkdownControl/VisualEditor.js
+++ b/packages/netlify-cms-widget-markdown/src/MarkdownControl/VisualEditor.js
@@ -45,8 +45,8 @@ function createEmptyRawDoc() {
   return { nodes: [emptyBlock] };
 }
 
-function createSlateValue(rawValue, { voidCodeBlock }, remarkPlugins) {
-  const rawDoc = rawValue && markdownToSlate(rawValue, { voidCodeBlock }, remarkPlugins);
+function createSlateValue(rawValue, { voidCodeBlock, remarkPlugins }) {
+  const rawDoc = rawValue && markdownToSlate(rawValue, { voidCodeBlock, remarkPlugins });
   const rawDocHasNodes = !isEmpty(get(rawDoc, 'nodes'));
   const document = Document.fromJSON(rawDocHasNodes ? rawDoc : createEmptyRawDoc());
   return Value.create({ document });
@@ -113,11 +113,10 @@ export default class Editor extends React.Component {
       remarkPlugins: this.remarkPlugins,
     });
     this.state = {
-      value: createSlateValue(
-        this.props.value,
-        { voidCodeBlock: !!this.codeBlockComponent },
-        this.remarkPlugins,
-      ),
+      value: createSlateValue(this.props.value, {
+        voidCodeBlock: !!this.codeBlockComponent,
+        remarkPlugins: this.remarkPlugins,
+      }),
     };
   }
 
@@ -139,11 +138,10 @@ export default class Editor extends React.Component {
     if (!this.state.value.equals(nextState.value)) return true;
 
     const raw = nextState.value.document.toJS();
-    const markdown = slateToMarkdown(
-      raw,
-      { voidCodeBlock: this.codeBlockComponent },
-      this.remarkPlugins,
-    );
+    const markdown = slateToMarkdown(raw, {
+      voidCodeBlock: this.codeBlockComponent,
+      remarkPlugins: this.remarkPlugins,
+    });
     return nextProps.value !== markdown;
   }
 
@@ -157,11 +155,10 @@ export default class Editor extends React.Component {
   componentDidUpdate(prevProps) {
     if (prevProps.value !== this.props.value) {
       this.setState({
-        value: createSlateValue(
-          this.props.value,
-          { voidCodeBlock: !!this.codeBlockComponent },
-          this.remarkPlugins,
-        ),
+        value: createSlateValue(this.props.value, {
+          voidCodeBlock: !!this.codeBlockComponent,
+          remarkPlugins: this.remarkPlugins,
+        }),
       });
     }
   }
@@ -201,11 +198,10 @@ export default class Editor extends React.Component {
   handleDocumentChange = debounce(editor => {
     const { onChange } = this.props;
     const raw = editor.value.document.toJS();
-    const markdown = slateToMarkdown(
-      raw,
-      { voidCodeBlock: this.codeBlockComponent },
-      this.remarkPlugins,
-    );
+    const markdown = slateToMarkdown(raw, {
+      voidCodeBlock: this.codeBlockComponent,
+      remarkPlugins: this.remarkPlugins,
+    });
     onChange(markdown);
   }, 150);
 

--- a/packages/netlify-cms-widget-markdown/src/MarkdownControl/VisualEditor.js
+++ b/packages/netlify-cms-widget-markdown/src/MarkdownControl/VisualEditor.js
@@ -110,6 +110,7 @@ export default class Editor extends React.Component {
       getAsset: props.getAsset,
       resolveWidget: props.resolveWidget,
       t: props.t,
+      remarkPlugins: this.remarkPlugins,
     });
     this.state = {
       value: createSlateValue(

--- a/packages/netlify-cms-widget-markdown/src/MarkdownControl/VisualEditor.js
+++ b/packages/netlify-cms-widget-markdown/src/MarkdownControl/VisualEditor.js
@@ -128,9 +128,11 @@ export default class Editor extends React.Component {
   };
 
   shouldComponentUpdate(nextProps, nextState) {
+    if (!this.state.value.equals(nextState.value)) return true;
+
     const raw = nextState.value.document.toJS();
     const markdown = slateToMarkdown(raw, { voidCodeBlock: this.codeBlockComponent });
-    return !this.state.value.equals(nextState.value) || nextProps.value !== markdown;
+    return nextProps.value !== markdown;
   }
 
   componentDidMount() {

--- a/packages/netlify-cms-widget-markdown/src/MarkdownControl/index.js
+++ b/packages/netlify-cms-widget-markdown/src/MarkdownControl/index.js
@@ -76,6 +76,7 @@ export default class MarkdownControl extends React.Component {
       classNameWrapper,
       field,
       getEditorComponents,
+      getRemarkPlugins,
       resolveWidget,
       t,
       isDisabled,
@@ -95,6 +96,7 @@ export default class MarkdownControl extends React.Component {
           value={value}
           field={field}
           getEditorComponents={getEditorComponents}
+          getRemarkPlugins={getRemarkPlugins}
           resolveWidget={resolveWidget}
           pendingFocus={pendingFocus && this.setFocusReceived}
           t={t}

--- a/packages/netlify-cms-widget-markdown/src/MarkdownControl/plugins/CopyPasteVisual.js
+++ b/packages/netlify-cms-widget-markdown/src/MarkdownControl/plugins/CopyPasteVisual.js
@@ -5,10 +5,10 @@ import isHotkey from 'is-hotkey';
 
 import { slateToMarkdown, markdownToSlate, htmlToSlate, markdownToHtml } from '../../serializers';
 
-function CopyPasteVisual({ getAsset, resolveWidget }) {
+function CopyPasteVisual({ getAsset, resolveWidget, remarkPlugins }) {
   function handleCopy(event, editor) {
-    const markdown = slateToMarkdown(editor.value.fragment.toJS());
-    const html = markdownToHtml(markdown, { getAsset, resolveWidget });
+    const markdown = slateToMarkdown(editor.value.fragment.toJS(), undefined, remarkPlugins);
+    const html = markdownToHtml(markdown, { getAsset, resolveWidget }, remarkPlugins);
     setEventTransfer(event, 'text', markdown);
     setEventTransfer(event, 'html', html);
     setEventTransfer(event, 'fragment', base64.serializeNode(editor.value.fragment));
@@ -28,7 +28,9 @@ function CopyPasteVisual({ getAsset, resolveWidget }) {
       }
 
       const html = data.types.includes('text/html') && data.getData('text/html');
-      const ast = html ? htmlToSlate(html) : markdownToSlate(data.getData('text/plain'));
+      const ast = html
+        ? htmlToSlate(html)
+        : markdownToSlate(data.getData('text/plain'), undefined, remarkPlugins);
       const doc = Document.fromJSON(ast);
       return editor.insertFragment(doc);
     },

--- a/packages/netlify-cms-widget-markdown/src/MarkdownControl/plugins/CopyPasteVisual.js
+++ b/packages/netlify-cms-widget-markdown/src/MarkdownControl/plugins/CopyPasteVisual.js
@@ -7,8 +7,8 @@ import { slateToMarkdown, markdownToSlate, htmlToSlate, markdownToHtml } from '.
 
 function CopyPasteVisual({ getAsset, resolveWidget, remarkPlugins }) {
   function handleCopy(event, editor) {
-    const markdown = slateToMarkdown(editor.value.fragment.toJS(), undefined, remarkPlugins);
-    const html = markdownToHtml(markdown, { getAsset, resolveWidget }, remarkPlugins);
+    const markdown = slateToMarkdown(editor.value.fragment.toJS(), { remarkPlugins });
+    const html = markdownToHtml(markdown, { getAsset, resolveWidget, remarkPlugins });
     setEventTransfer(event, 'text', markdown);
     setEventTransfer(event, 'html', html);
     setEventTransfer(event, 'fragment', base64.serializeNode(editor.value.fragment));
@@ -30,7 +30,7 @@ function CopyPasteVisual({ getAsset, resolveWidget, remarkPlugins }) {
       const html = data.types.includes('text/html') && data.getData('text/html');
       const ast = html
         ? htmlToSlate(html)
-        : markdownToSlate(data.getData('text/plain'), undefined, remarkPlugins);
+        : markdownToSlate(data.getData('text/plain'), { remarkPlugins });
       const doc = Document.fromJSON(ast);
       return editor.insertFragment(doc);
     },

--- a/packages/netlify-cms-widget-markdown/src/MarkdownControl/plugins/visual.js
+++ b/packages/netlify-cms-widget-markdown/src/MarkdownControl/plugins/visual.js
@@ -15,7 +15,7 @@ import Shortcode from './Shortcode';
 import { SLATE_DEFAULT_BLOCK_TYPE as defaultType } from '../../types';
 import Hotkey, { HOT_KEY_MAP } from './Hotkey';
 
-function plugins({ getAsset, resolveWidget, t }) {
+function plugins({ getAsset, resolveWidget, t, remarkPlugins }) {
   return [
     {
       onKeyDown(event, editor, next) {
@@ -51,7 +51,7 @@ function plugins({ getAsset, resolveWidget, t }) {
     CloseBlock({ defaultType }),
     SelectAll(),
     ForceInsert({ defaultType }),
-    CopyPasteVisual({ getAsset, resolveWidget }),
+    CopyPasteVisual({ getAsset, resolveWidget, remarkPlugins }),
     Shortcode({ defaultType }),
   ];
 }

--- a/packages/netlify-cms-widget-markdown/src/MarkdownPreview.js
+++ b/packages/netlify-cms-widget-markdown/src/MarkdownPreview.js
@@ -17,7 +17,7 @@ class MarkdownPreview extends React.Component {
       return null;
     }
 
-    const html = markdownToHtml(value, { getAsset, resolveWidget }, getRemarkPlugins());
+    const html = markdownToHtml(value, { getAsset, resolveWidget }, getRemarkPlugins?.());
     const toRender = field?.get('sanitize_preview', false) ? DOMPurify.sanitize(html) : html;
 
     return <WidgetPreviewContainer dangerouslySetInnerHTML={{ __html: toRender }} />;

--- a/packages/netlify-cms-widget-markdown/src/MarkdownPreview.js
+++ b/packages/netlify-cms-widget-markdown/src/MarkdownPreview.js
@@ -12,12 +12,12 @@ class MarkdownPreview extends React.Component {
   };
 
   render() {
-    const { value, getAsset, resolveWidget, field } = this.props;
+    const { value, getAsset, resolveWidget, field, getRemarkPlugins } = this.props;
     if (value === null) {
       return null;
     }
 
-    const html = markdownToHtml(value, { getAsset, resolveWidget });
+    const html = markdownToHtml(value, { getAsset, resolveWidget }, getRemarkPlugins());
     const toRender = field?.get('sanitize_preview', false) ? DOMPurify.sanitize(html) : html;
 
     return <WidgetPreviewContainer dangerouslySetInnerHTML={{ __html: toRender }} />;

--- a/packages/netlify-cms-widget-markdown/src/serializers/__tests__/remarkPlugins.spec.js
+++ b/packages/netlify-cms-widget-markdown/src/serializers/__tests__/remarkPlugins.spec.js
@@ -44,7 +44,7 @@ describe('registered remark plugins', () => {
             {
               type: 'link',
               title: null,
-              url: 'https://netlify.com',
+              url: 'https://this-value-should-be-replaced.com',
               children: [
                 {
                   type: 'text',

--- a/packages/netlify-cms-widget-markdown/src/serializers/__tests__/remarkPlugins.spec.js
+++ b/packages/netlify-cms-widget-markdown/src/serializers/__tests__/remarkPlugins.spec.js
@@ -9,8 +9,7 @@ describe('registered remark plugins', () => {
   });
 
   function withNetlifyLinks() {
-    return transformer;
-    function transformer(tree) {
+    return function transformer(tree) {
       visit(tree, 'link', function onLink(node) {
         node.url = 'https://netlify.com';
       });

--- a/packages/netlify-cms-widget-markdown/src/serializers/__tests__/remarkPlugins.spec.js
+++ b/packages/netlify-cms-widget-markdown/src/serializers/__tests__/remarkPlugins.spec.js
@@ -3,7 +3,7 @@ import visit from 'unist-util-visit';
 
 import { markdownToRemark, remarkToMarkdown } from '..';
 
-describe('remark plugins', () => {
+describe('registered remark plugins', () => {
   afterEach(() => {
     registry._clearRemarkPlugins();
   });
@@ -17,7 +17,7 @@ describe('remark plugins', () => {
     }
   }
 
-  it('should use remark transformer plugins from registry when converting mdast to markdown', () => {
+  it('should use remark transformer plugins when converting mdast to markdown', () => {
     registry.registerRemarkPlugin(withNetlifyLinks);
     const result = remarkToMarkdown({
       type: 'root',
@@ -66,7 +66,7 @@ describe('remark plugins', () => {
     );
   });
 
-  it('should use remark transformer plugins from registry when converting markdown to mdast', () => {
+  it('should use remark transformer plugins when converting markdown to mdast', () => {
     registry.registerRemarkPlugin(withNetlifyLinks);
     const result = markdownToRemark('Some text with [a link](https://example.com) in it.');
     expect(result).toMatchInlineSnapshot(`
@@ -182,7 +182,7 @@ Object {
 `);
   });
 
-  it('should use remark serializer plugins from registry when converting mdast to markdown', () => {
+  it('should use remark serializer plugins when converting mdast to markdown', () => {
     function withEscapedLessThanChar() {
       this.Compiler.prototype.visitors.text = node => {
         return node.value.replace(/</g, '&lt;');
@@ -207,7 +207,7 @@ Object {
     expect(result).toMatchInlineSnapshot(`"&lt;3 Netlify"`);
   });
 
-  it('should use remark preset with settings from registry when converting mdast to markdown', () => {
+  it('should use remark preset with settings when converting mdast to markdown', () => {
     const settings = {
       emphasis: '_',
       bullet: '-',

--- a/packages/netlify-cms-widget-markdown/src/serializers/__tests__/remarkPlugins.spec.js
+++ b/packages/netlify-cms-widget-markdown/src/serializers/__tests__/remarkPlugins.spec.js
@@ -1,0 +1,165 @@
+import registry from 'netlify-cms-core';
+import visit from 'unist-util-visit';
+
+import { markdownToRemark, remarkToMarkdown } from '..';
+
+describe('remark plugins', () => {
+  function withNetlifyLinks() {
+    return transformer;
+    function transformer(tree) {
+      visit(tree, 'link', function onLink(node) {
+        node.url = 'https://netlify.com';
+      });
+    }
+  }
+
+  it('should use remark transformer plugins from registry when converting mdast to markdown', () => {
+    registry.registerRemarkPlugin(withNetlifyLinks);
+    const result = remarkToMarkdown({
+      type: 'root',
+      children: [
+        {
+          type: 'paragraph',
+          children: [
+            {
+              type: 'text',
+              value: 'Some text with ',
+            },
+            {
+              type: 'link',
+              title: null,
+              url: 'https://example.com',
+              children: [
+                {
+                  type: 'text',
+                  value: 'a link',
+                },
+              ],
+            },
+            {
+              type: 'text',
+              value: ' in it.',
+            },
+          ],
+        },
+      ],
+    });
+    expect(result).toMatchInlineSnapshot(`"Some text with [a link](https://netlify.com) in it."`);
+  });
+
+  it('should use remark transformer plugins from registry when converting markdown to mdast', () => {
+    registry.registerRemarkPlugin(withNetlifyLinks);
+    const result = markdownToRemark('Some text with [a link](https://example.com) in it.');
+    expect(result).toMatchInlineSnapshot(`
+Object {
+  "children": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [],
+          "position": Position {
+            "end": Object {
+              "column": 16,
+              "line": 1,
+              "offset": 15,
+            },
+            "indent": Array [],
+            "start": Object {
+              "column": 1,
+              "line": 1,
+              "offset": 0,
+            },
+          },
+          "type": "text",
+          "value": "Some text with ",
+        },
+        Object {
+          "children": Array [
+            Object {
+              "children": Array [],
+              "position": Position {
+                "end": Object {
+                  "column": 23,
+                  "line": 1,
+                  "offset": 22,
+                },
+                "indent": Array [],
+                "start": Object {
+                  "column": 17,
+                  "line": 1,
+                  "offset": 16,
+                },
+              },
+              "type": "text",
+              "value": "a link",
+            },
+          ],
+          "position": Position {
+            "end": Object {
+              "column": 45,
+              "line": 1,
+              "offset": 44,
+            },
+            "indent": Array [],
+            "start": Object {
+              "column": 16,
+              "line": 1,
+              "offset": 15,
+            },
+          },
+          "title": null,
+          "type": "link",
+          "url": "https://netlify.com",
+        },
+        Object {
+          "children": Array [],
+          "position": Position {
+            "end": Object {
+              "column": 52,
+              "line": 1,
+              "offset": 51,
+            },
+            "indent": Array [],
+            "start": Object {
+              "column": 45,
+              "line": 1,
+              "offset": 44,
+            },
+          },
+          "type": "text",
+          "value": " in it.",
+        },
+      ],
+      "position": Position {
+        "end": Object {
+          "column": 52,
+          "line": 1,
+          "offset": 51,
+        },
+        "indent": Array [],
+        "start": Object {
+          "column": 1,
+          "line": 1,
+          "offset": 0,
+        },
+      },
+      "type": "paragraph",
+    },
+  ],
+  "position": Object {
+    "end": Object {
+      "column": 52,
+      "line": 1,
+      "offset": 51,
+    },
+    "start": Object {
+      "column": 1,
+      "line": 1,
+      "offset": 0,
+    },
+  },
+  "type": "root",
+}
+`);
+  });
+});

--- a/packages/netlify-cms-widget-markdown/src/serializers/__tests__/remarkPlugins.spec.js
+++ b/packages/netlify-cms-widget-markdown/src/serializers/__tests__/remarkPlugins.spec.js
@@ -1,13 +1,8 @@
-import registry from 'netlify-cms-core';
 import visit from 'unist-util-visit';
 
 import { markdownToRemark, remarkToMarkdown } from '..';
 
 describe('registered remark plugins', () => {
-  afterEach(() => {
-    registry._clearRemarkPlugins();
-  });
-
   function withNetlifyLinks() {
     return function transformer(tree) {
       visit(tree, 'link', function onLink(node) {
@@ -17,57 +12,63 @@ describe('registered remark plugins', () => {
   }
 
   it('should use remark transformer plugins when converting mdast to markdown', () => {
-    registry.registerRemarkPlugin(withNetlifyLinks);
-    const result = remarkToMarkdown({
-      type: 'root',
-      children: [
-        {
-          type: 'paragraph',
-          children: [
-            {
-              type: 'text',
-              value: 'Some ',
-            },
-            {
-              type: 'emphasis',
-              children: [
-                {
-                  type: 'text',
-                  value: 'important',
-                },
-              ],
-            },
-            {
-              type: 'text',
-              value: ' text with ',
-            },
-            {
-              type: 'link',
-              title: null,
-              url: 'https://this-value-should-be-replaced.com',
-              children: [
-                {
-                  type: 'text',
-                  value: 'a link',
-                },
-              ],
-            },
-            {
-              type: 'text',
-              value: ' in it.',
-            },
-          ],
-        },
-      ],
-    });
+    const plugins = [withNetlifyLinks];
+    const result = remarkToMarkdown(
+      {
+        type: 'root',
+        children: [
+          {
+            type: 'paragraph',
+            children: [
+              {
+                type: 'text',
+                value: 'Some ',
+              },
+              {
+                type: 'emphasis',
+                children: [
+                  {
+                    type: 'text',
+                    value: 'important',
+                  },
+                ],
+              },
+              {
+                type: 'text',
+                value: ' text with ',
+              },
+              {
+                type: 'link',
+                title: null,
+                url: 'https://this-value-should-be-replaced.com',
+                children: [
+                  {
+                    type: 'text',
+                    value: 'a link',
+                  },
+                ],
+              },
+              {
+                type: 'text',
+                value: ' in it.',
+              },
+            ],
+          },
+        ],
+      },
+      plugins,
+    );
     expect(result).toMatchInlineSnapshot(
       `"Some *important* text with [a link](https://netlify.com) in it."`,
     );
   });
 
   it('should use remark transformer plugins when converting markdown to mdast', () => {
-    registry.registerRemarkPlugin(withNetlifyLinks);
-    const result = markdownToRemark('Some text with [a link](https://example.com) in it.');
+    const plugins = [withNetlifyLinks];
+    const result = markdownToRemark(
+      'Some text with [a link](https://this-value-should-be-replaced.com) in it.',
+      plugins,
+    );
     expect(result).toMatchInlineSnapshot(`
 Object {
   "children": Array [
@@ -114,9 +115,9 @@ Object {
           ],
           "position": Position {
             "end": Object {
-              "column": 45,
+              "column": 67,
               "line": 1,
-              "offset": 44,
+              "offset": 66,
             },
             "indent": Array [],
             "start": Object {
@@ -133,15 +134,15 @@ Object {
           "children": Array [],
           "position": Position {
             "end": Object {
-              "column": 52,
+              "column": 74,
               "line": 1,
-              "offset": 51,
+              "offset": 73,
             },
             "indent": Array [],
             "start": Object {
-              "column": 45,
+              "column": 67,
               "line": 1,
-              "offset": 44,
+              "offset": 66,
             },
           },
           "type": "text",
@@ -150,9 +151,9 @@ Object {
       ],
       "position": Position {
         "end": Object {
-          "column": 52,
+          "column": 74,
           "line": 1,
-          "offset": 51,
+          "offset": 73,
         },
         "indent": Array [],
         "start": Object {
@@ -166,9 +167,9 @@ Object {
   ],
   "position": Object {
     "end": Object {
-      "column": 52,
+      "column": 74,
       "line": 1,
-      "offset": 51,
+      "offset": 73,
     },
     "start": Object {
       "column": 1,
@@ -190,21 +191,24 @@ Object {
       }
     }
 
-    registry.registerRemarkPlugin(withEscapedLessThanChar);
-    const result = remarkToMarkdown({
-      type: 'root',
-      children: [
-        {
-          type: 'paragraph',
-          children: [
-            {
-              type: 'text',
-              value: '<3 Netlify',
-            },
-          ],
-        },
-      ],
-    });
+    const plugins = [withEscapedLessThanChar];
+    const result = remarkToMarkdown(
+      {
+        type: 'root',
+        children: [
+          {
+            type: 'paragraph',
+            children: [
+              {
+                type: 'text',
+                value: '<3 Netlify',
+              },
+            ],
+          },
+        ],
+      },
+      plugins,
+    );
     expect(result).toMatchInlineSnapshot(`"&lt;3 Netlify"`);
   });
 
@@ -214,74 +218,77 @@ Object {
       bullet: '-',
     };
 
-    registry.registerRemarkPlugin({ settings });
-    const result = remarkToMarkdown({
-      type: 'root',
-      children: [
-        {
-          type: 'paragraph',
-          children: [
-            {
-              type: 'text',
-              value: 'Some ',
-            },
-            {
-              type: 'emphasis',
-              children: [
-                {
-                  type: 'text',
-                  value: 'important',
-                },
-              ],
-            },
-            {
-              type: 'text',
-              value: ' points:',
-            },
-          ],
-        },
-        {
-          type: 'list',
-          ordered: false,
-          start: null,
-          spread: false,
-          children: [
-            {
-              type: 'listItem',
-              spread: false,
-              checked: null,
-              children: [
-                {
-                  type: 'paragraph',
-                  children: [
-                    {
-                      type: 'text',
-                      value: 'One',
-                    },
-                  ],
-                },
-              ],
-            },
-            {
-              type: 'listItem',
-              spread: false,
-              checked: null,
-              children: [
-                {
-                  type: 'paragraph',
-                  children: [
-                    {
-                      type: 'text',
-                      value: 'Two',
-                    },
-                  ],
-                },
-              ],
-            },
-          ],
-        },
-      ],
-    });
+    const plugins = [{ settings }];
+    const result = remarkToMarkdown(
+      {
+        type: 'root',
+        children: [
+          {
+            type: 'paragraph',
+            children: [
+              {
+                type: 'text',
+                value: 'Some ',
+              },
+              {
+                type: 'emphasis',
+                children: [
+                  {
+                    type: 'text',
+                    value: 'important',
+                  },
+                ],
+              },
+              {
+                type: 'text',
+                value: ' points:',
+              },
+            ],
+          },
+          {
+            type: 'list',
+            ordered: false,
+            start: null,
+            spread: false,
+            children: [
+              {
+                type: 'listItem',
+                spread: false,
+                checked: null,
+                children: [
+                  {
+                    type: 'paragraph',
+                    children: [
+                      {
+                        type: 'text',
+                        value: 'One',
+                      },
+                    ],
+                  },
+                ],
+              },
+              {
+                type: 'listItem',
+                spread: false,
+                checked: null,
+                children: [
+                  {
+                    type: 'paragraph',
+                    children: [
+                      {
+                        type: 'text',
+                        value: 'Two',
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+      plugins,
+    );
     expect(result).toMatchInlineSnapshot(`
 "Some _important_ points:
 

--- a/packages/netlify-cms-widget-markdown/src/serializers/__tests__/remarkPlugins.spec.js
+++ b/packages/netlify-cms-widget-markdown/src/serializers/__tests__/remarkPlugins.spec.js
@@ -13,7 +13,7 @@ describe('registered remark plugins', () => {
       visit(tree, 'link', function onLink(node) {
         node.url = 'https://netlify.com';
       });
-    }
+    };
   }
 
   it('should use remark transformer plugins when converting mdast to markdown', () => {
@@ -183,9 +183,11 @@ Object {
 
   it('should use remark serializer plugins when converting mdast to markdown', () => {
     function withEscapedLessThanChar() {
-      this.Compiler.prototype.visitors.text = node => {
-        return node.value.replace(/</g, '&lt;');
-      };
+      if (this.Compiler) {
+        this.Compiler.prototype.visitors.text = node => {
+          return node.value.replace(/</g, '&lt;');
+        };
+      }
     }
 
     registry.registerRemarkPlugin(withEscapedLessThanChar);

--- a/packages/netlify-cms-widget-markdown/src/serializers/index.js
+++ b/packages/netlify-cms-widget-markdown/src/serializers/index.js
@@ -154,8 +154,8 @@ export function remarkToMarkdown(obj, remarkPlugins) {
 /**
  * Convert Markdown to HTML.
  */
-export function markdownToHtml(markdown, { getAsset, resolveWidget } = {}) {
-  const mdast = markdownToRemark(markdown);
+export function markdownToHtml(markdown, { getAsset, resolveWidget } = {}, remarkPlugins) {
+  const mdast = markdownToRemark(markdown, remarkPlugins);
 
   const hast = unified()
     .use(remarkToRehypeShortcodes, { plugins: getEditorComponents(), getAsset, resolveWidget })

--- a/packages/netlify-cms-widget-markdown/src/serializers/index.js
+++ b/packages/netlify-cms-widget-markdown/src/serializers/index.js
@@ -154,7 +154,7 @@ export function remarkToMarkdown(obj, remarkPlugins) {
 /**
  * Convert Markdown to HTML.
  */
-export function markdownToHtml(markdown, { getAsset, resolveWidget } = {}, remarkPlugins) {
+export function markdownToHtml(markdown, { getAsset, resolveWidget, remarkPlugins = [] } = {}) {
   const mdast = markdownToRemark(markdown, remarkPlugins);
 
   const hast = unified()
@@ -199,7 +199,7 @@ export function htmlToSlate(html) {
 /**
  * Convert Markdown to Slate's Raw AST.
  */
-export function markdownToSlate(markdown, { voidCodeBlock } = {}, remarkPlugins) {
+export function markdownToSlate(markdown, { voidCodeBlock, remarkPlugins = [] } = {}) {
   const mdast = markdownToRemark(markdown, remarkPlugins);
 
   const slateRaw = unified()
@@ -219,7 +219,7 @@ export function markdownToSlate(markdown, { voidCodeBlock } = {}, remarkPlugins)
  * MDAST. The conversion is manual because Unified can only operate on Unist
  * trees.
  */
-export function slateToMarkdown(raw, { voidCodeBlock } = {}, remarkPlugins) {
+export function slateToMarkdown(raw, { voidCodeBlock, remarkPlugins = [] } = {}) {
   const mdast = slateToRemark(raw, { voidCodeBlock });
   const markdown = remarkToMarkdown(mdast, remarkPlugins);
   return markdown;

--- a/packages/netlify-cms-widget-markdown/src/serializers/index.js
+++ b/packages/netlify-cms-widget-markdown/src/serializers/index.js
@@ -128,9 +128,10 @@ export function remarkToMarkdown(obj) {
   };
 
   const processor = unified()
+    .use({ settings: remarkToMarkdownPluginOpts })
     .use(remarkEscapeMarkdownEntities)
     .use(remarkStripTrailingBreaks)
-    .use(remarkToMarkdownPlugin, remarkToMarkdownPluginOpts)
+    .use(remarkToMarkdownPlugin)
     .use(remarkAllowAllText)
     .use(createRemarkShortcodeStringifier({ plugins: getEditorComponents() }))
     .use(registry.getRemarkPlugins());

--- a/packages/netlify-cms-widget-markdown/src/serializers/index.js
+++ b/packages/netlify-cms-widget-markdown/src/serializers/index.js
@@ -7,6 +7,7 @@ import remarkToRehype from 'remark-rehype';
 import rehypeToHtml from 'rehype-stringify';
 import htmlToRehype from 'rehype-parse';
 import rehypeToRemark from 'rehype-remark';
+import registry from 'netlify-cms-core';
 
 import remarkToRehypeShortcodes from './remarkRehypeShortcodes';
 import rehypePaperEmoji from './rehypePaperEmoji';
@@ -73,7 +74,10 @@ export function markdownToRemark(markdown) {
   /**
    * Further transform the MDAST with plugins.
    */
-  const result = unified().use(remarkSquashReferences).runSync(parsed);
+  const result = unified()
+    .use(remarkSquashReferences)
+    .use(registry.getRemarkPlugins())
+    .runSync(parsed);
 
   return result;
 }
@@ -129,6 +133,7 @@ export function remarkToMarkdown(obj) {
   const processedMdast = unified()
     .use(remarkEscapeMarkdownEntities)
     .use(remarkStripTrailingBreaks)
+    .use(registry.getRemarkPlugins())
     .runSync(mdast);
 
   const markdown = unified()

--- a/website/content/docs/beta-features.md
+++ b/website/content/docs/beta-features.md
@@ -3,13 +3,14 @@ group: Configuration
 weight: 200
 title: Beta Features!
 ---
-We run new functionality in an open beta format from time to time. That means that this functionality is totally available for use, and we *think* it might be ready for primetime, but it could break or change without notice.
+
+We run new functionality in an open beta format from time to time. That means that this functionality is totally available for use, and we _think_ it might be ready for primetime, but it could break or change without notice.
 
 **Use these features at your own risk.**
 
 ## Working with a Local Git Repository
 
-***added in netlify-cms@2.10.17 / netlify-cms-app@2.11.14***
+**_added in netlify-cms@2.10.17 / netlify-cms-app@2.11.14_**
 
 You can connect Netlify CMS to a local Git repository, instead of working with a live repo.
 
@@ -26,7 +27,8 @@ local_backend: true
 
 3. Run `npx netlify-cms-proxy-server` from the root directory of the above repository.
 
-   * If the default port (8081) is in use, the proxy server won't start and you will see an error message. In this case, follow [these steps](#configure-the-netlify-cms-proxy-server-port-number) before proceeding.
+   - If the default port (8081) is in use, the proxy server won't start and you will see an error message. In this case, follow [these steps](#configure-the-netlify-cms-proxy-server-port-number) before proceeding.
+
 4. Start your local development server (e.g. run `gatsby develop`).
 5. Open <http://localhost:8000/admin> to verify that your can administer your content locally.
 
@@ -55,7 +57,7 @@ local_backend:
 
 ## GitLab and BitBucket Editorial Workflow Support
 
-***added in netlify-cms@2.10.6 / netlify-cms-app@2.11.3***
+**_added in netlify-cms@2.10.6 / netlify-cms-app@2.11.3_**
 
 You can enable the Editorial Workflow with the following line in your Netlify CMS `config.yml` file:
 
@@ -212,7 +214,7 @@ Learn more about the benefits of GraphQL in the [GraphQL docs](https://graphql.o
 
 When using the [GitHub backend](/docs/github-backend), you can use Netlify CMS to accept contributions from GitHub users without giving them access to your repository. When they make changes in the CMS, the CMS forks your repository for them behind the scenes, and all the changes are made to the fork. When the contributor is ready to submit their changes, they can set their draft as ready for review in the CMS. This triggers a pull request to your repository, which you can merge using the GitHub UI.
 
-At the same time, any contributors who *do* have write access to the repository can continue to use Netlify CMS normally.
+At the same time, any contributors who _do_ have write access to the repository can continue to use Netlify CMS normally.
 
 More details and setup instructions can be found on [the Open Authoring docs page](/docs/open-authoring).
 
@@ -285,11 +287,11 @@ And for the image field being populated with a value of `image.png`.
 
 Supports all of the [`slug` templates](/docs/configuration-options#slug) and:
 
-* `{{dirname}}` The path to the file's parent directory, relative to the collection's `folder`.
-* `{{filename}}` The file name without the extension part.
-* `{{extension}}` The file extension.
-* `{{media_folder}}` The global `media_folder`.
-* `{{public_folder}}` The global `public_folder`.
+- `{{dirname}}` The path to the file's parent directory, relative to the collection's `folder`.
+- `{{filename}}` The file name without the extension part.
+- `{{extension}}` The file extension.
+- `{{media_folder}}` The global `media_folder`.
+- `{{public_folder}}` The global `public_folder`.
 
 ## List Widget: Variable Types
 
@@ -305,9 +307,9 @@ To use variable types in the list widget, update your field configuration as fol
 
 ### Additional list widget options
 
-* `types`: a nested list of object widgets. All widgets must be of type `object`. Every object widget may define different set of fields.
-* `typeKey`: the name of the field that will be added to every item in list representing the name of the object widget that item belongs to. Ignored if `types` is not defined. Default is `type`.
-* `summary`: allows customization of a collapsed list item object in a similar way to a [collection summary](/docs/configuration-options/?#summary)
+- `types`: a nested list of object widgets. All widgets must be of type `object`. Every object widget may define different set of fields.
+- `typeKey`: the name of the field that will be added to every item in list representing the name of the object widget that item belongs to. Ignored if `types` is not defined. Default is `type`.
+- `summary`: allows customization of a collapsed list item object in a similar way to a [collection summary](/docs/configuration-options/?#summary)
 
 ### Example Configuration
 
@@ -502,12 +504,12 @@ Netlify CMS generates the following commit types:
 
 Template tags produce the following output:
 
-* `{{slug}}`: the url-safe filename of the entry changed
-* `{{collection}}`: the name of the collection containing the entry changed
-* `{{path}}`: the full path to the file changed
-* `{{message}}`: the relevant message based on the current change (e.g. the `create` message when an entry is created)
-* `{{author-login}}`: the login/username of the author
-* `{{author-name}}`: the full name of the author (might be empty based on the user's profile)
+- `{{slug}}`: the url-safe filename of the entry changed
+- `{{collection}}`: the name of the collection containing the entry changed
+- `{{path}}`: the full path to the file changed
+- `{{message}}`: the relevant message based on the current change (e.g. the `create` message when an entry is created)
+- `{{author-login}}`: the login/username of the author
+- `{{author-name}}`: the full name of the author (might be empty based on the user's profile)
 
 ## Image widget file size limit
 
@@ -634,6 +636,7 @@ collections:
 ```
 
 Nested collections expect the following directory structure:
+
 ```bash
 content
 └── pages
@@ -647,3 +650,19 @@ content
         │   └── index.md
         └── index.md
 ```
+
+## Remark plugins
+
+You can register plugins to customize [`remark`](https://github.com/remarkjs/remark), the library used by the markdown widget for serializing and deserializing markdown.
+
+```js
+import { registerRemarkPlugin } from 'netlify-cms-core';
+
+// register a plugin
+registerRemarkPlugin(plugin);
+
+// provide global settings to all plugins, e.g. for customizing `remark-stringify`
+registerRemarkPlugin({ settings: { bullet: '-' } });
+```
+
+Note that `netlify-widget-markdown` currently uses `remark@10`, so you should check a plugin's compatibility first.

--- a/website/content/docs/beta-features.md
+++ b/website/content/docs/beta-features.md
@@ -653,7 +653,7 @@ content
 
 ## Remark plugins
 
-You can register plugins to customize [`remark`](https://github.com/remarkjs/remark), the library used by the markdown widget for serializing and deserializing markdown.
+You can register plugins to customize [`remark`](https://github.com/remarkjs/remark), the library used by the richtext editor for serializing and deserializing markdown.
 
 ```js
 import { registerRemarkPlugin } from 'netlify-cms-core';

--- a/website/content/docs/beta-features.md
+++ b/website/content/docs/beta-features.md
@@ -656,13 +656,11 @@ content
 You can register plugins to customize [`remark`](https://github.com/remarkjs/remark), the library used by the richtext editor for serializing and deserializing markdown.
 
 ```js
-import { registerRemarkPlugin } from 'netlify-cms-core';
-
 // register a plugin
-registerRemarkPlugin(plugin);
+CMS.registerRemarkPlugin(plugin);
 
 // provide global settings to all plugins, e.g. for customizing `remark-stringify`
-registerRemarkPlugin({ settings: { bullet: '-' } });
+CMS.registerRemarkPlugin({ settings: { bullet: '-' } });
 ```
 
 Note that `netlify-widget-markdown` currently uses `remark@10`, so you should check a plugin's compatibility first.


### PR DESCRIPTION
**Summary**

This PR allows registering remark plugins (and presets) to customize how markdown is serialized/deserialized in the richtext editor.

Two usecases which have come up are (i) avoid saving autolinks for mdx-compatibility, and (ii) enforce formatting options.

fixes:  #5516
related: #4601

did not mark #4601 as fixed, because this only affects how the richtext editor serializes to markdown. to enforce formatting for the markdown editor, the plaintext content would probably have to be run through a remark pipeline [here](https://github.com/netlify/netlify-cms/blob/3bd36776d6c02a0669df9a5b11f105efee2d2ca3/packages/netlify-cms-widget-markdown/src/MarkdownControl/RawEditor.js#L100) but that means text would change while typing, which is odd (i also ran into issues where the textarea lost focus while typing when i tried it).

(sorry for the formatting chages, these were done by `yarn format`)

**Test plan**

Added seriailzer tests.

**Checklist**

Please add a `x` inside each checkbox:

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [x] Code is formatted via running `yarn format`.
- [x] Tests are passing via running `yarn test`.
- [x] The status checks are successful (continuous integration). Those can be seen below.
