### PR TITLE
fix(i18n): fix that unable to delete page with SINGLE_FILE i18n structure

### DIFF
--- a/packages/netlify-cms-core/src/lib/__tests__/i18n.spec.js
+++ b/packages/netlify-cms-core/src/lib/__tests__/i18n.spec.js
@@ -181,6 +181,17 @@ describe('i18n', () => {
         ),
       ).toEqual(['src/content/en/index.md', 'src/content/de/index.md']);
     });
+
+    it('should return array with single path when structure is I18N_STRUCTURE.SINGLE_FILE', () => {
+      expect(
+        i18n.getFilePaths(
+          fromJS({
+            i18n: { structure: i18n.I18N_STRUCTURE.SINGLE_FILE, locales: ['en', 'de'] },
+          }),
+          ...args,
+        ),
+      ).toEqual(['src/content/index.md']);
+    });
   });
 
   describe('normalizeFilePath', () => {

--- a/packages/netlify-cms-core/src/lib/i18n.ts
+++ b/packages/netlify-cms-core/src/lib/i18n.ts
@@ -114,6 +114,11 @@ export function getFilePaths(
   slug: string,
 ) {
   const { structure, locales } = getI18nInfo(collection) as I18nInfo;
+
+  if (structure === I18N_STRUCTURE.SINGLE_FILE) {
+    return [path];
+  }
+
   const paths = locales.map(locale =>
     getFilePath(structure as I18N_STRUCTURE, extension, path, slug, locale),
   );


### PR DESCRIPTION
fixes that getFilePaths returns same path twice when i18n structure is SINGLE_FILE

**Checklist**
- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [x] Code is formatted via running `yarn format`.
- [x] Tests are passing via running `yarn test`.
- [x] The status checks are successful (continuous integration). Those can be seen below.

**A picture of a cute animal (not mandatory but encouraged)**
![image](https://user-images.githubusercontent.com/19573007/154451466-6e82b2ad-2948-4c8a-9df6-6d681a4847e6.png)
