### PR TITLE
chore: add missing `app_id` field to `CmsBackend` type

### DIFF
--- a/packages/netlify-cms-core/index.d.ts
+++ b/packages/netlify-cms-core/index.d.ts
@@ -355,6 +355,7 @@ declare module 'netlify-cms-core' {
     site_domain?: string;
     base_url?: string;
     auth_endpoint?: string;
+    app_id?: string;
     auth_type?: 'implicit' | 'pkce';
     cms_label_prefix?: string;
     squash_merges?: boolean;


### PR DESCRIPTION
**Summary**

this adds the missing `app_id` field (documented e.g. [here](https://www.netlifycms.org/docs/gitlab-backend/#client-side-pkce-authorization)) to the `CmsBackend` type

**Checklist**

Please add a `x` inside each checkbox:

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [x] Code is formatted via running `yarn format`.
- [x] Tests are passing via running `yarn test`.
- [x] The status checks are successful (continuous integration). Those can be seen below.
