### PR TITLE
Remove "Don't fork the repo"-Button - fixes #5723

### DIFF
--- a/packages/netlify-cms-backend-github/src/AuthenticationPage.js
+++ b/packages/netlify-cms-backend-github/src/AuthenticationPage.js
@@ -16,8 +16,9 @@ const ForkApprovalContainer = styled.div`
 `;
 const ForkButtonsContainer = styled.div`
   display: flex;
-  flex-flow: row nowrap;
+  flex-flow: column nowrap;
   justify-content: space-around;
+  align-items: center;
 `;
 
 export default class GitHubAuthenticationPage extends React.Component {
@@ -35,12 +36,16 @@ export default class GitHubAuthenticationPage extends React.Component {
   state = {};
 
   getPermissionToFork = () => {
-    return new Promise(resolve => {
+    return new Promise((resolve, reject) => {
       this.setState({
         requestingFork: true,
         approveFork: () => {
           this.setState({ requestingFork: false });
           resolve();
+        },
+        refuseFork: () => {
+          this.setState({ requestingFork: false });
+          reject();
         },
       });
     });
@@ -103,9 +108,9 @@ export default class GitHubAuthenticationPage extends React.Component {
     const { requestingFork } = this.state;
 
     if (requestingFork) {
-      const { approveFork } = this.state;
+      const { approveFork, refuseFork } = this.state;
       return {
-        renderPageContent: ({ LoginButton }) => (
+        renderPageContent: ({ LoginButton, TextButton, showAbortButton }) => (
           <ForkApprovalContainer>
             <p>
               Open Authoring is enabled: we need to use a fork on your github account. (If a fork
@@ -113,6 +118,9 @@ export default class GitHubAuthenticationPage extends React.Component {
             </p>
             <ForkButtonsContainer>
               <LoginButton onClick={approveFork}>Fork the repo</LoginButton>
+              {showAbortButton && (
+                <TextButton onClick={refuseFork}>Don&#39;t fork the repo</TextButton>
+              )}
             </ForkButtonsContainer>
           </ForkApprovalContainer>
         ),

--- a/packages/netlify-cms-ui-default/src/AuthenticationPage.js
+++ b/packages/netlify-cms-ui-default/src/AuthenticationPage.js
@@ -62,6 +62,17 @@ const LoginButton = styled.button`
   position: relative;
 `;
 
+const TextButton = styled.button`
+  ${buttons.button};
+  ${buttons.default};
+  ${buttons.grayText};
+
+  margin-top: 40px;
+  display: flex;
+  align-items: center;
+  position: relative;
+`;
+
 function AuthenticationPage({
   onLogin,
   loginDisabled,
@@ -76,7 +87,9 @@ function AuthenticationPage({
     <StyledAuthenticationPage>
       {renderPageLogo(logoUrl)}
       {loginErrorMessage ? <p>{loginErrorMessage}</p> : null}
-      {!renderPageContent ? null : renderPageContent({ LoginButton })}
+      {!renderPageContent
+        ? null
+        : renderPageContent({ LoginButton, TextButton, showAbortButton: !siteUrl })}
       {!renderButtonContent ? null : (
         <LoginButton disabled={loginDisabled} onClick={onLogin}>
           {renderButtonContent()}


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines here:
https://github.com/netlify/netlify-cms/blob/master/CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first two fields are mandatory:
-->

**Summary**
From Issue #5723: When a user logs into GitHub with Open Authoring enabled, they are presented with a screen about forking the repo.
![image](https://user-images.githubusercontent.com/9639382/136274604-b68f0936-1116-4469-95fa-6f1863d50b9e.png)
It is not clear, which button is the primary one and what the difference between "Don't fork the repo" and "Go back to site" is, since achieve the same thing.

This PR removes the button "Don't fork the repo" and thus centralises the Button "Fork the repo". Being an elevated button, it now is clear, that "Fork the repo" is the primary button and "Go back to site" is the cancel action (as it is not emphasized).
![image](https://user-images.githubusercontent.com/9639382/136275057-44d08a63-9800-419e-b431-d7968b2fb3e5.png)


<!--
Explain the **motivation** for making this change.
What existing problem does the pull request solve?
-->

**Test plan**

<!--
Demonstrate the code is solid.
Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.
-->
See above for screenshots of before and after.

**Checklist**

Please add a `x` inside each checkbox:

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [x] Code is formatted via running `yarn format`.
- [x] Tests are passing via running `yarn test`.
- [x] The status checks are successful (continuous integration). Those can be seen below.
