### PR TITLE
Upgrade immer to 9.0.6

### DIFF
--- a/packages/netlify-cms-core/package.json
+++ b/packages/netlify-cms-core/package.json
@@ -36,7 +36,7 @@
     "gotrue-js": "^0.9.24",
     "gray-matter": "^4.0.2",
     "history": "^4.7.2",
-    "immer": "^9.0.0",
+    "immer": "^9.0.6",
     "js-base64": "^3.0.0",
     "jwt-decode": "^3.0.0",
     "node-polyglot": "^2.3.0",


### PR DESCRIPTION
This is required to resolve a vulnerability, flagged by a GitHub dependabot alert
<img width="969" alt="Screenshot 2021-09-19 at 21 04 21" src="https://user-images.githubusercontent.com/5694621/133939754-6d7039b9-826a-4980-9df6-63ad55df66a8.png">
.
