### PR TITLE
docs: add Nuxt 3 static files location

### DIFF
--- a/website/content/docs/add-to-your-site.md
+++ b/website/content/docs/add-to-your-site.md
@@ -11,19 +11,19 @@ This tutorial guides you through the steps for adding Netlify CMS to a site that
 
 A static `admin` folder contains all Netlify CMS files, stored at the root of your published site. Where you store this folder in the source files depends on your static site generator. Here's the static file location for a few of the most popular static site generators:
 
-| These generators                           | store static files in |
-| ------------------------------------------ | --------------------- |
-| Jekyll, GitBook                            | `/` (project root)    |
-| Hugo, Gatsby, Nuxt, Gridsome, Zola, Sapper | `/static`             |
-| Next                                       | `/public`             |
-| Hexo, Middleman, Jigsaw                    | `/source`             |
-| Spike                                      | `/views`              |
-| Wyam                                       | `/input`              |
-| Pelican                                    | `/content`            |
-| VuePress                                   | `/.vuepress/public`   |
-| Elmstatic                                  | `/_site`              |
-| 11ty                                       | `/_site`              |
-| preact-cli                                 | `/src/static`         |
+| These generators                             | store static files in |
+| -------------------------------------------- | --------------------- |
+| Jekyll, GitBook                              | `/` (project root)    |
+| Hugo, Gatsby, Nuxt 2, Gridsome, Zola, Sapper | `/static`             |
+| Next, Nuxt 3                                 | `/public`             |
+| Hexo, Middleman, Jigsaw                      | `/source`             |
+| Spike                                        | `/views`              |
+| Wyam                                         | `/input`              |
+| Pelican                                      | `/content`            |
+| VuePress                                     | `/.vuepress/public`   |
+| Elmstatic                                    | `/_site`              |
+| 11ty                                         | `/_site`              |
+| preact-cli                                   | `/src/static`         |
 
 If your generator isn't listed here, you can check its documentation, or as a shortcut, look in your project for a `css` or `images` folder. The contents of folders like that are usually processed as static files, so it's likely you can store your `admin` folder next to those. (When you've found the location, feel free to add it to these docs by [filing a pull request](https://github.com/netlify/netlify-cms/blob/master/CONTRIBUTING.md#pull-requests)!)
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines here:
https://github.com/netlify/netlify-cms/blob/master/CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first two fields are mandatory:
-->

**Summary**

<!--
Explain the **motivation** for making this change.
What existing problem does the pull request solve?
-->

The Nuxt 2 `static` directory became the `public` directory on Nuxt 3, as described
on the [official docs](https://v3.nuxtjs.org/docs/directory-structure/public). 

This PR updates the `add-to-your-site` docs so both Nuxt 2 and 3 are covered
on the App File Structure table

**Test plan**

<!--
Demonstrate the code is solid.
Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.
-->

Lint:
```
❯ cd website
❯ yarn lint
yarn run v1.22.10
$ markdownlint 'content/docs/**/*.md'
✨  Done in 0.43s.
```
Run (with `yarn start`) and check UI on browser:
![image](https://user-images.githubusercontent.com/2357374/141850969-e6f3ccdb-7382-466a-8fc5-7db26eed3666.png)

**Checklist**

Please add a `x` inside each checkbox:

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [x] Code is formatted via running `yarn format`.
- [x] Tests are passing via running `yarn test`.
- [ ] The status checks are successful (continuous integration). Those can be seen below.

**A picture of a cute animal (not mandatory but encouraged)**
![image](https://user-images.githubusercontent.com/2357374/141851657-f5c2bec9-4ba0-4019-833d-d9a935868684.png)
