### PR TITLE
Inlined React Split Pane Usage

### DIFF
--- a/packages/netlify-cms-core/package.json
+++ b/packages/netlify-cms-core/package.json
@@ -56,7 +56,6 @@
     "react-router-dom": "^5.2.0",
     "react-scroll-sync": "^0.9.0",
     "react-sortable-hoc": "^2.0.0",
-    "react-split-pane": "^0.1.85",
     "react-topbar-progress-indicator": "^4.0.0",
     "react-virtualized-auto-sizer": "^1.0.2",
     "react-waypoint": "^10.0.0",

--- a/packages/netlify-cms-core/src/components/Editor/EditorInterface.js
+++ b/packages/netlify-cms-core/src/components/Editor/EditorInterface.js
@@ -3,7 +3,7 @@ import React, { Component } from 'react';
 import ImmutablePropTypes from 'react-immutable-proptypes';
 import { css, Global } from '@emotion/core';
 import styled from '@emotion/styled';
-import SplitPane from 'react-split-pane';
+import SplitPane from './SplitPane';
 import {
   colors,
   colorsRaw,

--- a/packages/netlify-cms-core/src/components/Editor/EditorInterface.js
+++ b/packages/netlify-cms-core/src/components/Editor/EditorInterface.js
@@ -3,7 +3,6 @@ import React, { Component } from 'react';
 import ImmutablePropTypes from 'react-immutable-proptypes';
 import { css, Global } from '@emotion/core';
 import styled from '@emotion/styled';
-import SplitPane from './SplitPane';
 import {
   colors,
   colorsRaw,
@@ -14,6 +13,7 @@ import {
 } from 'netlify-cms-ui-default';
 import { ScrollSync, ScrollSyncPane } from 'react-scroll-sync';
 
+import SplitPane from './SplitPane';
 import EditorControlPane from './EditorControlPane/EditorControlPane';
 import EditorPreviewPane from './EditorPreviewPane/EditorPreviewPane';
 import EditorToolbar from './EditorToolbar';

--- a/packages/netlify-cms-core/src/components/Editor/SplitPane/Pane.js
+++ b/packages/netlify-cms-core/src/components/Editor/SplitPane/Pane.js
@@ -1,0 +1,40 @@
+const Pane = (props) => {
+
+    const {
+        children,
+        className,
+        split,
+        style: styleProps,
+        size,
+        eleRef,
+    } = props;
+
+    const classes = ["Pane", split, className];
+
+    let style = {
+        flex: 1,
+        position: "relative",
+        outline: "none",
+    };
+
+    if (size !== undefined) {
+        if (split === "vertical") {
+            style.width = size;
+        } else {
+            style.height = size;
+            style.display = "flex";
+        }
+        style.flex = "none";
+    }
+
+    style = Object.assign({}, style, styleProps || {});
+
+    return (
+        <div ref={eleRef} className={classes.join(" ")} style={style}>
+            {children}
+        </div>
+    );
+  
+};
+
+export default Pane;

--- a/packages/netlify-cms-core/src/components/Editor/SplitPane/Pane.js
+++ b/packages/netlify-cms-core/src/components/Editor/SplitPane/Pane.js
@@ -1,40 +1,33 @@
-const Pane = (props) => {
+import React from 'react';
 
-    const {
-        children,
-        className,
-        split,
-        style: styleProps,
-        size,
-        eleRef,
-    } = props;
+function Pane(props) {
+  const { children, className, split, style: styleProps, size, eleRef } = props;
 
-    const classes = ["Pane", split, className];
+  const classes = ['Pane', split, className];
 
-    let style = {
-        flex: 1,
-        position: "relative",
-        outline: "none",
-    };
+  let style = {
+    flex: 1,
+    position: 'relative',
+    outline: 'none',
+  };
 
-    if (size !== undefined) {
-        if (split === "vertical") {
-            style.width = size;
-        } else {
-            style.height = size;
-            style.display = "flex";
-        }
-        style.flex = "none";
+  if (size !== undefined) {
+    if (split === 'vertical') {
+      style.width = size;
+    } else {
+      style.height = size;
+      style.display = 'flex';
     }
+    style.flex = 'none';
+  }
 
-    style = Object.assign({}, style, styleProps || {});
+  style = Object.assign({}, style, styleProps || {});
 
-    return (
-        <div ref={eleRef} className={classes.join(" ")} style={style}>
-            {children}
-        </div>
-    );
-  
-};
+  return (
+    <div ref={eleRef} className={classes.join(' ')} style={style}>
+      {children}
+    </div>
+  );
+}
 
 export default Pane;

--- a/packages/netlify-cms-core/src/components/Editor/SplitPane/README.md
+++ b/packages/netlify-cms-core/src/components/Editor/SplitPane/README.md
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2022 Jeremy Grieshop
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/netlify-cms-core/src/components/Editor/SplitPane/Resizer.js
+++ b/packages/netlify-cms-core/src/components/Editor/SplitPane/Resizer.js
@@ -1,0 +1,52 @@
+export const RESIZER_DEFAULT_CLASSNAME = "Resizer";
+
+const Resizer = (props) => {
+    
+    const {
+        className,
+        onClick,
+        onDoubleClick,
+        onMouseDown,
+        onTouchEnd,
+        onTouchStart,
+        resizerClassName,
+        split,
+        style,
+    } = props;
+    const classes = [resizerClassName, split, className];
+
+    return (
+        <span
+            role="presentation"
+            className={classes.join(" ")}
+            style={style}
+            onMouseDown={event => onMouseDown(event)}
+            onTouchStart={event => {
+                event.preventDefault();
+                onTouchStart(event);
+            }}
+            onTouchEnd={event => {
+                event.preventDefault();
+                onTouchEnd(event);
+            }}
+            onClick={event => {
+                if (onClick) {
+                    event.preventDefault();
+                    onClick(event);
+                }
+            }}
+            onDoubleClick={event => {
+                if (onDoubleClick) {
+                    event.preventDefault();
+                    onDoubleClick(event);
+                }
+            }}
+        />
+    );    
+};
+
+Resizer.defaultProps = {
+    resizerClassName: RESIZER_DEFAULT_CLASSNAME,
+};
+
+export default Resizer;

--- a/packages/netlify-cms-core/src/components/Editor/SplitPane/Resizer.js
+++ b/packages/netlify-cms-core/src/components/Editor/SplitPane/Resizer.js
@@ -1,52 +1,52 @@
-export const RESIZER_DEFAULT_CLASSNAME = "Resizer";
+import React from 'react';
+export const RESIZER_DEFAULT_CLASSNAME = 'Resizer';
 
-const Resizer = (props) => {
-    
-    const {
-        className,
-        onClick,
-        onDoubleClick,
-        onMouseDown,
-        onTouchEnd,
-        onTouchStart,
-        resizerClassName,
-        split,
-        style,
-    } = props;
-    const classes = [resizerClassName, split, className];
+function Resizer(props) {
+  const {
+    className,
+    onClick,
+    onDoubleClick,
+    onMouseDown,
+    onTouchEnd,
+    onTouchStart,
+    resizerClassName,
+    split,
+    style,
+  } = props;
+  const classes = [resizerClassName, split, className];
 
-    return (
-        <span
-            role="presentation"
-            className={classes.join(" ")}
-            style={style}
-            onMouseDown={event => onMouseDown(event)}
-            onTouchStart={event => {
-                event.preventDefault();
-                onTouchStart(event);
-            }}
-            onTouchEnd={event => {
-                event.preventDefault();
-                onTouchEnd(event);
-            }}
-            onClick={event => {
-                if (onClick) {
-                    event.preventDefault();
-                    onClick(event);
-                }
-            }}
-            onDoubleClick={event => {
-                if (onDoubleClick) {
-                    event.preventDefault();
-                    onDoubleClick(event);
-                }
-            }}
-        />
-    );    
-};
+  return (
+    <span
+      role="presentation"
+      className={classes.join(' ')}
+      style={style}
+      onMouseDown={event => onMouseDown(event)}
+      onTouchStart={event => {
+        event.preventDefault();
+        onTouchStart(event);
+      }}
+      onTouchEnd={event => {
+        event.preventDefault();
+        onTouchEnd(event);
+      }}
+      onClick={event => {
+        if (onClick) {
+          event.preventDefault();
+          onClick(event);
+        }
+      }}
+      onDoubleClick={event => {
+        if (onDoubleClick) {
+          event.preventDefault();
+          onDoubleClick(event);
+        }
+      }}
+    />
+  );
+}
 
 Resizer.defaultProps = {
-    resizerClassName: RESIZER_DEFAULT_CLASSNAME,
+  resizerClassName: RESIZER_DEFAULT_CLASSNAME,
 };
 
 export default Resizer;

--- a/packages/netlify-cms-core/src/components/Editor/SplitPane/SplitPane.js
+++ b/packages/netlify-cms-core/src/components/Editor/SplitPane/SplitPane.js
@@ -1,0 +1,318 @@
+import React, {useEffect, useState, useCallback, useRef} from "react";
+
+import Pane from "./Pane";
+import Resizer, {RESIZER_DEFAULT_CLASSNAME} from "./Resizer";
+
+function unFocus(document, window) {
+    if (document.selection) {
+        document.selection.empty();
+    } else {
+        try {
+            window.getSelection().removeAllRanges();
+            // eslint-disable-next-line no-empty
+        } catch (e) {}
+    }
+}
+
+function getDefaultSize(defaultSize, minSize, maxSize, draggedSize) {
+    if (typeof draggedSize === "number") {
+        const min = typeof minSize === "number" ? minSize : 0;
+        const max = typeof maxSize === "number" && maxSize >= 0 ? maxSize : Infinity;
+        return Math.max(min, Math.min(max, draggedSize));
+    }
+    if (defaultSize !== undefined) {
+        return defaultSize;
+    }
+    return minSize;
+}
+
+function removeNullChildren(children) {
+    return React.Children.toArray(children).filter(c => c);
+}
+
+const SplitPane = (props) => {
+
+    const {
+        allowResize = true,
+        children,
+        className,
+        defaultSize,
+        minSize = 50,
+        maxSize,
+        onChange,
+        onDragFinished,
+        onDragStarted,
+        onResizerClick,
+        onResizerDoubleClick,
+        paneClassName = "",
+        pane1ClassName = "",
+        pane2ClassName = "",
+        paneStyle,
+        primary = "first",
+        pane1Style: pane1StyleProps,
+        pane2Style: pane2StyleProps,
+        resizerClassName,
+        resizerStyle,
+        size,
+        split = "vertical",
+        step,
+        style: styleProps,
+    } = props;
+
+    const initialSize = size !== undefined ? size : getDefaultSize(defaultSize, minSize, maxSize, null);
+
+    const [active, setActive] = useState(false);
+    const [, setResized] = useState(false);
+    const [pane1Size, setPane1Size] = useState(primary === "first" ? initialSize : undefined);
+    const [pane2Size, setPane2Size] = useState(primary === "second" ? initialSize : undefined);
+    const [draggedSize, setDraggedSize] = useState();
+    const [position, setPosition] = useState();        
+
+    const splitPane = useRef();
+    const pane1 = useRef();
+    const pane2 = useRef();
+    const instanceProps = useRef({ size });
+   
+    const getSizeUpdate = useCallback(() => {
+        if (instanceProps.current.size === size && size !== undefined) {
+            return undefined;
+        }
+
+        const newSize = size !== undefined ? size : getDefaultSize(
+            defaultSize, minSize, maxSize, draggedSize
+        );
+
+        if (size !== undefined) {
+            setDraggedSize(newSize);
+        }
+
+        const isPanel1Primary = primary === "first";
+        if (isPanel1Primary) {
+            setPane1Size(newSize);
+            setPane2Size(undefined);
+        } else {        
+            setPane2Size(newSize);
+            setPane1Size(undefined);
+        }
+
+        instanceProps.current.size = newSize;
+
+    }, [defaultSize, draggedSize, maxSize, minSize, primary, size]);
+
+    const onMouseUp = useCallback(() => {        
+        if (allowResize && active) {
+            if (typeof onDragFinished === "function") {
+                onDragFinished(draggedSize);
+            }
+            setActive(false);
+        }
+    }, [active, allowResize, draggedSize, onDragFinished]);   
+
+    const onTouchMove = useCallback((event) => {        
+        if (allowResize && active) {
+            unFocus(document, window);
+            const isPrimaryFirst = primary === "first";
+            const ref = isPrimaryFirst ? pane1.current : pane2.current;
+            const ref2 = isPrimaryFirst ? pane2.current : pane1.current;
+            if (ref) {
+                const node = ref;
+                const node2 = ref2;
+
+                if (node.getBoundingClientRect) {
+                    const width = node.getBoundingClientRect().width;
+                    const height = node.getBoundingClientRect().height;
+                    const current =
+            split === "vertical"
+                ? event.touches[0].clientX
+                : event.touches[0].clientY;
+                    const size = split === "vertical" ? width : height;
+                    let positionDelta = position - current;
+                    if (step) {
+                        if (Math.abs(positionDelta) < step) {
+                            return;
+                        }
+                        // Integer division
+                        // eslint-disable-next-line no-bitwise
+                        positionDelta = ~~(positionDelta / step) * step;
+                    }
+                    let sizeDelta = isPrimaryFirst ? positionDelta : -positionDelta;
+
+                    const pane1Order = parseInt(window.getComputedStyle(node).order);
+                    const pane2Order = parseInt(window.getComputedStyle(node2).order);
+                    if (pane1Order > pane2Order) {
+                        sizeDelta = -sizeDelta;
+                    }
+
+                    let newMaxSize = maxSize;
+                    if (maxSize !== undefined && maxSize <= 0) {                        
+                        if (split === "vertical") {
+                            newMaxSize = splitPane.current.getBoundingClientRect().width + maxSize;
+                        } else {
+                            newMaxSize = splitPane.current.getBoundingClientRect().height + maxSize;
+                        }
+                    }
+
+                    let newSize = size - sizeDelta;
+                    const newPosition = position - positionDelta;
+
+                    if (newSize < minSize) {
+                        newSize = minSize;
+                    } else if (maxSize !== undefined && newSize > newMaxSize) {
+                        newSize = newMaxSize;
+                    } else {
+                        setPosition(newPosition);
+                        setResized(true);                        
+                    }
+
+                    if (onChange) onChange(newSize);
+
+                    setDraggedSize(newSize);
+                    if (isPrimaryFirst)
+                        setPane1Size(newSize);
+                    else 
+                        setPane2Size(newSize);                    
+                }
+            }
+        }
+    }, [active, allowResize, maxSize, minSize, onChange, position, primary, split, step]);
+
+    const onMouseMove = useCallback((event) => {
+        const eventWithTouches = Object.assign({}, event, {
+            touches: [{ clientX: event.clientX, clientY: event.clientY }],
+        });
+        onTouchMove(eventWithTouches);
+    }, [onTouchMove]);
+
+    const onTouchStart = useCallback((event) => {        
+        if (allowResize) {
+            unFocus(document, window);
+            const position =
+        split === "vertical"
+            ? event.touches[0].clientX
+            : event.touches[0].clientY;
+
+            if (typeof onDragStarted === "function") {
+                onDragStarted();
+            }
+            setActive(true);
+            setPosition(position);            
+        }
+    }, [allowResize, onDragStarted, split]);
+
+    const onMouseDown = useCallback((event) => {
+        const eventWithTouches = Object.assign({}, event, {
+            touches: [{ clientX: event.clientX, clientY: event.clientY }],
+        });
+        onTouchStart(eventWithTouches);
+    }, [onTouchStart]);
+
+    useEffect(() => {
+
+        document.addEventListener("mouseup", onMouseUp);
+        document.addEventListener("mousemove", onMouseMove);
+        document.addEventListener("touchmove", onTouchMove);
+
+        getSizeUpdate();
+
+        return () => {
+            document.removeEventListener("mouseup", onMouseUp);
+            document.removeEventListener("mousemove", onMouseMove);
+            document.removeEventListener("touchmove", onTouchMove);
+        };
+
+    }, [onMouseUp, onMouseMove, onTouchMove, getSizeUpdate]);
+
+    const disabledClass = allowResize ? "" : "disabled";
+    const resizerClassNamesIncludingDefault = resizerClassName
+        ? `${resizerClassName} ${RESIZER_DEFAULT_CLASSNAME}`
+        : resizerClassName;
+
+    const notNullChildren = removeNullChildren(children);
+
+    const style = {
+        display: "flex",
+        flex: 1,
+        height: "100%",
+        position: "absolute",
+        outline: "none",
+        overflow: "hidden",
+        MozUserSelect: "text",
+        WebkitUserSelect: "text",
+        msUserSelect: "text",
+        userSelect: "text",
+        ...styleProps,
+    };
+
+    if (split === "vertical") {
+        Object.assign(style, {
+            flexDirection: "row",
+            left: 0,
+            right: 0,
+        });
+    } else {
+        Object.assign(style, {
+            bottom: 0,
+            flexDirection: "column",
+            minHeight: "100%",
+            top: 0,
+            width: "100%",
+        });
+    }
+
+    const classes = ["SplitPane", className, split, disabledClass];
+
+    const pane1Style = { ...paneStyle, ...pane1StyleProps };
+    const pane2Style = { ...paneStyle, ...pane2StyleProps };
+
+    const pane1Classes = ["Pane1", paneClassName, pane1ClassName].join(" ");
+    const pane2Classes = ["Pane2", paneClassName, pane2ClassName].join(" ");
+
+    return (
+        <div
+            className={classes.join(" ")}
+            ref={node => {
+                splitPane.current = node;
+            }}
+            style={style}
+        >
+            <Pane
+                className={pane1Classes}
+                key="pane1"
+                eleRef={node => {
+                    pane1.current = node;
+                }}
+                size={pane1Size}
+                split={split}
+                style={pane1Style}
+            >
+                {notNullChildren[0]}
+            </Pane>
+            <Resizer
+                className={disabledClass}
+                onClick={onResizerClick}
+                onDoubleClick={onResizerDoubleClick}
+                onMouseDown={onMouseDown}
+                onTouchStart={onTouchStart}
+                onTouchEnd={onMouseUp}
+                key="resizer"
+                resizerClassName={resizerClassNamesIncludingDefault}
+                split={split}
+                style={resizerStyle || {}}
+            />
+            <Pane
+                className={pane2Classes}
+                key="pane2"
+                eleRef={node => {
+                    pane2.current = node;
+                }}
+                size={pane2Size}
+                split={split}
+                style={pane2Style}
+            >
+                {notNullChildren[1]}
+            </Pane>
+        </div>
+    );
+};
+
+export default SplitPane;

--- a/packages/netlify-cms-core/src/components/Editor/SplitPane/SplitPane.js
+++ b/packages/netlify-cms-core/src/components/Editor/SplitPane/SplitPane.js
@@ -1,318 +1,319 @@
-import React, {useEffect, useState, useCallback, useRef} from "react";
+import React, { useEffect, useState, useCallback, useRef } from 'react';
 
-import Pane from "./Pane";
-import Resizer, {RESIZER_DEFAULT_CLASSNAME} from "./Resizer";
+import Pane from './Pane';
+import Resizer, { RESIZER_DEFAULT_CLASSNAME } from './Resizer';
 
 function unFocus(document, window) {
-    if (document.selection) {
-        document.selection.empty();
-    } else {
-        try {
-            window.getSelection().removeAllRanges();
-            // eslint-disable-next-line no-empty
-        } catch (e) {}
-    }
+  if (document.selection) {
+    document.selection.empty();
+  } else {
+    try {
+      window.getSelection().removeAllRanges();
+      // eslint-disable-next-line no-empty
+    } catch (e) {}
+  }
 }
 
 function getDefaultSize(defaultSize, minSize, maxSize, draggedSize) {
-    if (typeof draggedSize === "number") {
-        const min = typeof minSize === "number" ? minSize : 0;
-        const max = typeof maxSize === "number" && maxSize >= 0 ? maxSize : Infinity;
-        return Math.max(min, Math.min(max, draggedSize));
-    }
-    if (defaultSize !== undefined) {
-        return defaultSize;
-    }
-    return minSize;
+  if (typeof draggedSize === 'number') {
+    const min = typeof minSize === 'number' ? minSize : 0;
+    const max = typeof maxSize === 'number' && maxSize >= 0 ? maxSize : Infinity;
+    return Math.max(min, Math.min(max, draggedSize));
+  }
+  if (defaultSize !== undefined) {
+    return defaultSize;
+  }
+  return minSize;
 }
 
 function removeNullChildren(children) {
-    return React.Children.toArray(children).filter(c => c);
+  return React.Children.toArray(children).filter(c => c);
 }
 
-const SplitPane = (props) => {
+function SplitPane(props) {
+  const {
+    allowResize = true,
+    children,
+    className,
+    defaultSize,
+    minSize = 50,
+    maxSize,
+    onChange,
+    onDragFinished,
+    onDragStarted,
+    onResizerClick,
+    onResizerDoubleClick,
+    paneClassName = '',
+    pane1ClassName = '',
+    pane2ClassName = '',
+    paneStyle,
+    primary = 'first',
+    pane1Style: pane1StyleProps,
+    pane2Style: pane2StyleProps,
+    resizerClassName,
+    resizerStyle,
+    size,
+    split = 'vertical',
+    step,
+    style: styleProps,
+  } = props;
 
-    const {
-        allowResize = true,
-        children,
-        className,
-        defaultSize,
-        minSize = 50,
-        maxSize,
-        onChange,
-        onDragFinished,
-        onDragStarted,
-        onResizerClick,
-        onResizerDoubleClick,
-        paneClassName = "",
-        pane1ClassName = "",
-        pane2ClassName = "",
-        paneStyle,
-        primary = "first",
-        pane1Style: pane1StyleProps,
-        pane2Style: pane2StyleProps,
-        resizerClassName,
-        resizerStyle,
-        size,
-        split = "vertical",
-        step,
-        style: styleProps,
-    } = props;
+  const initialSize =
+    size !== undefined ? size : getDefaultSize(defaultSize, minSize, maxSize, null);
 
-    const initialSize = size !== undefined ? size : getDefaultSize(defaultSize, minSize, maxSize, null);
+  const [active, setActive] = useState(false);
+  const [, setResized] = useState(false);
+  const [pane1Size, setPane1Size] = useState(primary === 'first' ? initialSize : undefined);
+  const [pane2Size, setPane2Size] = useState(primary === 'second' ? initialSize : undefined);
+  const [draggedSize, setDraggedSize] = useState();
+  const [position, setPosition] = useState();
 
-    const [active, setActive] = useState(false);
-    const [, setResized] = useState(false);
-    const [pane1Size, setPane1Size] = useState(primary === "first" ? initialSize : undefined);
-    const [pane2Size, setPane2Size] = useState(primary === "second" ? initialSize : undefined);
-    const [draggedSize, setDraggedSize] = useState();
-    const [position, setPosition] = useState();        
+  const splitPane = useRef();
+  const pane1 = useRef();
+  const pane2 = useRef();
+  const instanceProps = useRef({ size });
 
-    const splitPane = useRef();
-    const pane1 = useRef();
-    const pane2 = useRef();
-    const instanceProps = useRef({ size });
-   
-    const getSizeUpdate = useCallback(() => {
-        if (instanceProps.current.size === size && size !== undefined) {
-            return undefined;
-        }
-
-        const newSize = size !== undefined ? size : getDefaultSize(
-            defaultSize, minSize, maxSize, draggedSize
-        );
-
-        if (size !== undefined) {
-            setDraggedSize(newSize);
-        }
-
-        const isPanel1Primary = primary === "first";
-        if (isPanel1Primary) {
-            setPane1Size(newSize);
-            setPane2Size(undefined);
-        } else {        
-            setPane2Size(newSize);
-            setPane1Size(undefined);
-        }
-
-        instanceProps.current.size = newSize;
-
-    }, [defaultSize, draggedSize, maxSize, minSize, primary, size]);
-
-    const onMouseUp = useCallback(() => {        
-        if (allowResize && active) {
-            if (typeof onDragFinished === "function") {
-                onDragFinished(draggedSize);
-            }
-            setActive(false);
-        }
-    }, [active, allowResize, draggedSize, onDragFinished]);   
-
-    const onTouchMove = useCallback((event) => {        
-        if (allowResize && active) {
-            unFocus(document, window);
-            const isPrimaryFirst = primary === "first";
-            const ref = isPrimaryFirst ? pane1.current : pane2.current;
-            const ref2 = isPrimaryFirst ? pane2.current : pane1.current;
-            if (ref) {
-                const node = ref;
-                const node2 = ref2;
-
-                if (node.getBoundingClientRect) {
-                    const width = node.getBoundingClientRect().width;
-                    const height = node.getBoundingClientRect().height;
-                    const current =
-            split === "vertical"
-                ? event.touches[0].clientX
-                : event.touches[0].clientY;
-                    const size = split === "vertical" ? width : height;
-                    let positionDelta = position - current;
-                    if (step) {
-                        if (Math.abs(positionDelta) < step) {
-                            return;
-                        }
-                        // Integer division
-                        // eslint-disable-next-line no-bitwise
-                        positionDelta = ~~(positionDelta / step) * step;
-                    }
-                    let sizeDelta = isPrimaryFirst ? positionDelta : -positionDelta;
-
-                    const pane1Order = parseInt(window.getComputedStyle(node).order);
-                    const pane2Order = parseInt(window.getComputedStyle(node2).order);
-                    if (pane1Order > pane2Order) {
-                        sizeDelta = -sizeDelta;
-                    }
-
-                    let newMaxSize = maxSize;
-                    if (maxSize !== undefined && maxSize <= 0) {                        
-                        if (split === "vertical") {
-                            newMaxSize = splitPane.current.getBoundingClientRect().width + maxSize;
-                        } else {
-                            newMaxSize = splitPane.current.getBoundingClientRect().height + maxSize;
-                        }
-                    }
-
-                    let newSize = size - sizeDelta;
-                    const newPosition = position - positionDelta;
-
-                    if (newSize < minSize) {
-                        newSize = minSize;
-                    } else if (maxSize !== undefined && newSize > newMaxSize) {
-                        newSize = newMaxSize;
-                    } else {
-                        setPosition(newPosition);
-                        setResized(true);                        
-                    }
-
-                    if (onChange) onChange(newSize);
-
-                    setDraggedSize(newSize);
-                    if (isPrimaryFirst)
-                        setPane1Size(newSize);
-                    else 
-                        setPane2Size(newSize);                    
-                }
-            }
-        }
-    }, [active, allowResize, maxSize, minSize, onChange, position, primary, split, step]);
-
-    const onMouseMove = useCallback((event) => {
-        const eventWithTouches = Object.assign({}, event, {
-            touches: [{ clientX: event.clientX, clientY: event.clientY }],
-        });
-        onTouchMove(eventWithTouches);
-    }, [onTouchMove]);
-
-    const onTouchStart = useCallback((event) => {        
-        if (allowResize) {
-            unFocus(document, window);
-            const position =
-        split === "vertical"
-            ? event.touches[0].clientX
-            : event.touches[0].clientY;
-
-            if (typeof onDragStarted === "function") {
-                onDragStarted();
-            }
-            setActive(true);
-            setPosition(position);            
-        }
-    }, [allowResize, onDragStarted, split]);
-
-    const onMouseDown = useCallback((event) => {
-        const eventWithTouches = Object.assign({}, event, {
-            touches: [{ clientX: event.clientX, clientY: event.clientY }],
-        });
-        onTouchStart(eventWithTouches);
-    }, [onTouchStart]);
-
-    useEffect(() => {
-
-        document.addEventListener("mouseup", onMouseUp);
-        document.addEventListener("mousemove", onMouseMove);
-        document.addEventListener("touchmove", onTouchMove);
-
-        getSizeUpdate();
-
-        return () => {
-            document.removeEventListener("mouseup", onMouseUp);
-            document.removeEventListener("mousemove", onMouseMove);
-            document.removeEventListener("touchmove", onTouchMove);
-        };
-
-    }, [onMouseUp, onMouseMove, onTouchMove, getSizeUpdate]);
-
-    const disabledClass = allowResize ? "" : "disabled";
-    const resizerClassNamesIncludingDefault = resizerClassName
-        ? `${resizerClassName} ${RESIZER_DEFAULT_CLASSNAME}`
-        : resizerClassName;
-
-    const notNullChildren = removeNullChildren(children);
-
-    const style = {
-        display: "flex",
-        flex: 1,
-        height: "100%",
-        position: "absolute",
-        outline: "none",
-        overflow: "hidden",
-        MozUserSelect: "text",
-        WebkitUserSelect: "text",
-        msUserSelect: "text",
-        userSelect: "text",
-        ...styleProps,
-    };
-
-    if (split === "vertical") {
-        Object.assign(style, {
-            flexDirection: "row",
-            left: 0,
-            right: 0,
-        });
-    } else {
-        Object.assign(style, {
-            bottom: 0,
-            flexDirection: "column",
-            minHeight: "100%",
-            top: 0,
-            width: "100%",
-        });
+  const getSizeUpdate = useCallback(() => {
+    if (instanceProps.current.size === size && size !== undefined) {
+      return undefined;
     }
 
-    const classes = ["SplitPane", className, split, disabledClass];
+    const newSize =
+      size !== undefined ? size : getDefaultSize(defaultSize, minSize, maxSize, draggedSize);
 
-    const pane1Style = { ...paneStyle, ...pane1StyleProps };
-    const pane2Style = { ...paneStyle, ...pane2StyleProps };
+    if (size !== undefined) {
+      setDraggedSize(newSize);
+    }
 
-    const pane1Classes = ["Pane1", paneClassName, pane1ClassName].join(" ");
-    const pane2Classes = ["Pane2", paneClassName, pane2ClassName].join(" ");
+    const isPanel1Primary = primary === 'first';
+    if (isPanel1Primary) {
+      setPane1Size(newSize);
+      setPane2Size(undefined);
+    } else {
+      setPane2Size(newSize);
+      setPane1Size(undefined);
+    }
 
-    return (
-        <div
-            className={classes.join(" ")}
-            ref={node => {
-                splitPane.current = node;
-            }}
-            style={style}
-        >
-            <Pane
-                className={pane1Classes}
-                key="pane1"
-                eleRef={node => {
-                    pane1.current = node;
-                }}
-                size={pane1Size}
-                split={split}
-                style={pane1Style}
-            >
-                {notNullChildren[0]}
-            </Pane>
-            <Resizer
-                className={disabledClass}
-                onClick={onResizerClick}
-                onDoubleClick={onResizerDoubleClick}
-                onMouseDown={onMouseDown}
-                onTouchStart={onTouchStart}
-                onTouchEnd={onMouseUp}
-                key="resizer"
-                resizerClassName={resizerClassNamesIncludingDefault}
-                split={split}
-                style={resizerStyle || {}}
-            />
-            <Pane
-                className={pane2Classes}
-                key="pane2"
-                eleRef={node => {
-                    pane2.current = node;
-                }}
-                size={pane2Size}
-                split={split}
-                style={pane2Style}
-            >
-                {notNullChildren[1]}
-            </Pane>
-        </div>
-    );
-};
+    instanceProps.current.size = newSize;
+  }, [defaultSize, draggedSize, maxSize, minSize, primary, size]);
+
+  const onMouseUp = useCallback(() => {
+    if (allowResize && active) {
+      if (typeof onDragFinished === 'function') {
+        onDragFinished(draggedSize);
+      }
+      setActive(false);
+    }
+  }, [active, allowResize, draggedSize, onDragFinished]);
+
+  const onTouchMove = useCallback(
+    event => {
+      if (allowResize && active) {
+        unFocus(document, window);
+        const isPrimaryFirst = primary === 'first';
+        const ref = isPrimaryFirst ? pane1.current : pane2.current;
+        const ref2 = isPrimaryFirst ? pane2.current : pane1.current;
+        if (ref) {
+          const node = ref;
+          const node2 = ref2;
+
+          if (node.getBoundingClientRect) {
+            const width = node.getBoundingClientRect().width;
+            const height = node.getBoundingClientRect().height;
+            const current =
+              split === 'vertical' ? event.touches[0].clientX : event.touches[0].clientY;
+            const size = split === 'vertical' ? width : height;
+            let positionDelta = position - current;
+            if (step) {
+              if (Math.abs(positionDelta) < step) {
+                return;
+              }
+              // Integer division
+              // eslint-disable-next-line no-bitwise
+              positionDelta = ~~(positionDelta / step) * step;
+            }
+            let sizeDelta = isPrimaryFirst ? positionDelta : -positionDelta;
+
+            const pane1Order = parseInt(window.getComputedStyle(node).order);
+            const pane2Order = parseInt(window.getComputedStyle(node2).order);
+            if (pane1Order > pane2Order) {
+              sizeDelta = -sizeDelta;
+            }
+
+            let newMaxSize = maxSize;
+            if (maxSize !== undefined && maxSize <= 0) {
+              if (split === 'vertical') {
+                newMaxSize = splitPane.current.getBoundingClientRect().width + maxSize;
+              } else {
+                newMaxSize = splitPane.current.getBoundingClientRect().height + maxSize;
+              }
+            }
+
+            let newSize = size - sizeDelta;
+            const newPosition = position - positionDelta;
+
+            if (newSize < minSize) {
+              newSize = minSize;
+            } else if (maxSize !== undefined && newSize > newMaxSize) {
+              newSize = newMaxSize;
+            } else {
+              setPosition(newPosition);
+              setResized(true);
+            }
+
+            if (onChange) onChange(newSize);
+
+            setDraggedSize(newSize);
+            if (isPrimaryFirst) setPane1Size(newSize);
+            else setPane2Size(newSize);
+          }
+        }
+      }
+    },
+    [active, allowResize, maxSize, minSize, onChange, position, primary, split, step],
+  );
+
+  const onMouseMove = useCallback(
+    event => {
+      const eventWithTouches = Object.assign({}, event, {
+        touches: [{ clientX: event.clientX, clientY: event.clientY }],
+      });
+      onTouchMove(eventWithTouches);
+    },
+    [onTouchMove],
+  );
+
+  const onTouchStart = useCallback(
+    event => {
+      if (allowResize) {
+        unFocus(document, window);
+        const position = split === 'vertical' ? event.touches[0].clientX : event.touches[0].clientY;
+
+        if (typeof onDragStarted === 'function') {
+          onDragStarted();
+        }
+        setActive(true);
+        setPosition(position);
+      }
+    },
+    [allowResize, onDragStarted, split],
+  );
+
+  const onMouseDown = useCallback(
+    event => {
+      const eventWithTouches = Object.assign({}, event, {
+        touches: [{ clientX: event.clientX, clientY: event.clientY }],
+      });
+      onTouchStart(eventWithTouches);
+    },
+    [onTouchStart],
+  );
+
+  useEffect(() => {
+    document.addEventListener('mouseup', onMouseUp);
+    document.addEventListener('mousemove', onMouseMove);
+    document.addEventListener('touchmove', onTouchMove);
+
+    getSizeUpdate();
+
+    return () => {
+      document.removeEventListener('mouseup', onMouseUp);
+      document.removeEventListener('mousemove', onMouseMove);
+      document.removeEventListener('touchmove', onTouchMove);
+    };
+  }, [onMouseUp, onMouseMove, onTouchMove, getSizeUpdate]);
+
+  const disabledClass = allowResize ? '' : 'disabled';
+  const resizerClassNamesIncludingDefault = resizerClassName
+    ? `${resizerClassName} ${RESIZER_DEFAULT_CLASSNAME}`
+    : resizerClassName;
+
+  const notNullChildren = removeNullChildren(children);
+
+  const style = {
+    display: 'flex',
+    flex: 1,
+    height: '100%',
+    position: 'absolute',
+    outline: 'none',
+    overflow: 'hidden',
+    MozUserSelect: 'text',
+    WebkitUserSelect: 'text',
+    msUserSelect: 'text',
+    userSelect: 'text',
+    ...styleProps,
+  };
+
+  if (split === 'vertical') {
+    Object.assign(style, {
+      flexDirection: 'row',
+      left: 0,
+      right: 0,
+    });
+  } else {
+    Object.assign(style, {
+      bottom: 0,
+      flexDirection: 'column',
+      minHeight: '100%',
+      top: 0,
+      width: '100%',
+    });
+  }
+
+  const classes = ['SplitPane', className, split, disabledClass];
+
+  const pane1Style = { ...paneStyle, ...pane1StyleProps };
+  const pane2Style = { ...paneStyle, ...pane2StyleProps };
+
+  const pane1Classes = ['Pane1', paneClassName, pane1ClassName].join(' ');
+  const pane2Classes = ['Pane2', paneClassName, pane2ClassName].join(' ');
+
+  return (
+    <div
+      className={classes.join(' ')}
+      ref={node => {
+        splitPane.current = node;
+      }}
+      style={style}
+    >
+      <Pane
+        className={pane1Classes}
+        key="pane1"
+        eleRef={node => {
+          pane1.current = node;
+        }}
+        size={pane1Size}
+        split={split}
+        style={pane1Style}
+      >
+        {notNullChildren[0]}
+      </Pane>
+      <Resizer
+        className={disabledClass}
+        onClick={onResizerClick}
+        onDoubleClick={onResizerDoubleClick}
+        onMouseDown={onMouseDown}
+        onTouchStart={onTouchStart}
+        onTouchEnd={onMouseUp}
+        key="resizer"
+        resizerClassName={resizerClassNamesIncludingDefault}
+        split={split}
+        style={resizerStyle || {}}
+      />
+      <Pane
+        className={pane2Classes}
+        key="pane2"
+        eleRef={node => {
+          pane2.current = node;
+        }}
+        size={pane2Size}
+        split={split}
+        style={pane2Style}
+      >
+        {notNullChildren[1]}
+      </Pane>
+    </div>
+  );
+}
 
 export default SplitPane;

--- a/packages/netlify-cms-core/src/components/Editor/SplitPane/index.js
+++ b/packages/netlify-cms-core/src/components/Editor/SplitPane/index.js
@@ -1,8 +1,8 @@
-import ReactSplitPane from "./SplitPane";
-import Pane from "./Pane";
-
-export default ReactSplitPane
-export { Pane };
+import ReactSplitPane from './SplitPane';
+import Pane from './Pane';
 /**
  * Implementation from https://github.com/JeremyGrieshop/react-split-pane/blob/main/SplitPane.js
  */
+
+export default ReactSplitPane;
+export { Pane };

--- a/packages/netlify-cms-core/src/components/Editor/SplitPane/index.js
+++ b/packages/netlify-cms-core/src/components/Editor/SplitPane/index.js
@@ -1,0 +1,8 @@
+import ReactSplitPane from "./SplitPane";
+import Pane from "./Pane";
+
+export default ReactSplitPane
+export { Pane };
+/**
+ * Implementation from https://github.com/JeremyGrieshop/react-split-pane/blob/main/SplitPane.js
+ */

--- a/yarn.lock
+++ b/yarn.lock
@@ -15026,7 +15026,7 @@ promzard@^0.3.0:
   dependencies:
     read "1"
 
-prop-types@^15.0.0, prop-types@^15.5.10, prop-types@^15.5.4, prop-types@^15.5.6, prop-types@^15.5.7, prop-types@^15.5.8, prop-types@^15.6.0, prop-types@^15.6.1, prop-types@^15.6.2, prop-types@^15.7.2:
+prop-types@^15.0.0, prop-types@^15.5.10, prop-types@^15.5.6, prop-types@^15.5.7, prop-types@^15.5.8, prop-types@^15.6.0, prop-types@^15.6.1, prop-types@^15.6.2, prop-types@^15.7.2:
   version "15.8.1"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.8.1.tgz#67d87bf1a694f48435cf332c24af10214a3140b5"
   integrity sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==
@@ -15658,22 +15658,6 @@ react-sortable-hoc@^2.0.0:
     "@babel/runtime" "^7.2.0"
     invariant "^2.2.4"
     prop-types "^15.5.7"
-
-react-split-pane@^0.1.85:
-  version "0.1.92"
-  resolved "https://registry.yarnpkg.com/react-split-pane/-/react-split-pane-0.1.92.tgz#68242f72138aed95dd5910eeb9d99822c4fc3a41"
-  integrity sha512-GfXP1xSzLMcLJI5BM36Vh7GgZBpy+U/X0no+VM3fxayv+p1Jly5HpMofZJraeaMl73b3hvlr+N9zJKvLB/uz9w==
-  dependencies:
-    prop-types "^15.7.2"
-    react-lifecycles-compat "^3.0.4"
-    react-style-proptype "^3.2.2"
-
-react-style-proptype@^3.2.2:
-  version "3.2.2"
-  resolved "https://registry.yarnpkg.com/react-style-proptype/-/react-style-proptype-3.2.2.tgz#d8e998e62ce79ec35b087252b90f19f1c33968a0"
-  integrity sha512-ywYLSjNkxKHiZOqNlso9PZByNEY+FTyh3C+7uuziK0xFXu9xzdyfHwg4S9iyiRRoPCR4k2LqaBBsWVmSBwCWYQ==
-  dependencies:
-    prop-types "^15.5.4"
 
 react-syntax-highlighter@^11.0.2:
   version "11.0.3"


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines here:
https://github.com/netlify/netlify-cms/blob/master/CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first two fields are mandatory:
-->

**Summary**
Fixes #5376. I've inlined the usage of SplitPane and removed all references to the library in the codebase.
As described in the issue the library that provided that component `react-split-pane` is no longer being maintained and causes React 17 compatibility issues.

Both to the compatability issues and the library being unmaintained it was deemed that the ideal path was to inline the usage of the components. Thank you to @jeremyGrieshop for modernizing the library in his own implementation and hence making it a painless migration.

There is still one reference to the old dependency in the yarn.lock under the website folder. But I'm unsure of how y'all want to go about removing that since it seems to come from it using the published version of netlify core:  `netlify-cms-core@^2.54.3`

**Test plan**

- Ran the full suite of tests locally via the `test:all` script

<!--
Demonstrate the code is solid.
Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.
-->

**Checklist**

Please add a `x` inside each checkbox:

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [x] Code is formatted via running `yarn format`.
- [x] Tests are passing via running `yarn test`.
- [ ] The status checks are successful (continuous integration). Those can be seen below.

**A picture of a cute animal (not mandatory but encouraged)**
As requested
![Cat](https://media.giphy.com/media/BLCHvwl9C5j1u/giphy.gif)