### PR TITLE
fix(translations): correct catalan locale

### DIFF
--- a/packages/netlify-cms-locales/src/ca/index.js
+++ b/packages/netlify-cms-locales/src/ca/index.js
@@ -84,9 +84,9 @@ const ca = {
         max: '%{fieldLabel} ha de ser %{maxValue} o més.',
         rangeCount: '%{fieldLabel} ha de tenir entre %{minCount} i %{maxCount} element(s).',
         rangeCountExact: '%{fieldLabel} ha de tenir exactament %{count} element(s).',
-        rangeMin: '%{fieldLabel} ha de tenir com a mínim %{minCount} element(s).',
+        rangeMin: '%{fieldLabel} ha de tenir com a mínim %{minCount} d\'element(s).',
         rangeMax: '%{fieldLabel} ha de ser %{maxCount} o inferior.',
-        invalidPath: `'%{path}' no és un camí vàlid`,
+        invalidPath: `'%{path}' no és una ruta valida`,
         pathExists: `'%{path}' ja existeix`,
       },
       i18n: {
@@ -97,7 +97,7 @@ const ca = {
       onLeavePage: 'Estàs segur que vols deixar aquesta pàgina?',
       onUpdatingWithUnsavedChanges:
         "Tens canvis no guardats, si us plau, guarda'ls abans d'actualitzar l'estat.",
-      onPublishingNotReady: 'si us plau, actualitza l\'estat a "Ready" abans de publicar.',
+      onPublishingNotReady: 'Si us plau, actualitza l\'estat a "Llest" abans de publicar.',
       onPublishingWithUnsavedChanges:
         "Tens canvis no guardats, si us plau, guarda'ls abans de publicar-los.",
       onPublishing: 'Estàs segur que vols publicar aquesta entrada?',
@@ -135,7 +135,7 @@ const ca = {
       deleting: 'Eliminant...',
       updating: 'Actualizant...',
       status: 'Estat: %{status}',
-      backCollection: ' Escrivint a la colecció %{collectionLabel}',
+      backCollection: 'Escrivint a la colecció %{collectionLabel}',
       unsavedChanges: 'Canvis no guardats',
       changesSaved: 'Canvis guardats',
       draft: 'Esborrany',
@@ -213,8 +213,8 @@ const ca = {
       loading: 'Carregant...',
       noResults: 'Sense resultats.',
       noAssetsFound: 'Arxius no trobats.',
-      noImagesFound: 'Imatges no trobats.',
-      private: 'Privat ',
+      noImagesFound: 'Imatges no trobades.',
+      private: 'Privat',
       images: 'Imatges',
       mediaAssets: 'Arxius multimèdia',
       search: 'Buscar...',
@@ -233,7 +233,7 @@ const ca = {
     errorBoundary: {
       title: 'Error',
       details: "S'ha produït un error - si us plau ",
-      reportIt: "informa'ns d'això a GitHub.",
+      reportIt: "Informa'ns d'això a GitHub.",
       detailsHeading: 'Detalls',
       recoveredEntry: {
         heading: 'Document recuperat',

--- a/packages/netlify-cms-locales/src/ca/index.js
+++ b/packages/netlify-cms-locales/src/ca/index.js
@@ -84,7 +84,7 @@ const ca = {
         max: '%{fieldLabel} ha de ser %{maxValue} o més.',
         rangeCount: '%{fieldLabel} ha de tenir entre %{minCount} i %{maxCount} element(s).',
         rangeCountExact: '%{fieldLabel} ha de tenir exactament %{count} element(s).',
-        rangeMin: '%{fieldLabel} ha de tenir com a mínim %{minCount} d\'element(s).',
+        rangeMin: "%{fieldLabel} ha de tenir com a mínim %{minCount} d'element(s).",
         rangeMax: '%{fieldLabel} ha de ser %{maxCount} o inferior.',
         invalidPath: `'%{path}' no és una ruta valida`,
         pathExists: `'%{path}' ja existeix`,


### PR DESCRIPTION
## Motivation and summary
I started the Catalan contribution of Netlify CMS (https://github.com/netlify/netlify-cms/pull/3412) and I'm glad and impressed that some fellow countrymen joined and improved my initial translation, even with the new strings added by you in the new features. 

I've been following the trace of the translations and I've noticed a few (extremely minor) mistakes in the translation strings so the aim of this PR is to fix them and encourage people to keep collaborating with you guys.

## Last but not least
The cute animal picture, which because of my debauchery has evolved into a GIF.

![Cute cat](https://user-images.githubusercontent.com/14785182/134134991-7c21bcc8-f36d-4f42-a2c9-013ce0fd58a8.gif)


