### PR TITLE
feat(core): pass `locale` to custom preview templates

### DIFF
--- a/packages/netlify-cms-core/src/components/Editor/EditorInterface.js
+++ b/packages/netlify-cms-core/src/components/Editor/EditorInterface.js
@@ -291,6 +291,7 @@ class EditorInterface extends Component {
                 entry={previewEntry}
                 fields={fields}
                 fieldsMetaData={fieldsMetaData}
+                locale={leftPanelLocale}
               />
             </PreviewPaneContainer>
           </StyledSplitPane>


### PR DESCRIPTION
Closes #5911

<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines here:
https://github.com/netlify/netlify-cms/blob/master/CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first two fields are mandatory:
-->

**Summary**

Pass the currently selected locale to the editor preview pane to allow custom preview templates to adapt to different locales (see #5911).

**Test plan**

I created a collection in `dev-test/config.yml` with i18n enabled.

In `dev-test/index.html` I registered a custom preview template to display the passed `locale` prop:

```js
CMS.registerPreviewTemplate(
  'posts',
  createClass({
    render() {
      return h('p', {}, this.props.locale);
    },
  }),
);
```

The locale string displayed in the preview pane and toggling between the locale currently being edited updated the preview string.

I’d love to add an integration test for a custom preview template and check the props it receives, but I couldn’t see any existing tests for this.

**Checklist**

Please add a `x` inside each checkbox:

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [x] Code is formatted via running `yarn format`.
- [x] Tests are passing via running `yarn test`.
- [x] The status checks are successful (continuous integration). Those can be seen below.

**A picture of a cute animal (not mandatory but encouraged)**

A locale locust:

![locust](https://user-images.githubusercontent.com/357379/138174092-dc1aa094-2489-4e41-9c95-43448b7ac81b.png)
By Charles J. Sharp - Own work, from Sharp Photography, sharpphotography, CC BY-SA 4.0, https://commons.wikimedia.org/w/index.php?curid=59068817
