### PR TITLE
fix: overflow table on the docs page

### DIFF
--- a/website/src/components/markdown.js
+++ b/website/src/components/markdown.js
@@ -78,6 +78,8 @@ const StyledMarkdown = styled.div`
     margin-bottom: 40px;
     width: 100%;
     text-align: left;
+    display: block;
+    overflow: auto;
   }
 
   tbody tr {

--- a/website/src/components/sidebar-layout.js
+++ b/website/src/components/sidebar-layout.js
@@ -6,7 +6,7 @@ import Page from './page';
 import { mq } from '../utils';
 
 const Children = styled.div`
-  overflow: auto;
+  overflow: hidden;
   padding-left: 2rem;
 `;
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines here:
https://github.com/netlify/netlify-cms/blob/master/CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first two fields are mandatory:
-->
Fixes #5659

**Summary**

When the table width is too wide, the scrollbar is not in the right place (at the bottom of the content page)

**Test plan**

Before:
![before - scrollbar not in the right place](https://user-images.githubusercontent.com/50788123/128146043-a4bf40fc-2c52-4544-918d-44ff7df28115.png)

After:
![after - scrollbar is in the right place](https://user-images.githubusercontent.com/50788123/128146171-75a18d54-3d9f-49a0-a12a-821864640757.png)


**Checklist**

Please add a `x` inside each checkbox:

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [x  Code is formatted via running `yarn format`.
- [x] Tests are passing via running `yarn test`.
- [ ] The status checks are successful (continuous integration). Those can be seen below.

**A picture of a cute animal (not mandatory but encouraged)**
