### PR TITLE
chore(ci): pin Node.js version

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v2
         with:
-          node-version: '*'
+          node-version: '16.8'
           check-latest: true
       - name: log versions
         run: node --version && npm --version && yarn --version


### PR DESCRIPTION
Our CI fails due to https://github.com/nodejs/node/issues/40030