### PR TITLE
fix(i18n): fixes that preview not changing with locale

### DIFF
--- a/packages/netlify-cms-core/src/components/Editor/EditorControlPane/EditorControlPane.js
+++ b/packages/netlify-cms-core/src/components/Editor/EditorControlPane/EditorControlPane.js
@@ -110,6 +110,7 @@ export default class ControlPane extends React.Component {
 
   handleLocaleChange = val => {
     this.setState({ selectedLocale: val });
+    this.props.onLocaleChange(val);
   };
 
   validate = async () => {


### PR DESCRIPTION
**Summary**
Though we are passing `onLocaleChange` prop to EditorControlPane, that prop is not actually being used by the component.  
So EditorLayout doesn't get updates reagrding locale selection changes.

This was causing preview pane to not update according to the selected locale as mentioned in issue: https://github.com/netlify/netlify-cms/issues/5337

closes #5337

**Checklist**
- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [x] Code is formatted via running `yarn format`.
- [x] Tests are passing via running `yarn test`.
- [x] The status checks are successful (continuous integration). Those can be seen below.

**A picture of a cute animal (not mandatory but encouraged)**  
Red Panda  
![red-panda](https://user-images.githubusercontent.com/19573007/136448173-2640b0a7-23df-435d-8fbc-7188122843b7.png)


