### PR TITLE
chore: add checkout step

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -13,6 +13,7 @@ jobs:
     outputs:
       cms: ${{ steps.filter.outputs.cms }}
     steps:
+      - uses: actions/checkout@v3
       - uses: dorny/paths-filter@v2
         id: filter
         with:


### PR DESCRIPTION
Follow up to https://github.com/netlify/netlify-cms/pull/6390

The checkout step is needed for `push` events