### PR TITLE
Fix (i18n): Return the Correct Locale from Filenames - fixes #5909

### DIFF
--- a/packages/netlify-cms-core/src/lib/__tests__/i18n.spec.js
+++ b/packages/netlify-cms-core/src/lib/__tests__/i18n.spec.js
@@ -207,6 +207,36 @@ describe('i18n', () => {
     });
   });
 
+  describe('getLocaleFromPath', () => {
+    it('should return the locale from folder name in the path when structure is I18N_STRUCTURE.MULTIPLE_FOLDERS', () => {
+      expect(
+        i18n.getLocaleFromPath(
+          i18n.I18N_STRUCTURE.MULTIPLE_FOLDERS,
+          'md',
+          'src/content/en/index.md',
+        ),
+      ).toEqual('en');
+    });
+
+    it('should return the locale extension from the file name when structure is I18N_STRUCTURE.MULTIPLE_FILES', () => {
+      expect(
+        i18n.getLocaleFromPath(i18n.I18N_STRUCTURE.MULTIPLE_FILES, 'md', 'src/content/index.en.md'),
+      ).toEqual('en');
+    });
+
+    it('issue #5909: return the correct locale extension for language gd', () => {
+      expect(
+        i18n.getLocaleFromPath(i18n.I18N_STRUCTURE.MULTIPLE_FILES, 'md', 'src/content/index.gd.md'),
+      ).toEqual('gd');
+    });
+
+    it('should return an empty string when structure is I18N_STRUCTURE.SINGLE_FILE', () => {
+      expect(
+        i18n.getLocaleFromPath(i18n.I18N_STRUCTURE.SINGLE_FILE, 'md', 'src/content/index.md'),
+      ).toEqual('');
+    });
+  });
+
   describe('getI18nFiles', () => {
     const locales = ['en', 'de', 'fr'];
     const default_locale = 'en';

--- a/packages/netlify-cms-core/src/lib/i18n.ts
+++ b/packages/netlify-cms-core/src/lib/i18n.ts
@@ -1,5 +1,5 @@
 import { Map, List } from 'immutable';
-import { set, trimEnd, groupBy, escapeRegExp } from 'lodash';
+import { set, groupBy, escapeRegExp } from 'lodash';
 
 import { selectEntrySlug } from '../reducers/collections';
 
@@ -98,7 +98,7 @@ export function getLocaleFromPath(structure: I18N_STRUCTURE, extension: string, 
       return parts.pop();
     }
     case I18N_STRUCTURE.MULTIPLE_FILES: {
-      const parts = trimEnd(path, `.${extension}`);
+      const parts = path.slice(0, -`.${extension}`.length);
       return parts.split('.').pop();
     }
     case I18N_STRUCTURE.SINGLE_FILE:


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines here:
https://github.com/netlify/netlify-cms/blob/master/CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first two fields are mandatory:
-->

**Summary**
When determining the locale from the filename in a `i18n.structure: multiple_files`-setup, the code returned `g` for the file `index.gd.md`. This was due to the use of the lodash-method `trimEnd` for removing the file extension.

As per the [lodash docs](https://docs-lodash.com/v4/trim-end/) the `trimEnd` method does not remove the specified string from the end, but instead removes all characters from the end. So in this case when calling 
```js
trimEnd('index.gd.md', '.md')
```
it did not just remove the '.md' at the end, as intended, but instead all occurrences of the characters `.`, `m` and `d` from the end. Thus the result was `index.g` instead of `index.gd`.

I changed the implementation to use the [`String.prototype.slice()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) method to remove the number of characters of file extension from the end of the string.

This closes #5909.
<!--
Explain the **motivation** for making this change.
What existing problem does the pull request solve?
-->

**Test plan**
I added jest tests.
<!--
Demonstrate the code is solid.
Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.
-->

**Checklist**

Please add a `x` inside each checkbox:

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [x] Code is formatted via running `yarn format`.
- [x] Tests are passing via running `yarn test`.
- [x] The status checks are successful (continuous integration). Those can be seen below.


