### PR TITLE
fix: set proper image path, when using dynamic media_folder

### DIFF
--- a/packages/netlify-cms-lib-widgets/src/stringTemplate.ts
+++ b/packages/netlify-cms-lib-widgets/src/stringTemplate.ts
@@ -1,6 +1,6 @@
 import moment from 'moment';
 import { Map } from 'immutable';
-import { basename, dirname, extname } from 'path';
+import { basename, dirname, extname, join } from 'path';
 import { get, trimEnd } from 'lodash';
 
 const filters = [
@@ -222,6 +222,13 @@ export function addFileTemplateFields(entryPath: string, fields: Map<string, str
     map.set('dirname', dirnameExcludingFolder);
     map.set('filename', filename);
     map.set('extension', extension === '' ? extension : extension.substr(1));
+
+    const imagePath = map.get('image')
+    const imageFileName = imagePath?.split('/').pop()
+    const mediaFolder = map.get('media_folder')
+    if (mediaFolder && imageFileName) {
+      map.set('image', join(mediaFolder, imageFileName))
+    }
   });
 
   return fields;


### PR DESCRIPTION
**Summary**

Set proper image path by replacing it with the most actual media_folder field value. Fixes https://github.com/netlify/netlify-cms/issues/3723

**Test plan**

No idea, how it should be tested.

**Checklist**

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [x] Code is formatted via running `yarn format`.
- [x] Tests are passing via running `yarn test`.
- [ ] The status checks are successful (continuous integration). Those can be seen below.

**P.S**

I'm not sure at all that this is a proper way to fix it. But decided to make a PR just to get discussion started.