### PR TITLE
Make 'Now' button on DateTime widget consistent with 'Add' button on List widget

### DIFF
--- a/packages/netlify-cms-ui-default/src/ObjectWidgetTopBar.js
+++ b/packages/netlify-cms-ui-default/src/ObjectWidgetTopBar.js
@@ -41,14 +41,8 @@ const ExpandButton = styled.button`
 `;
 
 const AddButton = styled.button`
-  ${buttons.button};
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  padding: 2px 12px;
-  font-size: 12px;
-  font-weight: bold;
-  border-radius: 3px;
+  ${buttons.button}
+  ${buttons.widget}
 
   ${Icon} {
     margin-left: 6px;

--- a/packages/netlify-cms-ui-default/src/styles.js
+++ b/packages/netlify-cms-ui-default/src/styles.js
@@ -191,6 +191,15 @@ const buttons = {
     background-color: ${colorsRaw.gray};
     color: ${colorsRaw.white};
   `,
+  widget: css`
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    padding: 2px 12px;
+    font-size: 12px;
+    font-weight: bold;
+    border-radius: 3px;
+  `,
   medium: css`
     height: 27px;
     line-height: 27px;

--- a/packages/netlify-cms-widget-datetime/src/DateTimeControl.js
+++ b/packages/netlify-cms-widget-datetime/src/DateTimeControl.js
@@ -21,9 +21,7 @@ function NowButton({ t, handleChange }) {
       <button
         css={css`
           ${buttons.button}
-          ${buttons.default}
-    ${buttons.lightBlue}
-    ${buttons.small}
+          ${buttons.widget}
         `}
         onClick={() => {
           handleChange(moment());


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines here:
https://github.com/netlify/netlify-cms/blob/master/CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first two fields are mandatory:
-->

**Summary**

<!--
Explain the **motivation** for making this change.
What existing problem does the pull request solve?
-->
Closes #5706
Changed the styling of the 'Now' button on the DateTime widget to match the styling of the 'Add xxx' button on the List widget.

**Test plan**
Tested locally

<!--
Demonstrate the code is solid.
Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.
-->
![image](https://user-images.githubusercontent.com/40375803/129500066-e91c6070-2d67-4f01-924c-e1587e0d6898.png)
Figure: 'Now' button changed to be consistent with 'Add xxx' buttons

**Checklist**

Please add a `x` inside each checkbox:

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [x] Code is formatted via running `yarn format`.
- [x] Tests are passing via running `yarn test`.
- [x] The status checks are successful (continuous integration). Those can be seen below.

**A picture of a cute animal (not mandatory but encouraged)**
![image](https://user-images.githubusercontent.com/40375803/129500130-37bb558e-cd7b-4754-8cc9-3174099e7d73.png)
