### PR TITLE
Add missing `auth_type` to `CmsBackend` type

### DIFF
--- a/packages/netlify-cms-core/index.d.ts
+++ b/packages/netlify-cms-core/index.d.ts
@@ -355,6 +355,7 @@ declare module 'netlify-cms-core' {
     site_domain?: string;
     base_url?: string;
     auth_endpoint?: string;
+    auth_type?: 'implicit' | 'pkce';
     cms_label_prefix?: string;
     squash_merges?: boolean;
     proxy_url?: string;


### PR DESCRIPTION
**Summary**

This adds the missing `auth_type` field to the `CmsBackend` type.

**Test plan**

none

**Checklist**

Please add a `x` inside each checkbox:

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [ ] Code is formatted via running `yarn format`.
- [ ] Tests are passing via running `yarn test`.
- [ ] The status checks are successful (continuous integration). Those can be seen below.

**A picture of a cute animal (not mandatory but encouraged)**
