### PR TITLE
feat: render hint for typed list items - closes 3650

### DIFF
--- a/dev-test/config.yml
+++ b/dev-test/config.yml
@@ -246,6 +246,7 @@ collections: # A list of collections the CMS should be able to edit
         types:
           - label: 'Type 1 Object'
             name: 'type_1_object'
+            hint: 'Hint for a typed list item'
             widget: 'object'
             fields:
               - { label: 'String', name: 'string', widget: 'string' }

--- a/packages/netlify-cms-widget-list/src/ListControl.js
+++ b/packages/netlify-cms-widget-list/src/ListControl.js
@@ -7,6 +7,8 @@ import { List, Map, fromJS } from 'immutable';
 import { partial, isEmpty, uniqueId } from 'lodash';
 import uuid from 'uuid/v4';
 import { SortableContainer, SortableElement, SortableHandle } from 'react-sortable-hoc';
+import ReactMarkdown from 'react-markdown';
+import gfm from 'remark-gfm';
 import NetlifyCmsWidgetObject from 'netlify-cms-widget-object';
 import {
   ListItemTopBar,
@@ -16,6 +18,7 @@ import {
   FieldLabel,
 } from 'netlify-cms-ui-default';
 import { stringTemplate, validations } from 'netlify-cms-lib-widgets';
+import { ControlHint } from 'netlify-cms-core/src/components/Editor/EditorControlPane/EditorControl';
 
 import {
   TYPES_KEY,
@@ -524,6 +527,7 @@ export default class ListControl extends React.Component {
         return this.renderErroneousTypedItem(index, item);
       }
     }
+    const fieldHint = field.get('hint');
     return (
       <SortableListItem
         css={[styles.listControlItem, collapsed && styles.listControlItemCollapsed]}
@@ -552,30 +556,54 @@ export default class ListControl extends React.Component {
         </NestedObjectLabel>
         <ClassNames>
           {({ css, cx }) => (
-            <ObjectControl
-              classNameWrapper={cx(classNameWrapper, {
-                [css`
-                  ${styleStrings.collapsedObjectControl};
-                `]: collapsed,
-              })}
-              value={item}
-              field={field}
-              onChangeObject={this.handleChangeFor(index)}
-              editorControl={editorControl}
-              resolveWidget={resolveWidget}
-              metadata={metadata}
-              forList
-              onValidateObject={onValidateObject}
-              clearFieldErrors={clearFieldErrors}
-              fieldsErrors={fieldsErrors}
-              ref={this.processControlRef}
-              controlRef={controlRef}
-              validationKey={key}
-              collapsed={collapsed}
-              data-testid={`object-control-${key}`}
-              hasError={hasError}
-              parentIds={[...parentIds, forID, key]}
-            />
+            <div>
+              <ObjectControl
+                classNameWrapper={cx(classNameWrapper, {
+                  [css`
+                    ${styleStrings.collapsedObjectControl};
+                  `]: collapsed,
+                })}
+                value={item}
+                field={field}
+                onChangeObject={this.handleChangeFor(index)}
+                editorControl={editorControl}
+                resolveWidget={resolveWidget}
+                metadata={metadata}
+                forList
+                onValidateObject={onValidateObject}
+                clearFieldErrors={clearFieldErrors}
+                fieldsErrors={fieldsErrors}
+                ref={this.processControlRef}
+                controlRef={controlRef}
+                validationKey={key}
+                collapsed={collapsed}
+                data-testid={`object-control-${key}`}
+                hasError={hasError}
+                parentIds={[...parentIds, forID, key]}
+              />
+              {isVariableTypesList && fieldHint && (
+                <ControlHint active={false} error={hasError}>
+                  <ReactMarkdown
+                    remarkPlugins={[gfm]}
+                    allowedElements={['a', 'strong', 'em', 'del']}
+                    unwrapDisallowed={true}
+                    components={{
+                      // eslint-disable-next-line no-unused-vars
+                      a: ({ node, ...props }) => (
+                        <a
+                          {...props}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          style={{ color: 'inherit' }}
+                        />
+                      ),
+                    }}
+                  >
+                    {fieldHint}
+                  </ReactMarkdown>
+                </ControlHint>
+              )}
+            </div>
           )}
         </ClassNames>
       </SortableListItem>

--- a/packages/netlify-cms-widget-list/src/__tests__/ListControl.spec.js
+++ b/packages/netlify-cms-widget-list/src/__tests__/ListControl.spec.js
@@ -789,4 +789,32 @@ describe('ListControl', () => {
     listControl.validate();
     expect(props.onValidateObject).toHaveBeenCalledWith('forID', []);
   });
+
+  it('should render list type hint', () => {
+    const field = fromJS({
+      name: 'list',
+      label: 'List',
+      types: [
+        {
+          label: 'Type 1 Object',
+          name: 'type_1_object',
+          hint: 'Type 1 Object hint',
+          widget: 'object',
+          fields: [
+            { label: 'First Name', name: 'first_name', widget: 'string' },
+            { label: 'Last Name', name: 'last_name', widget: 'string' },
+          ],
+        },
+      ],
+    });
+
+    const { getAllByText } = render(
+      <ListControl
+        {...props}
+        field={field}
+        value={fromJS([{ first_name: 'hello', last_name: 'world', type: 'type_1_object' }])}
+      />,
+    );
+    expect(getAllByText('Type 1 Object hint')[0]).toBeInTheDocument();
+  });
 });

--- a/packages/netlify-cms-widget-list/src/__tests__/__snapshots__/ListControl.spec.js.snap
+++ b/packages/netlify-cms-widget-list/src/__tests__/__snapshots__/ListControl.spec.js.snap
@@ -212,17 +212,19 @@ exports[`ListControl should add to list when add button is clicked 1`] = `
         >
           No string
         </div>
-        <mock-object-control
-          classnamewrapper="classNameWrapper"
-          collapsed="false"
-          data-testid="object-control-0"
-          field="Map { \\"name\\": \\"list\\", \\"label\\": \\"List\\", \\"fields\\": List [ Map { \\"label\\": \\"String\\", \\"name\\": \\"string\\", \\"widget\\": \\"string\\" } ] }"
-          fieldserrors="Map {}"
-          forlist="true"
-          parentids="forID,0"
-          validationkey="0"
-          value="Map {}"
-        />
+        <div>
+          <mock-object-control
+            classnamewrapper="classNameWrapper"
+            collapsed="false"
+            data-testid="object-control-0"
+            field="Map { \\"name\\": \\"list\\", \\"label\\": \\"List\\", \\"fields\\": List [ Map { \\"label\\": \\"String\\", \\"name\\": \\"string\\", \\"widget\\": \\"string\\" } ] }"
+            fieldserrors="Map {}"
+            forlist="true"
+            parentids="forID,0"
+            validationkey="0"
+            value="Map {}"
+          />
+        </div>
       </div>
     </div>
   </div>
@@ -441,17 +443,19 @@ exports[`ListControl should remove from list when remove button is clicked 1`] =
         >
           item 1
         </div>
-        <mock-object-control
-          classnamewrapper="classNameWrapper"
-          collapsed="false"
-          data-testid="object-control-0"
-          field="Map { \\"name\\": \\"list\\", \\"label\\": \\"List\\", \\"collapsed\\": false, \\"minimize_collapsed\\": true, \\"fields\\": List [ Map { \\"label\\": \\"String\\", \\"name\\": \\"string\\", \\"widget\\": \\"string\\" } ] }"
-          fieldserrors="Map {}"
-          forlist="true"
-          parentids="forID,0"
-          validationkey="0"
-          value="Map { \\"string\\": \\"item 1\\" }"
-        />
+        <div>
+          <mock-object-control
+            classnamewrapper="classNameWrapper"
+            collapsed="false"
+            data-testid="object-control-0"
+            field="Map { \\"name\\": \\"list\\", \\"label\\": \\"List\\", \\"collapsed\\": false, \\"minimize_collapsed\\": true, \\"fields\\": List [ Map { \\"label\\": \\"String\\", \\"name\\": \\"string\\", \\"widget\\": \\"string\\" } ] }"
+            fieldserrors="Map {}"
+            forlist="true"
+            parentids="forID,0"
+            validationkey="0"
+            value="Map { \\"string\\": \\"item 1\\" }"
+          />
+        </div>
       </div>
       <div
         class="emotion-16 emotion-17"
@@ -470,17 +474,19 @@ exports[`ListControl should remove from list when remove button is clicked 1`] =
         >
           item 2
         </div>
-        <mock-object-control
-          classnamewrapper="classNameWrapper"
-          collapsed="false"
-          data-testid="object-control-1"
-          field="Map { \\"name\\": \\"list\\", \\"label\\": \\"List\\", \\"collapsed\\": false, \\"minimize_collapsed\\": true, \\"fields\\": List [ Map { \\"label\\": \\"String\\", \\"name\\": \\"string\\", \\"widget\\": \\"string\\" } ] }"
-          fieldserrors="Map {}"
-          forlist="true"
-          parentids="forID,1"
-          validationkey="1"
-          value="Map { \\"string\\": \\"item 2\\" }"
-        />
+        <div>
+          <mock-object-control
+            classnamewrapper="classNameWrapper"
+            collapsed="false"
+            data-testid="object-control-1"
+            field="Map { \\"name\\": \\"list\\", \\"label\\": \\"List\\", \\"collapsed\\": false, \\"minimize_collapsed\\": true, \\"fields\\": List [ Map { \\"label\\": \\"String\\", \\"name\\": \\"string\\", \\"widget\\": \\"string\\" } ] }"
+            fieldserrors="Map {}"
+            forlist="true"
+            parentids="forID,1"
+            validationkey="1"
+            value="Map { \\"string\\": \\"item 2\\" }"
+          />
+        </div>
       </div>
     </div>
   </div>
@@ -700,17 +706,19 @@ exports[`ListControl should remove from list when remove button is clicked 2`] =
         >
           item 2
         </div>
-        <mock-object-control
-          classnamewrapper="classNameWrapper css-1pznrxi"
-          collapsed="true"
-          data-testid="object-control-2"
-          field="Map { \\"name\\": \\"list\\", \\"label\\": \\"List\\", \\"collapsed\\": false, \\"minimize_collapsed\\": true, \\"fields\\": List [ Map { \\"label\\": \\"String\\", \\"name\\": \\"string\\", \\"widget\\": \\"string\\" } ] }"
-          fieldserrors="Map {}"
-          forlist="true"
-          parentids="forID,2"
-          validationkey="2"
-          value="Map { \\"string\\": \\"item 2\\" }"
-        />
+        <div>
+          <mock-object-control
+            classnamewrapper="classNameWrapper css-d8z35y"
+            collapsed="true"
+            data-testid="object-control-2"
+            field="Map { \\"name\\": \\"list\\", \\"label\\": \\"List\\", \\"collapsed\\": false, \\"minimize_collapsed\\": true, \\"fields\\": List [ Map { \\"label\\": \\"String\\", \\"name\\": \\"string\\", \\"widget\\": \\"string\\" } ] }"
+            fieldserrors="Map {}"
+            forlist="true"
+            parentids="forID,2"
+            validationkey="2"
+            value="Map { \\"string\\": \\"item 2\\" }"
+          />
+        </div>
       </div>
     </div>
   </div>
@@ -940,17 +948,19 @@ exports[`ListControl should render list with fields with collapse = "false" and 
         >
           item 1
         </div>
-        <mock-object-control
-          classnamewrapper="classNameWrapper"
-          collapsed="false"
-          data-testid="object-control-0"
-          field="Map { \\"name\\": \\"list\\", \\"label\\": \\"List\\", \\"collapsed\\": false, \\"fields\\": List [ Map { \\"label\\": \\"String\\", \\"name\\": \\"string\\", \\"widget\\": \\"string\\" } ] }"
-          fieldserrors="Map {}"
-          forlist="true"
-          parentids="forID,0"
-          validationkey="0"
-          value="Map { \\"string\\": \\"item 1\\" }"
-        />
+        <div>
+          <mock-object-control
+            classnamewrapper="classNameWrapper"
+            collapsed="false"
+            data-testid="object-control-0"
+            field="Map { \\"name\\": \\"list\\", \\"label\\": \\"List\\", \\"collapsed\\": false, \\"fields\\": List [ Map { \\"label\\": \\"String\\", \\"name\\": \\"string\\", \\"widget\\": \\"string\\" } ] }"
+            fieldserrors="Map {}"
+            forlist="true"
+            parentids="forID,0"
+            validationkey="0"
+            value="Map { \\"string\\": \\"item 1\\" }"
+          />
+        </div>
       </div>
       <div
         class="emotion-16 emotion-17"
@@ -969,17 +979,19 @@ exports[`ListControl should render list with fields with collapse = "false" and 
         >
           item 2
         </div>
-        <mock-object-control
-          classnamewrapper="classNameWrapper"
-          collapsed="false"
-          data-testid="object-control-1"
-          field="Map { \\"name\\": \\"list\\", \\"label\\": \\"List\\", \\"collapsed\\": false, \\"fields\\": List [ Map { \\"label\\": \\"String\\", \\"name\\": \\"string\\", \\"widget\\": \\"string\\" } ] }"
-          fieldserrors="Map {}"
-          forlist="true"
-          parentids="forID,1"
-          validationkey="1"
-          value="Map { \\"string\\": \\"item 2\\" }"
-        />
+        <div>
+          <mock-object-control
+            classnamewrapper="classNameWrapper"
+            collapsed="false"
+            data-testid="object-control-1"
+            field="Map { \\"name\\": \\"list\\", \\"label\\": \\"List\\", \\"collapsed\\": false, \\"fields\\": List [ Map { \\"label\\": \\"String\\", \\"name\\": \\"string\\", \\"widget\\": \\"string\\" } ] }"
+            fieldserrors="Map {}"
+            forlist="true"
+            parentids="forID,1"
+            validationkey="1"
+            value="Map { \\"string\\": \\"item 2\\" }"
+          />
+        </div>
       </div>
     </div>
   </div>
@@ -1198,17 +1210,19 @@ exports[`ListControl should render list with fields with collapse = "false" and 
         >
           item 1
         </div>
-        <mock-object-control
-          classnamewrapper="classNameWrapper"
-          collapsed="false"
-          data-testid="object-control-0"
-          field="Map { \\"name\\": \\"list\\", \\"label\\": \\"List\\", \\"collapsed\\": false, \\"minimize_collapsed\\": true, \\"fields\\": List [ Map { \\"label\\": \\"String\\", \\"name\\": \\"string\\", \\"widget\\": \\"string\\" } ] }"
-          fieldserrors="Map {}"
-          forlist="true"
-          parentids="forID,0"
-          validationkey="0"
-          value="Map { \\"string\\": \\"item 1\\" }"
-        />
+        <div>
+          <mock-object-control
+            classnamewrapper="classNameWrapper"
+            collapsed="false"
+            data-testid="object-control-0"
+            field="Map { \\"name\\": \\"list\\", \\"label\\": \\"List\\", \\"collapsed\\": false, \\"minimize_collapsed\\": true, \\"fields\\": List [ Map { \\"label\\": \\"String\\", \\"name\\": \\"string\\", \\"widget\\": \\"string\\" } ] }"
+            fieldserrors="Map {}"
+            forlist="true"
+            parentids="forID,0"
+            validationkey="0"
+            value="Map { \\"string\\": \\"item 1\\" }"
+          />
+        </div>
       </div>
       <div
         class="emotion-16 emotion-17"
@@ -1227,17 +1241,19 @@ exports[`ListControl should render list with fields with collapse = "false" and 
         >
           item 2
         </div>
-        <mock-object-control
-          classnamewrapper="classNameWrapper"
-          collapsed="false"
-          data-testid="object-control-1"
-          field="Map { \\"name\\": \\"list\\", \\"label\\": \\"List\\", \\"collapsed\\": false, \\"minimize_collapsed\\": true, \\"fields\\": List [ Map { \\"label\\": \\"String\\", \\"name\\": \\"string\\", \\"widget\\": \\"string\\" } ] }"
-          fieldserrors="Map {}"
-          forlist="true"
-          parentids="forID,1"
-          validationkey="1"
-          value="Map { \\"string\\": \\"item 2\\" }"
-        />
+        <div>
+          <mock-object-control
+            classnamewrapper="classNameWrapper"
+            collapsed="false"
+            data-testid="object-control-1"
+            field="Map { \\"name\\": \\"list\\", \\"label\\": \\"List\\", \\"collapsed\\": false, \\"minimize_collapsed\\": true, \\"fields\\": List [ Map { \\"label\\": \\"String\\", \\"name\\": \\"string\\", \\"widget\\": \\"string\\" } ] }"
+            fieldserrors="Map {}"
+            forlist="true"
+            parentids="forID,1"
+            validationkey="1"
+            value="Map { \\"string\\": \\"item 2\\" }"
+          />
+        </div>
       </div>
     </div>
   </div>
@@ -1457,17 +1473,19 @@ exports[`ListControl should render list with fields with default collapse ("true
         >
           item 1
         </div>
-        <mock-object-control
-          classnamewrapper="classNameWrapper css-1pznrxi"
-          collapsed="true"
-          data-testid="object-control-0"
-          field="Map { \\"name\\": \\"list\\", \\"label\\": \\"List\\", \\"fields\\": List [ Map { \\"label\\": \\"String\\", \\"name\\": \\"string\\", \\"widget\\": \\"string\\" } ] }"
-          fieldserrors="Map {}"
-          forlist="true"
-          parentids="forID,0"
-          validationkey="0"
-          value="Map { \\"string\\": \\"item 1\\" }"
-        />
+        <div>
+          <mock-object-control
+            classnamewrapper="classNameWrapper css-d8z35y"
+            collapsed="true"
+            data-testid="object-control-0"
+            field="Map { \\"name\\": \\"list\\", \\"label\\": \\"List\\", \\"fields\\": List [ Map { \\"label\\": \\"String\\", \\"name\\": \\"string\\", \\"widget\\": \\"string\\" } ] }"
+            fieldserrors="Map {}"
+            forlist="true"
+            parentids="forID,0"
+            validationkey="0"
+            value="Map { \\"string\\": \\"item 1\\" }"
+          />
+        </div>
       </div>
       <div
         class="emotion-16 emotion-17"
@@ -1486,17 +1504,19 @@ exports[`ListControl should render list with fields with default collapse ("true
         >
           item 2
         </div>
-        <mock-object-control
-          classnamewrapper="classNameWrapper css-1pznrxi"
-          collapsed="true"
-          data-testid="object-control-1"
-          field="Map { \\"name\\": \\"list\\", \\"label\\": \\"List\\", \\"fields\\": List [ Map { \\"label\\": \\"String\\", \\"name\\": \\"string\\", \\"widget\\": \\"string\\" } ] }"
-          fieldserrors="Map {}"
-          forlist="true"
-          parentids="forID,1"
-          validationkey="1"
-          value="Map { \\"string\\": \\"item 2\\" }"
-        />
+        <div>
+          <mock-object-control
+            classnamewrapper="classNameWrapper css-d8z35y"
+            collapsed="true"
+            data-testid="object-control-1"
+            field="Map { \\"name\\": \\"list\\", \\"label\\": \\"List\\", \\"fields\\": List [ Map { \\"label\\": \\"String\\", \\"name\\": \\"string\\", \\"widget\\": \\"string\\" } ] }"
+            fieldserrors="Map {}"
+            forlist="true"
+            parentids="forID,1"
+            validationkey="1"
+            value="Map { \\"string\\": \\"item 2\\" }"
+          />
+        </div>
       </div>
     </div>
   </div>
@@ -1897,17 +1917,19 @@ exports[`ListControl should render list with nested object 1`] = `
         >
           Object
         </div>
-        <mock-object-control
-          classnamewrapper="classNameWrapper css-1pznrxi"
-          collapsed="true"
-          data-testid="object-control-0"
-          field="Map { \\"name\\": \\"list\\", \\"label\\": \\"List\\", \\"field\\": Map { \\"name\\": \\"object\\", \\"widget\\": \\"object\\", \\"label\\": \\"Object\\", \\"fields\\": List [ Map { \\"name\\": \\"title\\", \\"widget\\": \\"string\\", \\"label\\": \\"Title\\" } ] } }"
-          fieldserrors="Map {}"
-          forlist="true"
-          parentids="forID,0"
-          validationkey="0"
-          value="Map { \\"object\\": Map { \\"title\\": \\"item 1\\" } }"
-        />
+        <div>
+          <mock-object-control
+            classnamewrapper="classNameWrapper css-d8z35y"
+            collapsed="true"
+            data-testid="object-control-0"
+            field="Map { \\"name\\": \\"list\\", \\"label\\": \\"List\\", \\"field\\": Map { \\"name\\": \\"object\\", \\"widget\\": \\"object\\", \\"label\\": \\"Object\\", \\"fields\\": List [ Map { \\"name\\": \\"title\\", \\"widget\\": \\"string\\", \\"label\\": \\"Title\\" } ] } }"
+            fieldserrors="Map {}"
+            forlist="true"
+            parentids="forID,0"
+            validationkey="0"
+            value="Map { \\"object\\": Map { \\"title\\": \\"item 1\\" } }"
+          />
+        </div>
       </div>
       <div
         class="emotion-16 emotion-17"
@@ -1926,17 +1948,19 @@ exports[`ListControl should render list with nested object 1`] = `
         >
           Object
         </div>
-        <mock-object-control
-          classnamewrapper="classNameWrapper css-1pznrxi"
-          collapsed="true"
-          data-testid="object-control-1"
-          field="Map { \\"name\\": \\"list\\", \\"label\\": \\"List\\", \\"field\\": Map { \\"name\\": \\"object\\", \\"widget\\": \\"object\\", \\"label\\": \\"Object\\", \\"fields\\": List [ Map { \\"name\\": \\"title\\", \\"widget\\": \\"string\\", \\"label\\": \\"Title\\" } ] } }"
-          fieldserrors="Map {}"
-          forlist="true"
-          parentids="forID,1"
-          validationkey="1"
-          value="Map { \\"object\\": Map { \\"title\\": \\"item 2\\" } }"
-        />
+        <div>
+          <mock-object-control
+            classnamewrapper="classNameWrapper css-d8z35y"
+            collapsed="true"
+            data-testid="object-control-1"
+            field="Map { \\"name\\": \\"list\\", \\"label\\": \\"List\\", \\"field\\": Map { \\"name\\": \\"object\\", \\"widget\\": \\"object\\", \\"label\\": \\"Object\\", \\"fields\\": List [ Map { \\"name\\": \\"title\\", \\"widget\\": \\"string\\", \\"label\\": \\"Title\\" } ] } }"
+            fieldserrors="Map {}"
+            forlist="true"
+            parentids="forID,1"
+            validationkey="1"
+            value="Map { \\"object\\": Map { \\"title\\": \\"item 2\\" } }"
+          />
+        </div>
       </div>
     </div>
   </div>
@@ -2155,17 +2179,19 @@ exports[`ListControl should render list with nested object with collapse = false
         >
           Object
         </div>
-        <mock-object-control
-          classnamewrapper="classNameWrapper"
-          collapsed="false"
-          data-testid="object-control-0"
-          field="Map { \\"name\\": \\"list\\", \\"label\\": \\"List\\", \\"collapsed\\": false, \\"field\\": Map { \\"name\\": \\"object\\", \\"widget\\": \\"object\\", \\"label\\": \\"Object\\", \\"fields\\": List [ Map { \\"name\\": \\"title\\", \\"widget\\": \\"string\\", \\"label\\": \\"Title\\" } ] } }"
-          fieldserrors="Map {}"
-          forlist="true"
-          parentids="forID,0"
-          validationkey="0"
-          value="Map { \\"object\\": Map { \\"title\\": \\"item 1\\" } }"
-        />
+        <div>
+          <mock-object-control
+            classnamewrapper="classNameWrapper"
+            collapsed="false"
+            data-testid="object-control-0"
+            field="Map { \\"name\\": \\"list\\", \\"label\\": \\"List\\", \\"collapsed\\": false, \\"field\\": Map { \\"name\\": \\"object\\", \\"widget\\": \\"object\\", \\"label\\": \\"Object\\", \\"fields\\": List [ Map { \\"name\\": \\"title\\", \\"widget\\": \\"string\\", \\"label\\": \\"Title\\" } ] } }"
+            fieldserrors="Map {}"
+            forlist="true"
+            parentids="forID,0"
+            validationkey="0"
+            value="Map { \\"object\\": Map { \\"title\\": \\"item 1\\" } }"
+          />
+        </div>
       </div>
       <div
         class="emotion-16 emotion-17"
@@ -2184,17 +2210,19 @@ exports[`ListControl should render list with nested object with collapse = false
         >
           Object
         </div>
-        <mock-object-control
-          classnamewrapper="classNameWrapper"
-          collapsed="false"
-          data-testid="object-control-1"
-          field="Map { \\"name\\": \\"list\\", \\"label\\": \\"List\\", \\"collapsed\\": false, \\"field\\": Map { \\"name\\": \\"object\\", \\"widget\\": \\"object\\", \\"label\\": \\"Object\\", \\"fields\\": List [ Map { \\"name\\": \\"title\\", \\"widget\\": \\"string\\", \\"label\\": \\"Title\\" } ] } }"
-          fieldserrors="Map {}"
-          forlist="true"
-          parentids="forID,1"
-          validationkey="1"
-          value="Map { \\"object\\": Map { \\"title\\": \\"item 2\\" } }"
-        />
+        <div>
+          <mock-object-control
+            classnamewrapper="classNameWrapper"
+            collapsed="false"
+            data-testid="object-control-1"
+            field="Map { \\"name\\": \\"list\\", \\"label\\": \\"List\\", \\"collapsed\\": false, \\"field\\": Map { \\"name\\": \\"object\\", \\"widget\\": \\"object\\", \\"label\\": \\"Object\\", \\"fields\\": List [ Map { \\"name\\": \\"title\\", \\"widget\\": \\"string\\", \\"label\\": \\"Title\\" } ] } }"
+            fieldserrors="Map {}"
+            forlist="true"
+            parentids="forID,1"
+            validationkey="1"
+            value="Map { \\"object\\": Map { \\"title\\": \\"item 2\\" } }"
+          />
+        </div>
       </div>
     </div>
   </div>


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines here:
https://github.com/netlify/netlify-cms/blob/master/CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first two fields are mandatory:
-->

**Summary**
This commit adds rendering of hints for typed list items. The `hint` property is already a valid configuration option that was simply not being rendered.
![summary](https://user-images.githubusercontent.com/16124144/137632279-f23f4128-00d2-4f05-ab6a-cd9ea12dfd89.png)
<!--
Explain the **motivation** for making this change.
What existing problem does the pull request solve?
-->

**Test plan**
![test](https://user-images.githubusercontent.com/16124144/137632280-3b9f437f-4af5-4006-a195-de8faad37fef.png)
<!--
Demonstrate the code is solid.
Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.
-->

**Checklist**

Please add a `x` inside each checkbox:

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [x] Code is formatted via running `yarn format`.
- [x] Tests are passing via running `yarn test`.
- [x] The status checks are successful (continuous integration). Those can be seen below.

**A picture of a cute animal (not mandatory but encouraged)**