### PR TITLE
fix(widget-list): add missing translations in widget list top bar

### DIFF
--- a/packages/netlify-cms-locales/src/en/index.js
+++ b/packages/netlify-cms-locales/src/en/index.js
@@ -197,6 +197,10 @@ const en = {
       datetime: {
         now: 'Now',
       },
+      list: {
+        add: 'Add %{item}',
+        addType: 'Add %{item} item',
+      },
     },
   },
   mediaLibrary: {

--- a/packages/netlify-cms-ui-default/src/ObjectWidgetTopBar.js
+++ b/packages/netlify-cms-ui-default/src/ObjectWidgetTopBar.js
@@ -65,6 +65,7 @@ class ObjectWidgetTopBar extends React.Component {
     collapsed: PropTypes.bool,
     heading: PropTypes.node,
     label: PropTypes.string,
+    t: PropTypes.func.isRequired,
   };
 
   renderAddUI() {
@@ -82,7 +83,9 @@ class ObjectWidgetTopBar extends React.Component {
     return (
       <Dropdown
         renderButton={() => (
-          <StyledDropdownButton>Add {this.props.label} item</StyledDropdownButton>
+          <StyledDropdownButton>
+            {this.props.t('editor.editorWidgets.list.addType', { item: this.props.label })}
+          </StyledDropdownButton>
         )}
       >
         {types.map((type, idx) => (
@@ -99,7 +102,8 @@ class ObjectWidgetTopBar extends React.Component {
   renderAddButton() {
     return (
       <AddButton onClick={this.props.onAdd}>
-        Add {this.props.label} <Icon type="add" size="xsmall" />
+        {this.props.t('editor.editorWidgets.list.add', { item: this.props.label })}
+        <Icon type="add" size="xsmall" />
       </AddButton>
     );
   }

--- a/packages/netlify-cms-widget-list/src/ListControl.js
+++ b/packages/netlify-cms-widget-list/src/ListControl.js
@@ -128,6 +128,7 @@ export default class ListControl extends React.Component {
     clearFieldErrors: PropTypes.func.isRequired,
     fieldsErrors: ImmutablePropTypes.map.isRequired,
     entry: ImmutablePropTypes.map.isRequired,
+    t: PropTypes.func.isRequired,
   };
 
   static defaultProps = {
@@ -604,7 +605,7 @@ export default class ListControl extends React.Component {
   }
 
   renderListControl() {
-    const { value, forID, field, classNameWrapper } = this.props;
+    const { value, forID, field, classNameWrapper, t } = this.props;
     const { itemsCollapsed, listCollapsed } = this.state;
     const items = value || List();
     const label = field.get('label', field.get('name'));
@@ -635,6 +636,7 @@ export default class ListControl extends React.Component {
               label={labelSingular.toLowerCase()}
               onCollapseToggle={this.handleCollapseAllToggle}
               collapsed={selfCollapsed}
+              t={t}
             />
             {(!selfCollapsed || !minimizeCollapsedItems) && (
               <SortableList

--- a/packages/netlify-cms-widget-list/src/__tests__/ListControl.spec.js
+++ b/packages/netlify-cms-widget-list/src/__tests__/ListControl.spec.js
@@ -587,7 +587,7 @@ describe('ListControl', () => {
 
     expect(queryByTestId('object-control-0')).toBeNull();
 
-    fireEvent.click(getByText('Add list'));
+    fireEvent.click(getByText('editor.editorWidgets.list.add'));
 
     expect(props.onChange).toHaveBeenCalledTimes(1);
     expect(props.onChange).toHaveBeenCalledWith(fromJS([{}]));

--- a/packages/netlify-cms-widget-list/src/__tests__/__snapshots__/ListControl.spec.js.snap
+++ b/packages/netlify-cms-widget-list/src/__tests__/__snapshots__/ListControl.spec.js.snap
@@ -177,7 +177,7 @@ exports[`ListControl should add to list when add button is clicked 1`] = `
       <button
         class="emotion-10 emotion-11"
       >
-        Add list 
+        editor.editorWidgets.list.add
         <span
           class="emotion-0 emotion-8 emotion-2"
         >
@@ -406,7 +406,7 @@ exports[`ListControl should remove from list when remove button is clicked 1`] =
       <button
         class="emotion-10 emotion-11"
       >
-        Add list 
+        editor.editorWidgets.list.add
         <span
           class="emotion-0 emotion-8 emotion-2"
         >
@@ -665,7 +665,7 @@ exports[`ListControl should remove from list when remove button is clicked 2`] =
       <button
         class="emotion-10 emotion-11"
       >
-        Add list 
+        editor.editorWidgets.list.add
         <span
           class="emotion-0 emotion-8 emotion-2"
         >
@@ -905,7 +905,7 @@ exports[`ListControl should render list with fields with collapse = "false" and 
       <button
         class="emotion-10 emotion-11"
       >
-        Add list 
+        editor.editorWidgets.list.add
         <span
           class="emotion-0 emotion-8 emotion-2"
         >
@@ -1163,7 +1163,7 @@ exports[`ListControl should render list with fields with collapse = "false" and 
       <button
         class="emotion-10 emotion-11"
       >
-        Add list 
+        editor.editorWidgets.list.add
         <span
           class="emotion-0 emotion-8 emotion-2"
         >
@@ -1422,7 +1422,7 @@ exports[`ListControl should render list with fields with default collapse ("true
       <button
         class="emotion-10 emotion-11"
       >
-        Add list 
+        editor.editorWidgets.list.add
         <span
           class="emotion-0 emotion-8 emotion-2"
         >
@@ -1663,7 +1663,7 @@ exports[`ListControl should render list with fields with default collapse ("true
       <button
         class="emotion-10 emotion-11"
       >
-        Add list 
+        editor.editorWidgets.list.add
         <span
           class="emotion-0 emotion-8 emotion-2"
         >
@@ -1862,7 +1862,7 @@ exports[`ListControl should render list with nested object 1`] = `
       <button
         class="emotion-10 emotion-11"
       >
-        Add list 
+        editor.editorWidgets.list.add
         <span
           class="emotion-0 emotion-8 emotion-2"
         >
@@ -2120,7 +2120,7 @@ exports[`ListControl should render list with nested object with collapse = false
       <button
         class="emotion-10 emotion-11"
       >
-        Add list 
+        editor.editorWidgets.list.add
         <span
           class="emotion-0 emotion-8 emotion-2"
         >

--- a/packages/netlify-cms-widget-object/src/ObjectControl.js
+++ b/packages/netlify-cms-widget-object/src/ObjectControl.js
@@ -38,6 +38,7 @@ export default class ObjectControl extends React.Component {
     clearFieldErrors: PropTypes.func.isRequired,
     fieldsErrors: ImmutablePropTypes.map.isRequired,
     hasError: PropTypes.bool,
+    t: PropTypes.func.isRequired,
   };
 
   static defaultProps = {
@@ -135,7 +136,7 @@ export default class ObjectControl extends React.Component {
   };
 
   render() {
-    const { field, forID, classNameWrapper, forList, hasError } = this.props;
+    const { field, forID, classNameWrapper, forList, hasError, t } = this.props;
     const collapsed = forList ? this.props.collapsed : this.state.collapsed;
     const multiFields = field.get('fields');
     const singleField = field.get('field');
@@ -168,6 +169,7 @@ export default class ObjectControl extends React.Component {
                   collapsed={collapsed}
                   onCollapseToggle={this.handleCollapseToggle}
                   heading={collapsed && this.objectLabel()}
+                  t={t}
                 />
               )}
               <div


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines here:
https://github.com/netlify/netlify-cms/blob/master/CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first two fields are mandatory:
-->

**Summary**
While using the CMS in another language, I noticed that in the list widget some labels were not translatable.
This was also reported in [this issue](https://github.com/netlify/netlify-cms/issues/5471) by another user.

This PR fixes #5471 by updating the component responsible for displaying the `Add` button and exposes two new translations keys to respectively handle the basic and the variable types code paths.


**Test plan**

Here is a code extract where I'm willingly adding very verbose translations:
![Capture d’écran 2021-08-03 à 18 13 24](https://user-images.githubusercontent.com/15725942/128050107-cf00819b-849c-4ae7-8c16-3e63578007de.png)

Here is the expected result in the Kitchen Sink demo:
![Capture d’écran 2021-08-03 à 18 13 12](https://user-images.githubusercontent.com/15725942/128050097-d0cfa857-8209-4111-a19e-fc70b4c6f08e.png)

<!--
Demonstrate the code is solid.
Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.
-->

**Checklist**

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [x] Code is formatted via running `yarn format`.
- [x] Tests are passing via running `yarn test`.
- [ ] The status checks are successful (continuous integration). Those can be seen below.

**A picture of my cute cat**

![IMG_1184](https://user-images.githubusercontent.com/15725942/128047408-fa7ac054-0593-4e1d-a982-76b5cce681cd.jpg)

