### PR TITLE
feat: add string template filters "default" and "choice" (#3677)

### DIFF
--- a/packages/netlify-cms-lib-widgets/src/__tests__/stringTemplate.spec.js
+++ b/packages/netlify-cms-lib-widgets/src/__tests__/stringTemplate.spec.js
@@ -142,10 +142,10 @@ describe('stringTemplate', () => {
       ).toBe('BACKENDSLUG-title-none');
     });
 
-    it('return apply filter for choice', () => {
+    it('return apply filter for ternary', () => {
       expect(
         compileStringTemplate(
-          "{{slug | upper}}-{{starred | choice('star️','nostar')}}-{{done | choice('done', 'open️')}}",
+          "{{slug | upper}}-{{starred | ternary('star️','nostar')}}-{{done | ternary('done', 'open️')}}",
           date,
           'backendSlug',
           fromJS({ slug: 'entrySlug', starred: true, done: false }),

--- a/packages/netlify-cms-lib-widgets/src/stringTemplate.ts
+++ b/packages/netlify-cms-lib-widgets/src/stringTemplate.ts
@@ -18,7 +18,7 @@ const filters = [
     transform: (str: string, match: RegExpMatchArray) => (str ? str : match[1]),
   },
   {
-    pattern: /^choice\('(.*)',\s*'(.*)'\)$/,
+    pattern: /^ternary\('(.*)',\s*'(.*)'\)$/,
     transform: (str: string, match: RegExpMatchArray) => (str ? match[1] : match[2]),
   },
 ];

--- a/website/content/docs/beta-features.md
+++ b/website/content/docs/beta-features.md
@@ -545,7 +545,7 @@ collections:
 ```
 
 The above config will transform the title field to uppercase and format the date field using `YYYY-MM-DD` format.
-Available transformations are `upper`, `lower`, `date('<format>'), default('defaultValue') and choice('valueForTrue','valueForFalse')`
+Available transformations are `upper`, `lower`, `date('<format>'), default('defaultValue') and ternary('valueForTrue','valueForFalse')`
 
 ## Registering to CMS Events
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines here:
https://github.com/netlify/netlify-cms/blob/master/CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first two fields are mandatory:
-->

add string template filters "default" and "choice"

<!--
Explain the **motivation** for making this change.
What existing problem does the pull request solve?
-->
add a nullable field to test default and a boolean field to test choice field, like so:

    summary: "{{title | upper}} - {{subtitle | default('<none>')}} - {{draft | choice('⭐️', '☆')}} - {{date | date('YYYY-MM-DD')}}"


<!--
Demonstrate the code is solid.
Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.
-->

**Checklist**

Please add a `x` inside each checkbox:

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [x] Code is formatted via running `yarn format`.
- [x] Tests are passing via running `yarn test`.
- [x] The status checks are successful (continuous integration). Those can be seen below.

**A picture of a cute animal (not mandatory but encouraged)**
