### PR TITLE
fix: Unformatted text in the widgets docs page

### DIFF
--- a/website/content/docs/widgets.md
+++ b/website/content/docs/widgets.md
@@ -17,12 +17,12 @@ The following options are available on all fields:
 - `required`: specify as `false` to make a field optional; defaults to `true`
 - `hint`: optionally add helper text directly below a widget. Useful for including instructions. Accepts markdown for bold, italic, strikethrough, and links.
 - `pattern`: add field validation by specifying a list with a [regex pattern](https://regexr.com/) and an error message; more extensive validation can be achieved with [custom widgets](../custom-widgets/#advanced-field-validation)
-  - **Example:**
-        ```yaml
-        - label: "Title"
-          name: "title"
-          widget: "string"
-          pattern: ['.{12,}', "Must have at least 12 characters"]
-        ```
+- **Example:**
+  ```yaml
+    label: "Title"
+    name: "title"
+    widget: "string"
+    pattern: ['.{12,}', "Must have at least 12 characters"]
+  ```
 
 ## Default widgets


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines here:
https://github.com/netlify/netlify-cms/blob/master/CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first two fields are mandatory:
-->

**Summary**
###  Fixes #5915 
- Changing the indent level seems to have worked here

    ![Screenshot from 2021-11-03 16-02-35](https://user-images.githubusercontent.com/37417813/140047227-318d0481-6fe3-47c8-9379-d5d8a9ed0b95.png)

- The single line issue was because of the ```white-space: nowrap```
 
    ![Screenshot from 2021-11-03 16-18-50](https://user-images.githubusercontent.com/37417813/140047432-24dd036a-a098-4e86-aba7-01567515b97e.png)

- Changing it to ```white-space: normal``` results in

    ![Screenshot from 2021-11-03 16-06-34](https://user-images.githubusercontent.com/37417813/140047583-00820750-26fa-4360-9be5-696cef03b633.png)

The first one looks cleaner imo

**Checklist**

Please add a `x` inside each checkbox:

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [x] Code is formatted via running `yarn format`.
- [x] Tests are passing via running `yarn test`.
- [x] The status checks are successful (continuous integration). Those can be seen below.

**A picture of a cute animal (not mandatory but encouraged)**





