### PR TITLE
fix(markdown-widget): apply list item style on each block in a selection

### DIFF
--- a/cypress/integration/markdown_widget_list_spec.js
+++ b/cypress/integration/markdown_widget_list_spec.js
@@ -164,6 +164,30 @@ describe('Markdown widget', () => {
           `);
       });
 
+      it('wrap each bottom-most block in a selection with a list item block', () => {
+        cy.focused()
+          .type('foo')
+          .enter()
+          .type('bar')
+          .enter()
+          .type('baz')
+          .setSelection('foo', 'baz')
+          .clickUnorderedListButton()
+          .confirmMarkdownEditorContent(`
+            <ul>
+              <li>
+                <p>foo</p>
+              </li>
+              <li>
+                <p>bar</p>
+              </li>
+              <li>
+                <p>baz</p>
+              </li>
+            </ul>
+          `)
+      })
+
       it('combines adjacent same-typed lists, not differently typed lists', () => {
         cy.focused()
           .type('foo')

--- a/cypress/integration/markdown_widget_list_spec.js
+++ b/cypress/integration/markdown_widget_list_spec.js
@@ -321,6 +321,8 @@ describe('Markdown widget', () => {
               </li>
               <li>
                 <p>bar</p>
+              </li>
+              <li>
                 <p>baz</p>
               </li>
             </ul>
@@ -334,14 +336,12 @@ describe('Markdown widget', () => {
               </li>
               <li>
                 <p>bar</p>
-                <ul>
-                  <li>
-                    <p>baz</p>
-                  </li>
-                </ul>
               </li>
-            </ul> 
+            </ul>
+            <p>baz</p>
           `)
+          .clickUnorderedListButton()
+          .tabkey()
           .setCursorAfter('baz')
           .enter()
           .tabkey()

--- a/cypress/integration/markdown_widget_list_spec.js
+++ b/cypress/integration/markdown_widget_list_spec.js
@@ -188,6 +188,22 @@ describe('Markdown widget', () => {
           `)
       })
 
+      it('unwraps list item block from each selected list item and unwraps all of them from the outer list block', () => {
+        cy.clickUnorderedListButton()
+          .type('foo')
+          .enter()
+          .type('bar')
+          .enter()
+          .type('baz')
+          .setSelection('foo', 'baz')
+          .clickUnorderedListButton()
+          .confirmMarkdownEditorContent(`
+            <p>foo</p>
+            <p>bar</p>
+            <p>baz</p>
+          `)
+      })
+      
       it('combines adjacent same-typed lists, not differently typed lists', () => {
         cy.focused()
           .type('foo')

--- a/packages/netlify-cms-widget-markdown/src/MarkdownControl/plugins/List.js
+++ b/packages/netlify-cms-widget-markdown/src/MarkdownControl/plugins/List.js
@@ -192,11 +192,9 @@ function ListPlugin({ defaultType, unorderedListType, orderedListType }) {
 
           default: {
             if (blocks.size > 1) {
-              const listItems = [];
-              blocks.forEach(block => {
-                const listItem = Block.create({ type: 'list-item', nodes: [block] });
-                listItems.push(listItem);
-              });
+              const listItems = blocks.map(block =>
+                Block.create({ type: 'list-item', nodes: [block] }),
+              );
               const listBlock = Block.create({ type: 'bulleted-list', nodes: listItems });
               editor
                 .delete()

--- a/packages/netlify-cms-widget-markdown/src/MarkdownControl/plugins/List.js
+++ b/packages/netlify-cms-widget-markdown/src/MarkdownControl/plugins/List.js
@@ -195,7 +195,7 @@ function ListPlugin({ defaultType, unorderedListType, orderedListType }) {
               const listItems = blocks.map(block =>
                 Block.create({ type: 'list-item', nodes: [block] }),
               );
-              const listBlock = Block.create({ type: 'bulleted-list', nodes: listItems });
+              const listBlock = Block.create({ type, nodes: listItems });
               editor
                 .delete()
                 .replaceNodeByKey(startBlock.key, listBlock)

--- a/packages/netlify-cms-widget-markdown/src/MarkdownControl/plugins/List.js
+++ b/packages/netlify-cms-widget-markdown/src/MarkdownControl/plugins/List.js
@@ -192,13 +192,16 @@ function ListPlugin({ defaultType, unorderedListType, orderedListType }) {
 
           default: {
             if (blocks.size > 1) {
-              const listItems = []
+              const listItems = [];
               blocks.forEach(block => {
-                const listItem = Block.create({ type: 'list-item', nodes: [block]})
-                listItems.push(listItem)
-              })
-              const listBlock = Block.create({ type: 'bulleted-list', nodes: listItems })
-              editor.delete().replaceNodeByKey(startBlock.key, listBlock).moveToRangeOfNode(listBlock)
+                const listItem = Block.create({ type: 'list-item', nodes: [block] });
+                listItems.push(listItem);
+              });
+              const listBlock = Block.create({ type: 'bulleted-list', nodes: listItems });
+              editor
+                .delete()
+                .replaceNodeByKey(startBlock.key, listBlock)
+                .moveToRangeOfNode(listBlock);
             } else {
               editor.wrapInList(type);
             }

--- a/packages/netlify-cms-widget-markdown/src/MarkdownControl/plugins/List.js
+++ b/packages/netlify-cms-widget-markdown/src/MarkdownControl/plugins/List.js
@@ -152,7 +152,7 @@ function ListPlugin({ defaultType, unorderedListType, orderedListType }) {
         if (!LIST_TYPES.includes(type)) {
           throw Error(`${type} is not a valid list type, must be one of: ${LIST_TYPES}`);
         }
-        const { startBlock } = editor.value;
+        const { startBlock, blocks } = editor.value;
         const target = editor.getBlockContainer();
 
         switch (get(target, 'type')) {
@@ -191,7 +191,17 @@ function ListPlugin({ defaultType, unorderedListType, orderedListType }) {
           }
 
           default: {
-            editor.wrapInList(type);
+            if (blocks.size > 1) {
+              const listItems = []
+              blocks.forEach(block => {
+                const listItem = Block.create({ type: 'list-item', nodes: [block]})
+                listItems.push(listItem)
+              })
+              const listBlock = Block.create({ type: 'bulleted-list', nodes: listItems })
+              editor.delete().replaceNodeByKey(startBlock.key, listBlock).moveToRangeOfNode(listBlock)
+            } else {
+              editor.wrapInList(type);
+            }
             break;
           }
         }


### PR DESCRIPTION
fixes #5654 
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines here:
https://github.com/netlify/netlify-cms/blob/master/CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first two fields are mandatory:
-->

**Summary**
When selecting multiple paragraph blocks and click List button, the current behaviour is to turn them into one list block which contains **one** list item, no matter how many paragraph blocks are selected.

This PR changes that behavior to make Netlify CMS editor more in line with the convention in most rich text editors. Each paragraph block in the selection will be wrapped with a respective list item. Then all the list items will be wrapped with one unifying list block.

HTML before clicking List button:
```
<p>Item 1</p>
<p>Item 2</p>
<p>Item 3</p>
```
HTML after clicking List button:
```
<ul>
  <li>
      <p>Item 1</p>
  </li>
  <li>
      <p>Item 2</p>
  </li>
  <li>
      <p>Item 3</p>
  </li>
</ul>

```
<!--
Explain the **motivation** for making this change.
What existing problem does the pull request solve?
-->

**Test plan**
TODO:
- [x] Write a test to check if all bottom-most blocks in a selection are turned into list items when clicking List button
- [x] Write a test to check if all list items in a selection are turned back into paragraph blocks when clicking List button 
<!--
Demonstrate the code is solid.
Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.
-->

**Checklist**

Please add a `x` inside each checkbox:

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [x] Code is formatted via running `yarn format`.
- [x] Tests are passing via running `yarn test`.
- [x] The status checks are successful (continuous integration). Those can be seen below.

