### PR TITLE
fix: sets a limit for editor minSize in editor split view

### DIFF
--- a/packages/netlify-cms-core/src/components/Editor/EditorInterface.js
+++ b/packages/netlify-cms-core/src/components/Editor/EditorInterface.js
@@ -279,6 +279,7 @@ class EditorInterface extends Component {
           <ReactSplitPaneGlobalStyles />
           <StyledSplitPane
             maxSize={-100}
+            minSize={400}
             defaultSize={parseInt(localStorage.getItem(SPLIT_PANE_POSITION), 10) || '50%'}
             onChange={size => localStorage.setItem(SPLIT_PANE_POSITION, size)}
             onDragStarted={this.handleSplitPaneDragStart}


### PR DESCRIPTION


**Summary**
This fix sets a min width for the editor in the editor/preview split view. This is mostly a appearance fix.


**Test plan**
Comparing between before and after fix:

## Before
<img width="400" alt="Screenshot 2022-06-15 at 16 15 52" src="https://user-images.githubusercontent.com/54435884/173850042-ced2a227-da4d-463b-8116-b349fef14506.png">

## After
<img width="400" alt="Screenshot 2022-06-15 at 16 15 10" src="https://user-images.githubusercontent.com/54435884/173850049-3127cd39-2758-4511-a8bb-dc8c8eff8b57.png">

**Checklist**


- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [x] Code is formatted via running `yarn format`.
- [x] Tests are passing via running `yarn test`.
- [ ] The status checks are successful (continuous integration). Those can be seen below.

**A picture of a cute animal (not mandatory but encouraged)**
