### PR TITLE
chore: increase yarn network timeout

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -30,7 +30,7 @@ jobs:
       - name: log versions
         run: node --version && npm --version && yarn --version
       - name: install dependecies
-        run: yarn --frozen-lockfile && yarn bootstrap
+        run: yarn --frozen-lockfile --network-timeout 1000000 && yarn bootstrap
       - name: run unit tests
         run: yarn test:ci
         env:


### PR DESCRIPTION
We've been having `yarn install` timeouts in our CI, see https://github.com/netlify/netlify-cms/runs/4505200149?check_suite_focus=true#step:5:7

Increasing the timeout should fix this.