### PR TITLE
🐛 Fixing i18n onLocaleChange is not a function error

### DIFF
--- a/packages/netlify-cms-core/src/components/Editor/EditorControlPane/EditorControlPane.js
+++ b/packages/netlify-cms-core/src/components/Editor/EditorControlPane/EditorControlPane.js
@@ -253,4 +253,5 @@ ControlPane.propTypes = {
   onChange: PropTypes.func.isRequired,
   onValidate: PropTypes.func.isRequired,
   locale: PropTypes.string,
+  onLocaleChange: PropTypes.func.isRequired,
 };

--- a/packages/netlify-cms-core/src/components/Editor/EditorInterface.js
+++ b/packages/netlify-cms-core/src/components/Editor/EditorInterface.js
@@ -265,7 +265,12 @@ class EditorInterface extends Component {
 
     const editor2 = (
       <ControlPaneContainer overFlow={!this.state.scrollSyncEnabled} blockEntry={showEventBlocker}>
-        <EditorControlPane {...editorProps} locale={locales?.[1]} t={t} />
+        <EditorControlPane 
+          {...editorProps} 
+          locale={locales?.[1]} 
+          t={t} 
+          onLocaleChange={this.handleLeftPanelLocaleChange}
+      />
       </ControlPaneContainer>
     );
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines here:
https://github.com/netlify/netlify-cms/blob/master/CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first two fields are mandatory:
-->

**Summary**

Fix #6307 onLocaleChange error
This change will solve `this.props.onLocaleChange is not a function` error

**Test plan**

Setup Netify CMS with i18n enabled.
1- Click New button in the index page.
2- Change writing locale dropdown from Writing in EN to another locale, for example, Writing in FR
3- check the console and verify that the error is no longer displayed

**Checklist**

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [x] Code is formatted via running `yarn format`.
- [x] Tests are passing via running `yarn test`.
- [x] The status checks are successful (continuous integration). Those can be seen below.

**A picture of a cute animal (not mandatory but encouraged)**
🦅 