### PR TITLE
fix: dropdown overflow in markdown widget

### DIFF
--- a/packages/netlify-cms-widget-markdown/src/MarkdownControl/VisualEditor.js
+++ b/packages/netlify-cms-widget-markdown/src/MarkdownControl/VisualEditor.js
@@ -19,8 +19,7 @@ import schema from './schema';
 function visualEditorStyles({ minimal }) {
   return `
   position: relative;
-  overflow: hidden;
-  overflow-x: auto;
+  overflow: auto;
   font-family: ${fonts.primary};
   min-height: ${minimal ? 'auto' : lengths.richTextEditorMinHeight};
   border-top-left-radius: 0;


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines here:
https://github.com/netlify/netlify-cms/blob/master/CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first two fields are mandatory:
-->

**Summary**

fixes  #5871 

<!--
Explain the **motivation** for making this change.
What existing problem does the pull request solve?
-->

It solves the dropdown overflow being hidden inside the rich text editor

**Before the fix:**

<img width="1440" alt="Screenshot 2021-10-10 at 1 15 35 AM" src="https://user-images.githubusercontent.com/9020200/136672056-e43a7835-0779-4aae-bcac-b247121da598.png">

**After fix:**

<img width="1440" alt="Screenshot 2021-10-10 at 1 16 27 AM" src="https://user-images.githubusercontent.com/9020200/136672065-8544580c-bf68-4f54-af3e-59635b41b907.png">

**Test plan**

I was able to reproduce the issue and verify the fix in the chrome browser.

<!--
Demonstrate the code is solid.
Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.
-->

**Checklist**

Please add a `x` inside each checkbox:

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [x] Code is formatted via running `yarn format`.
- [x] Tests are passing via running `yarn test`.
- [x] The status checks are successful (continuous integration). Those can be seen below.

**A picture of a cute animal (not mandatory but encouraged)**
