### PR TITLE
style: indicate that disabled publish button is not clickable

### DIFF
--- a/packages/netlify-cms-core/src/components/Workflow/WorkflowCard.js
+++ b/packages/netlify-cms-core/src/components/Workflow/WorkflowCard.js
@@ -84,6 +84,7 @@ const PublishButton = styled.button`
   &[disabled] {
     background-color: ${colorsRaw.grayLight};
     color: ${colorsRaw.gray};
+    cursor: not-allowed;
   }
 `;
 

--- a/packages/netlify-cms-core/src/components/Workflow/WorkflowCard.js
+++ b/packages/netlify-cms-core/src/components/Workflow/WorkflowCard.js
@@ -82,9 +82,7 @@ const PublishButton = styled.button`
   margin-left: 6px;
 
   &[disabled] {
-    background-color: ${colorsRaw.grayLight};
-    color: ${colorsRaw.gray};
-    cursor: not-allowed;
+    ${buttons.disabled};
   }
 `;
 


### PR DESCRIPTION
**Summary**

Currently, the "Publish" button in the Workflow tab has a "pointer" cursor, even when it is disabled, which can be confusing to users. This PR changes the cursor to `not-allowed` when the publish button is disabled.

![Screenshot_20210809_162806](https://user-images.githubusercontent.com/20753323/128722959-feaea16e-4975-4add-8a83-d89c25f67940.png)

**Test plan**

<!--
Demonstrate the code is solid.
Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.
-->

**Checklist**

Please add a `x` inside each checkbox:

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [x] Code is formatted via running `yarn format`.
- [x] Tests are passing via running `yarn test`.
- [ ] The status checks are successful (continuous integration). Those can be seen below.

**A picture of a cute animal (not mandatory but encouraged)**
