### PR TITLE
fix(widget-relation): don't invoke onChange if component is not mounted

### DIFF
--- a/packages/netlify-cms-widget-relation/src/RelationControl.js
+++ b/packages/netlify-cms-widget-relation/src/RelationControl.js
@@ -151,11 +151,12 @@ export default class RelationControl extends React.Component {
       this.mounted && this.setState({ initialOptions });
 
       //set metadata
-      onChange(value, {
-        [field.get('name')]: {
-          [field.get('collection')]: metadata,
-        },
-      });
+      this.mounted &&
+        onChange(value, {
+          [field.get('name')]: {
+            [field.get('collection')]: metadata,
+          },
+        });
     }
   }
 


### PR DESCRIPTION
**Summary**

Fixes https://github.com/netlify/netlify-cms/issues/5093
Probably fixes https://github.com/netlify/netlify-cms/issues/4891 too

This should fix a race condition in the relation widget, where slower to load entries override faster to load ones when switching between entries.

**Test plan**

Existing tests

**Checklist**

Please add a `x` inside each checkbox:

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [x] Code is formatted via running `yarn format`.
- [x] Tests are passing via running `yarn test`.
- [x] The status checks are successful (continuous integration). Those can be seen below.

**A picture of a cute animal (not mandatory but encouraged)**
🐱 