### PR TITLE
fix(docs): fix typos in docs

### DIFF
--- a/website/content/docs/beta-features.md
+++ b/website/content/docs/beta-features.md
@@ -497,7 +497,7 @@ Netlify CMS generates the following commit types:
 | --------------- | ---------------------------------------- | ----------------------------------------------------------- |
 | `create`        | A new entry is created                   | `slug`, `path`, `collection`, `author-login`, `author-name` |
 | `update`        | An existing entry is changed             | `slug`, `path`, `collection`, `author-login`, `author-name` |
-| `delete`        | An exising entry is deleted              | `slug`, `path`, `collection`, `author-login`, `author-name` |
+| `delete`        | An existing entry is deleted             | `slug`, `path`, `collection`, `author-login`, `author-name` |
 | `uploadMedia`   | A media file is uploaded                 | `path`, `author-login`, `author-name`                       |
 | `deleteMedia`   | A media file is deleted                  | `path`, `author-login`, `author-name`                       |
 | `openAuthoring` | A commit is made via a forked repository | `message`, `author-login`, `author-name`                    |

--- a/website/content/docs/netlify-large-media.md
+++ b/website/content/docs/netlify-large-media.md
@@ -28,7 +28,7 @@ You can learn more about this feature in [Netlify's image transformation docs](h
 
 In repositories enabled with Netlify Large Media, Netlify CMS will use the image transformation query parameters to load thumbnail-sized images for the media gallery view. This makes images in the media gallery load significantly faster.
 
-**Note:** When using this option all tracked file types have to be imported into Large Media. For example if you track `*.jpg` but still have jpg-files that are not imported into Large Media the backend will throw an error. Check the [netlify docs](https://docs.netlify.com/large-media/setup/#migrate-files-from-git-history) on how to add previously commited files to Large Media.
+**Note:** When using this option all tracked file types have to be imported into Large Media. For example if you track `*.jpg` but still have jpg-files that are not imported into Large Media the backend will throw an error. Check the [netlify docs](https://docs.netlify.com/large-media/setup/#migrate-files-from-git-history) on how to add previously committed files to Large Media.
 
 You can disable the automatic image transformations with the `use_large_media_transforms_in_media_library` configuration setting, nested under `backend` in the CMS `config.yml` file:
 


### PR DESCRIPTION
**Summary**
made corrections to the typos i have found in the documentations.

**Checklist**

Please add a `x` inside each checkbox:

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [x] Code is formatted via running `yarn format`.
- [x] Tests are passing via running `yarn test`.
- [x] The status checks are successful (continuous integration). Those can be seen below.

**A picture of a cute animal (not mandatory but encouraged)**
