### PR TITLE
ci(workflow): add cache to workflows using actions/setup-node

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -6,13 +6,13 @@ on:
       - master
 
     paths-ignore:
-      - 'website/**'
+      - "website/**"
 
   pull_request:
     types: [opened, synchronize, reopened]
 
     paths-ignore:
-      - 'website/**'
+      - "website/**"
 
 jobs:
   build:
@@ -25,8 +25,9 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v2
         with:
-          node-version: '*'
+          node-version: "*"
           check-latest: true
+          cache: npm
       - name: log versions
         run: node --version && npm --version && yarn --version
       - name: install dependecies
@@ -59,8 +60,9 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v2
         with:
-          node-version: '*'
+          node-version: "*"
           check-latest: true
+          cache: npm
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
         run: echo "::set-output name=dir::$(yarn cache dir)"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,8 +1,7 @@
 name: Netlify CMS Publish
 
 on:
-  repository_dispatch:
-
+  repository_dispatch: null
 jobs:
   check-permission:
     runs-on: ubuntu-latest
@@ -10,7 +9,7 @@ jobs:
       SENDER: ${{ github.event.sender.login }}
       ALLOWED_LOGINS_TO_PUBLISH: ${{ secrets.ALLOWED_LOGINS_TO_PUBLISH }}
     steps:
-      - name: 'Check Permission To Publish'
+      - name: "Check Permission To Publish"
         run: |
           if [[ "$SENDER" =~ ^$ALLOWED_LOGINS_TO_PUBLISH$ ]]; then
               echo "$SENDER is allowed to publish"
@@ -29,8 +28,9 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v2
         with:
-          node-version: '*'
+          node-version: "*"
           check-latest: true
+          cache: npm
       - uses: actions/cache@v2
         with:
           path: ~/.cache/yarn
@@ -59,7 +59,7 @@ jobs:
           SLACK_TOKEN: ${{secrets.SLACK_TOKEN}}
           CHANNEL_ID: ${{secrets.CHANNEL_ID}}
           PUBLISH_COMMAND: "yarn\npublish:ci"
-          CODE_PATTERN: 'Enter OTP'
+          CODE_PATTERN: "Enter OTP"
           # 40 minutes for the entire command, 20 minutes for waiting for 2FA
-          TIMEOUT: '2400000'
-          REVERT_COMMAND: './scripts/revert_publish.sh'
+          TIMEOUT: "2400000"
+          REVERT_COMMAND: "./scripts/revert_publish.sh"


### PR DESCRIPTION
## Description

Add `cache` to workflows using `actions/setup-node`

## Context

`setup-node` GitHub Action just released a new option to add cache to steps using it.

You can find the details here: https://github.blog/changelog/2021-07-02-github-actions-setup-node-now-supports-dependency-caching/

---

🤖 This PR has been generated automatically by [this octoherd script](https://github.com/oscard0m/octoherd-script-add-cache-to-node-github-action), feel free to run it in your GitHub user/org repositories! 💪🏾
