### PR TITLE
feat: register custom formats

### DIFF
--- a/packages/netlify-cms-core/src/formats/formats.ts
+++ b/packages/netlify-cms-core/src/formats/formats.ts
@@ -5,6 +5,7 @@ import yamlFormatter from './yaml';
 import tomlFormatter from './toml';
 import jsonFormatter from './json';
 import { FrontmatterInfer, frontmatterJSON, frontmatterTOML, frontmatterYAML } from './frontmatter';
+import { getCustomFormatsExtensions, getCustomFormatsFormatters } from '../lib/registry';
 
 import type { Delimiter } from './frontmatter';
 import type { Collection, EntryObject, Format } from '../types/redux';
@@ -22,6 +23,10 @@ export const formatExtensions = {
   'toml-frontmatter': 'md',
   'yaml-frontmatter': 'md',
 };
+
+export function getFormatExtensions() {
+  return { ...formatExtensions, ...getCustomFormatsExtensions() };
+}
 
 export const extensionFormatters = {
   yml: yamlFormatter,
@@ -43,6 +48,7 @@ function formatByName(name: Format, customDelimiter?: Delimiter) {
     'json-frontmatter': frontmatterJSON(customDelimiter),
     'toml-frontmatter': frontmatterTOML(customDelimiter),
     'yaml-frontmatter': frontmatterYAML(customDelimiter),
+    ...getCustomFormatsFormatters(),
   }[name];
 }
 

--- a/packages/netlify-cms-core/src/lib/registry.js
+++ b/packages/netlify-cms-core/src/lib/registry.js
@@ -31,6 +31,7 @@ const registry = {
   mediaLibraries: [],
   locales: {},
   eventHandlers,
+  formats: {},
 };
 
 export default {
@@ -58,6 +59,10 @@ export default {
   removeEventListener,
   getEventListeners,
   invokeEvent,
+  registerCustomFormat,
+  getCustomFormats,
+  getCustomFormatsExtensions,
+  getCustomFormatsFormatters,
 };
 
 /**
@@ -283,4 +288,24 @@ export function registerLocale(locale, phrases) {
 
 export function getLocale(locale) {
   return registry.locales[locale];
+}
+
+export function registerCustomFormat(name, extension, formatter) {
+  registry.formats[name] = { extension, formatter };
+}
+
+export function getCustomFormats() {
+  return registry.formats;
+}
+
+export function getCustomFormatsExtensions() {
+  return Object.entries(registry.formats).reduce(function (acc, [name, { extension }]) {
+    return { ...acc, [name]: extension };
+  }, {});
+}
+
+export function getCustomFormatsFormatters() {
+  return Object.entries(registry.formats).reduce(function (acc, [name, { formatter }]) {
+    return { ...acc, [name]: formatter };
+  }, {});
 }


### PR DESCRIPTION
**Summary**
We are using netlify cms  to edit our translation files. This PR add the ability to register more file formats (could be xml, po, binary, etc.)

**Test plan**

<!--
Demonstrate the code is solid.
Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.
-->

**Checklist**

Please add a `x` inside each checkbox:

- [X] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [X] Code is formatted via running `yarn format`.
- [X] Tests are passing via running `yarn test`.
- [X] The status checks are successful (continuous integration). Those can be seen below.

