### PR TITLE
chore: remove all .substring() usage

### DIFF
--- a/cypress/plugins/bitbucket.js
+++ b/cypress/plugins/bitbucket.js
@@ -88,7 +88,7 @@ async function prepareTestBitBucketRepo({ lfs }) {
   // postfix a random string to avoid collisions
   const postfix = Math.random()
     .toString(32)
-    .substring(2);
+    .slice(2);
   const testRepoName = `${repo}-${Date.now()}-${postfix}`;
 
   console.log('Creating repository', testRepoName);

--- a/cypress/plugins/github.js
+++ b/cypress/plugins/github.js
@@ -61,7 +61,7 @@ async function prepareTestGitHubRepo() {
   // postfix a random string to avoid collisions
   const postfix = Math.random()
     .toString(32)
-    .substring(2);
+    .slice(2);
   const testRepoName = `${repo}-${Date.now()}-${postfix}`;
 
   const client = getGitHubClient(token);

--- a/cypress/plugins/gitlab.js
+++ b/cypress/plugins/gitlab.js
@@ -52,7 +52,7 @@ async function prepareTestGitLabRepo() {
   // postfix a random string to avoid collisions
   const postfix = Math.random()
     .toString(32)
-    .substring(2);
+    .slice(2);
   const testRepoName = `${repo}-${Date.now()}-${postfix}`;
 
   const client = getGitLabClient(token);

--- a/cypress/plugins/proxy.js
+++ b/cypress/plugins/proxy.js
@@ -61,7 +61,7 @@ let serverProcess;
 async function setupProxy(options) {
   const postfix = Math.random()
     .toString(32)
-    .substring(2);
+    .slice(2);
 
   const testRepoName = `proxy-test-repo-${Date.now()}-${postfix}`;
   const tempDir = path.join('.temp', testRepoName);

--- a/packages/netlify-cms-core/src/formats/frontmatter.ts
+++ b/packages/netlify-cms-core/src/formats/frontmatter.ts
@@ -36,8 +36,7 @@ const parsers = {
       let JSONoutput = jsonFormatter.toFile(metadata).trim();
       // Trim leading and trailing brackets.
       if (JSONoutput.slice(0, 1) === '{' && JSONoutput.slice(-1) === '}') {
-        // eslint-disable-next-line unicorn/prefer-string-slice
-        JSONoutput = JSONoutput.substring(1, JSONoutput.length - 1);
+        JSONoutput = JSONoutput.slice(1, -1);
       }
       return JSONoutput;
     },
@@ -55,8 +54,8 @@ const parsers = {
 };
 
 function inferFrontmatterFormat(str: string) {
-  // eslint-disable-next-line unicorn/prefer-string-slice
-  const firstLine = str.substring(0, str.indexOf('\n')).trim();
+  const lineEnd = str.indexOf('\n');
+  const firstLine = str.slice(0, lineEnd !== -1 ? lineEnd : 0).trim();
   if (firstLine.length > 3 && firstLine.slice(0, 3) === '---') {
     // No need to infer, `gray-matter` will handle things like `---toml` for us.
     return;
@@ -132,8 +131,7 @@ export class FrontmatterFormatter {
       comments,
       ...format,
     });
-    // eslint-disable-next-line unicorn/prefer-string-slice
-    return trimLastLineBreak && file.slice(-1) === '\n' ? file.substring(0, file.length - 1) : file;
+    return trimLastLineBreak && file.slice(-1) === '\n' ? file.slice(0, -1) : file;
   }
 }
 

--- a/packages/netlify-cms-core/src/lib/textHelper.js
+++ b/packages/netlify-cms-core/src/lib/textHelper.js
@@ -7,6 +7,5 @@ export function stringToRGB(str) {
 
   const c = (hash & 0x00ffffff).toString(16).toUpperCase();
 
-  // eslint-disable-next-line unicorn/prefer-string-slice
-  return '00000'.substring(0, 6 - c.length) + c;
+  return `00000${c}`.slice(-6);
 }

--- a/packages/netlify-cms-widget-file/src/withFileControl.js
+++ b/packages/netlify-cms-widget-file/src/withFileControl.js
@@ -319,11 +319,7 @@ export default function withFileControl({ forImage } = {}) {
       if (!value || value.length <= size) {
         return value;
       }
-      // eslint-disable-next-line unicorn/prefer-string-slice
-      const text = `${value.substring(0, size / 2)}\u2026${value.substring(
-        value.length - size / 2 + 1,
-        value.length,
-      )}`;
+      const text = `${value.slice(0, size / 2)}\u2026${value.slice(-(size / 2) + 1)}`;
       return (
         <FileLink href={value} rel="noopener" target="_blank">
           {text}

--- a/packages/netlify-cms-widget-markdown/src/serializers/slateRemark.js
+++ b/packages/netlify-cms-widget-markdown/src/serializers/slateRemark.js
@@ -177,10 +177,8 @@ export default function slateToRemark(raw, { voidCodeBlock }) {
     const index = node.text.search(exp);
     if (index > -1) {
       const substringIndex = trailing ? index : index + 1;
-      // eslint-disable-next-line unicorn/prefer-string-slice
-      const firstSplit = node.text.substring(0, substringIndex);
-      // eslint-disable-next-line unicorn/prefer-string-slice
-      const secondSplit = node.text.substring(substringIndex);
+      const firstSplit = node.text.slice(0, substringIndex);
+      const secondSplit = node.text.slice(substringIndex);
       const whitespace = trailing ? secondSplit : firstSplit;
       const text = trailing ? firstSplit : secondSplit;
       return { whitespace, trimmedNode: { ...node, text } };


### PR DESCRIPTION
**Summary**

This is a second step after #6333 which removes all uses of `substring()` and replaces it with `slice()`

**Test plan**


**Checklist**

Please add a `x` inside each checkbox:

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [x] Code is formatted via running `yarn format`.
- [ ] Tests are passing via running `yarn test`.
- [ ] The status checks are successful (continuous integration). Those can be seen below.

**A picture of a cute animal (not mandatory but encouraged)**
