### PR TITLE
fix(richtext): improvement to the Rich Text Editor #5446

### DIFF
--- a/cypress/integration/markdown_widget_backspace_spec.js
+++ b/cypress/integration/markdown_widget_backspace_spec.js
@@ -25,6 +25,17 @@ describe('Markdown widget', () => {
           <p></p>
         `);
     });
+    it('moves to previous block when no character left to delete', () => {
+      cy.focused()
+        .type('foo')
+        .enter()
+        .clickHeadingOneButton()
+        .type('a')
+        .backspace({times: 2})
+        .confirmMarkdownEditorContent(`
+          <p>foo</p>
+        `);
+    });
     it('does nothing at start of first block in document when non-empty and non-default', () => {
       cy.focused()
         .clickHeadingOneButton()

--- a/packages/netlify-cms-widget-markdown/src/MarkdownControl/plugins/CloseBlock.js
+++ b/packages/netlify-cms-widget-markdown/src/MarkdownControl/plugins/CloseBlock.js
@@ -1,6 +1,6 @@
 import isHotkey from 'is-hotkey';
 
-function CloseBlock() {
+function CloseBlock({ defaultType }) {
   return {
     onKeyDown(event, editor, next) {
       const { selection, startBlock } = editor.value;
@@ -13,6 +13,9 @@ function CloseBlock() {
       }
       if (!selection.start.isAtStartOfNode(startBlock) || startBlock.text.length > 0) {
         return next();
+      }
+      if (startBlock.type !== defaultType) {
+        editor.setBlocks(defaultType);
       }
       return next();
     },

--- a/packages/netlify-cms-widget-markdown/src/MarkdownControl/plugins/visual.js
+++ b/packages/netlify-cms-widget-markdown/src/MarkdownControl/plugins/visual.js
@@ -48,7 +48,7 @@ function plugins({ getAsset, resolveWidget, t, remarkPlugins }) {
     Link({ type: 'link' }),
     LineBreak(),
     BreakToDefaultBlock({ defaultType }),
-    CloseBlock(),
+    CloseBlock({ defaultType }),
     SelectAll(),
     ForceInsert({ defaultType }),
     CopyPasteVisual({ getAsset, resolveWidget, remarkPlugins }),


### PR DESCRIPTION
- When deleting in a block, don't take an extra delete step to remove the block format
- fixes #5446 

<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines here:
https://github.com/netlify/netlify-cms/blob/master/CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first two fields are mandatory:
-->

When deleting in a richtext editor, no longer take an extra delete step just to remove the formatting. I left quotes and lists as they were, because there's an explicit visual feedback in the editor

<!--
Explain the **motivation** for making this change.
What existing problem does the pull request solve?
-->

Write in richtext editor
- normal paragraph
- heading
- delete the heading (with backspace)

<!--
Demonstrate the code is solid.
Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.
-->

**Checklist**

Please add a `x` inside each checkbox:

- [X] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [X] Code is formatted via running `yarn format`.
- [X] Tests are passing via running `yarn test`.
- [x] The status checks are successful (continuous integration). Those can be seen below.

**A picture of a cute animal (not mandatory but encouraged)**
