### PR TITLE
feat: add truncate filter to summary tag

### DIFF
--- a/packages/netlify-cms-lib-widgets/src/__tests__/stringTemplate.spec.js
+++ b/packages/netlify-cms-lib-widgets/src/__tests__/stringTemplate.spec.js
@@ -1,12 +1,13 @@
 import { fromJS } from 'immutable';
 
 import {
-  keyToPathArray,
   compileStringTemplate,
-  parseDateFromEntry,
-  extractTemplateVars,
   expandPath,
+  extractTemplateVars,
+  keyToPathArray,
+  parseDateFromEntry,
 } from '../stringTemplate';
+
 describe('stringTemplate', () => {
   describe('keyToPathArray', () => {
     it('should return array of length 1 with simple path', () => {
@@ -151,6 +152,28 @@ describe('stringTemplate', () => {
           fromJS({ slug: 'entrySlug', starred: true, done: false }),
         ),
       ).toBe('BACKENDSLUG-star️-open️');
+    });
+
+    it('return apply filter for truncate', () => {
+      expect(
+        compileStringTemplate(
+          '{{slug | truncate(6)}}',
+          date,
+          'backendSlug',
+          fromJS({ slug: 'entrySlug', starred: true, done: false }),
+        ),
+      ).toBe('backen...');
+    });
+
+    it('return apply filter for truncate', () => {
+      expect(
+        compileStringTemplate(
+          "{{slug | truncate(3,'***')}}",
+          date,
+          'backendSlug',
+          fromJS({ slug: 'entrySlug', starred: true, done: false }),
+        ),
+      ).toBe('bac***');
     });
   });
 

--- a/packages/netlify-cms-lib-widgets/src/stringTemplate.ts
+++ b/packages/netlify-cms-lib-widgets/src/stringTemplate.ts
@@ -1,7 +1,7 @@
-import moment from 'moment';
 import { Map } from 'immutable';
+import { get, trimEnd, truncate } from 'lodash';
+import moment from 'moment';
 import { basename, dirname, extname } from 'path';
-import { get, trimEnd } from 'lodash';
 
 const filters = [
   { pattern: /^upper$/, transform: (str: string) => str.toUpperCase() },
@@ -20,6 +20,18 @@ const filters = [
   {
     pattern: /^ternary\('(.*)',\s*'(.*)'\)$/,
     transform: (str: string, match: RegExpMatchArray) => (str ? match[1] : match[2]),
+  },
+  {
+    pattern: /^truncate\(([0-9]+)(?:(?:,\s*['"])([^'"]*)(?:['"]))?\)$/,
+    transform: (str: string, match: RegExpMatchArray) => {
+      const omission = match[2] || '...';
+      const length = parseInt(match[1]) + omission.length;
+
+      return truncate(str, {
+        length,
+        omission,
+      });
+    },
   },
 ];
 

--- a/website/content/docs/beta-features.md
+++ b/website/content/docs/beta-features.md
@@ -556,14 +556,15 @@ collections:
   - name: 'posts'
     label: 'Posts'
     folder: '_posts'
-    summary: "{{title | upper}} - {{date | date('YYYY-MM-DD')}}"
+    summary: "{{title | upper}} - {{date | date('YYYY-MM-DD')}} – {{body | truncate(20, '***')}}"
     fields:
       - { label: 'Title', name: 'title', widget: 'string' }
       - { label: 'Publish Date', name: 'date', widget: 'datetime' }
+      - { label: 'Body', name: 'body', widget: 'markdown' }
 ```
 
 The above config will transform the title field to uppercase and format the date field using `YYYY-MM-DD` format.
-Available transformations are `upper`, `lower`, `date('<format>'), default('defaultValue') and ternary('valueForTrue','valueForFalse')`
+Available transformations are `upper`, `lower`, `date('<format>')`, `default('defaultValue')`, `ternary('valueForTrue','valueForFalse')` and `truncate(<number>)`/`truncate(<number>, '<string>')`  
 
 ## Registering to CMS Events
 


### PR DESCRIPTION
**Summary**

When using the new types feature of the list widget, there is no good solution to show a summary for markdown fields. I added a new `truncate` filter for the summary tag.

I can be used as followed:
{{body | truncate(20)}} -> Will truncate the body field after 20 characters and adds the default ... at the end.
{{body | truncate(20, '***')}} -> Will truncate the body field after 20 characters and adds *** at the end.

**Checklist**

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [x] Code is formatted via running `yarn format`.
- [x] Tests are passing via running `yarn test`.
- [x] The status checks are successful (continuous integration). Those can be seen below.

