### PR TITLE
Export local backend middlewares in proxy server

### DIFF
--- a/packages/netlify-cms-proxy-server/src/middlewares.ts
+++ b/packages/netlify-cms-proxy-server/src/middlewares.ts
@@ -5,6 +5,9 @@ import { createLogger } from './logger';
 
 import type express from 'express';
 
+export { localGitMiddleware } from './middlewares/localGit';
+export { localFsMiddleware } from './middlewares/localFs';
+
 type Options = {
   logLevel?: string;
 };


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines here:
https://github.com/netlify/netlify-cms/blob/master/CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first two fields are mandatory:
-->

**Summary**

<!--
Explain the **motivation** for making this change.
What existing problem does the pull request solve?
-->

For `local_backend` users with an existing express server already running, who would like to avoid having to run yet another server on another port to have _some_ parts of the functionality work. With this change, it's possible to use the middleware directly, without creating a whole server in a new process:

```js
const handler = require('netlify-cms-proxy-server/dist/middlewares').localFsMiddleware({
  repoPath: ...,
  logger: console,
})

handler(req, res)
```

👆 the above works both with express and in a next.js api handler.

**Test plan**

So, my plan was _just_ to export it to begin with. My hope was that it could be an undocumented part of the API surface of this library and therefore subject to change without a major bump, but it would be useable for those who happen to know it's there.

Having it be an official part of the "real" API surface would be a comparatively change: there would need to be a separate entrypoint for the middleware module part of the library, which doesn't have the side-effect of trying to start a server (and it'd probably be a good idea to generate `.d.ts` files and write documentation, recommended usage, etc., and maybe get rid of the type dependency on winston in the params). And I can't see the harm in just doing this small change for now.

**Checklist**

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [x] Code is formatted via running `yarn format`.
- [x] Tests are passing via running `yarn test`.
- [x] The status checks are successful (continuous integration). Those can be seen below.

**A picture of a cute animal (not mandatory but encouraged)**

![telegram-cloud-photo-size-4-5958282957670167938-y](https://user-images.githubusercontent.com/15040698/135383848-9f3a651b-0233-4b03-a8b6-39586e099346.jpg)

(my parents' cat)