### PR TITLE
Fallback to title when overriding with empty or non-existant field

### DIFF
--- a/packages/netlify-cms-core/src/reducers/__tests__/collections.spec.js
+++ b/packages/netlify-cms-core/src/reducers/__tests__/collections.spec.js
@@ -383,7 +383,9 @@ describe('collections', () => {
   });
 
   describe('selectEntryCollectionTitle', () => {
-    const entry = fromJS({ data: { title: 'entry title', otherField: 'other field' } });
+    const entry = fromJS({
+      data: { title: 'entry title', otherField: 'other field', emptyLinkTitle: '' },
+    });
 
     it('should return the entry title if set', () => {
       const collection = fromJS({
@@ -411,6 +413,24 @@ describe('collections', () => {
       });
 
       expect(selectEntryCollectionTitle(collection, entry)).toEqual('other field');
+    });
+
+    it('should return the entry title if identifier_field content is not defined in collection', () => {
+      const collection = fromJS({
+        identifier_field: 'missingLinkTitle',
+        fields: [{ name: 'title' }, { name: 'otherField' }],
+      });
+
+      expect(selectEntryCollectionTitle(collection, entry)).toEqual('entry title');
+    });
+
+    it('should return the entry title if identifier_field content is empty', () => {
+      const collection = fromJS({
+        identifier_field: 'emptyLinkTitle',
+        fields: [{ name: 'title' }, { name: 'otherField' }, { name: 'emptyLinkTitle' }],
+      });
+
+      expect(selectEntryCollectionTitle(collection, entry)).toEqual('entry title');
     });
 
     it('should return the entry label of a file collection', () => {

--- a/packages/netlify-cms-core/src/reducers/collections.ts
+++ b/packages/netlify-cms-core/src/reducers/collections.ts
@@ -378,7 +378,14 @@ export function selectEntryCollectionTitle(collection: Collection, entry: EntryM
   // try to infer a title field from the entry data
   const entryData = entry.get('data');
   const titleField = selectInferedField(collection, 'title');
-  return titleField && entryData.getIn(keyToPathArray(titleField));
+  const result = titleField && entryData.getIn(keyToPathArray(titleField));
+
+  // if the custom field does not yield a result, fallback to 'title'
+  if (!result && titleField !== 'title') {
+    return entryData.getIn(keyToPathArray('title'));
+  }
+
+  return result;
 }
 
 export function selectDefaultSortableFields(


### PR DESCRIPTION
Fixes #5773 

**Summary**

When using the `nested depth` collections feature, netlify displays the entry title in the sidebar which can be quite long. Overriding via `identifier_field` requires that the `identifier_field` is present (and non-empty?) for all entries which is not desirable.

This change simply checks whether the overriding field content is non-empty and otherwise falls back to using the `title` content.

**Test plan**

The impact should be visible from the screentshots in #5773. To achieve that:

- Change `dev-test/config.yml` and `dev-test/index.html` as attached
 [config.yml.txt](https://github.com/netlify/netlify-cms/files/7090449/config.yml.txt)
[index.html.txt](https://github.com/netlify/netlify-cms/files/7090456/index.html.txt)

Netlify should then display the short title "Sub Direcory" in the last `pages` entry while without the patch the entry title will read "Sub Directory below Directory".

**Checklist**

Please add a `x` inside each checkbox:

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [x] Code is formatted via running `yarn format`.
- [x] Tests are passing via running `yarn test`.
- [x] The status checks are successful (continuous integration). Those can be seen below.

