### PR TITLE
refactor(netlify-cms-ui-default): use grayDark for button

### DIFF
--- a/packages/netlify-cms-backend-git-gateway/src/__tests__/__snapshots__/AuthenticationPage.spec.js.snap
+++ b/packages/netlify-cms-backend-git-gateway/src/__tests__/__snapshots__/AuthenticationPage.spec.js.snap
@@ -140,7 +140,7 @@ exports[`GitGatewayAuthenticationPage should render with no identity error 1`] =
   padding: 0 15px;
   background-color: #798291;
   color: #fff;
-  background-color: #798291;
+  background-color: #313d3e;
   color: #fff;
   padding: 0 12px;
   margin-top: -40px;
@@ -232,7 +232,7 @@ exports[`GitGatewayAuthenticationPage should render with no identity error 1`] =
   padding: 0 15px;
   background-color: #798291;
   color: #fff;
-  background-color: #798291;
+  background-color: #313d3e;
   color: #fff;
   padding: 0 12px;
   margin-top: -40px;

--- a/packages/netlify-cms-ui-default/src/styles.js
+++ b/packages/netlify-cms-ui-default/src/styles.js
@@ -64,7 +64,7 @@ const colors = {
   active: colorsRaw.blue,
   activeBackground: colorsRaw.blueLight,
   inactive: colorsRaw.gray,
-  button: colorsRaw.gray,
+  button: colorsRaw.grayDark,
   buttonText: colorsRaw.white,
   inputBackground: colorsRaw.white,
   infoText: colorsRaw.blue,


### PR DESCRIPTION
**Summary**

This PR is a fix for
https://github.com/netlify/netlify-cms/issues/1333#issuecomment-998115794
because it changes the background color used by `button` to `grayDark`
so that it is accessible.

**Test plan**

![screenshot-netlify](https://user-images.githubusercontent.com/3806031/146808390-97bdff14-33b8-4ca9-8c83-9e8ad538c857.png)

Tested the `grayDark` color [here ](https://dequeuniversity.com/rules/axe/4.3/color-contrast?application=axeAPI)and it passes.

![image](https://user-images.githubusercontent.com/3806031/146808538-107f33fa-4aa6-4c7d-ac2d-c946913419a5.png)

**Checklist**

Please add a `x` inside each checkbox:

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [x] Code is formatted via running `yarn format`.
- [x] Tests are passing via running `yarn test`.
- [x] The status checks are successful (continuous integration). Those can be seen below.

**A picture of a cute animal (not mandatory but encouraged)**
![image](https://user-images.githubusercontent.com/3806031/146808603-ba5684c8-36a3-46c4-a794-a74123bff4ed.png)


