### PR TITLE
ci(workflow): add yarn' cache from setup-node action to 'e2e-with-cypress' job

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -61,15 +61,7 @@ jobs:
         with:
           node-version: '*'
           check-latest: true
-      - name: Get yarn cache directory path
-        id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn cache dir)"
-      - uses: actions/cache@v2
-        with:
-          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-          key: ${{ runner.os }}-yarn-${{ hashFiles(format('{0}{1}', github.workspace, '/yarn.lock')) }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-
+          cache: yarn
       - uses: actions/download-artifact@master
         with:
           name: dev-test-website-${{ runner.os }}


### PR DESCRIPTION
**Summary**
Follow up from https://github.com/netlify/netlify-cms/pull/5924