### PR TITLE
fix: replace error instanceof EditorialWorkflowError check

### DIFF
--- a/packages/netlify-cms-core/src/backend.ts
+++ b/packages/netlify-cms-core/src/backend.ts
@@ -5,10 +5,10 @@ import {
   localForage,
   Cursor,
   CURSOR_COMPATIBILITY_SYMBOL,
-  EditorialWorkflowError,
   getPathDepth,
   blobToFileObj,
   asyncLock,
+  EDITORIAL_WORKFLOW_ERROR,
 } from 'netlify-cms-lib-util';
 import { basename, join, extname, dirname } from 'path';
 import { stringTemplate } from 'netlify-cms-lib-widgets';
@@ -417,7 +417,7 @@ export class Backend {
       (await this.implementation
         .unpublishedEntry({ collection: collection.get('name'), slug })
         .catch(error => {
-          if (error instanceof EditorialWorkflowError && error.notUnderEditorialWorkflow) {
+          if (error.name === EDITORIAL_WORKFLOW_ERROR && error.notUnderEditorialWorkflow) {
             return Promise.resolve(false);
           }
           return Promise.reject(error);


### PR DESCRIPTION
**Summary**

Using a custom backend that inherited from `GitGateway` was unable to initially save a new page because the `instanceof` check was returning false, despite the error being an `EditorialWorkflowError`

Checking the `name` field instead appears to be a pattern already in use in `actions/editorialWorkflow.ts`

**Test plan**

Existing tests for `entryExist` should continue to work with this change

**Checklist**

Please add a `x` inside each checkbox:

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [x] Code is formatted via running `yarn format`.
- [x] Tests are passing via running `yarn test`.
- [ ] The status checks are successful (continuous integration). Those can be seen below.

**A picture of a cute animal (not mandatory but encouraged)**
