### PR TITLE
fix: performance improvements on List and Object widgets

### DIFF
--- a/packages/netlify-cms-widget-list/src/ListControl.js
+++ b/packages/netlify-cms-widget-list/src/ListControl.js
@@ -550,34 +550,36 @@ export default class ListControl extends React.Component {
         <NestedObjectLabel collapsed={collapsed} error={hasError}>
           {this.objectLabel(item)}
         </NestedObjectLabel>
-        <ClassNames>
-          {({ css, cx }) => (
-            <ObjectControl
-              classNameWrapper={cx(classNameWrapper, {
-                [css`
-                  ${styleStrings.collapsedObjectControl};
-                `]: collapsed,
-              })}
-              value={item}
-              field={field}
-              onChangeObject={this.handleChangeFor(index)}
-              editorControl={editorControl}
-              resolveWidget={resolveWidget}
-              metadata={metadata}
-              forList
-              onValidateObject={onValidateObject}
-              clearFieldErrors={clearFieldErrors}
-              fieldsErrors={fieldsErrors}
-              ref={this.processControlRef}
-              controlRef={controlRef}
-              validationKey={key}
-              collapsed={collapsed}
-              data-testid={`object-control-${key}`}
-              hasError={hasError}
-              parentIds={[...parentIds, forID, key]}
-            />
-          )}
-        </ClassNames>
+        {!collapsed && (
+          <ClassNames>
+            {({ css, cx }) => (
+              <ObjectControl
+                classNameWrapper={cx(classNameWrapper, {
+                  [css`
+                    ${styleStrings.collapsedObjectControl};
+                  `]: collapsed,
+                })}
+                value={item}
+                field={field}
+                onChangeObject={this.handleChangeFor(index)}
+                editorControl={editorControl}
+                resolveWidget={resolveWidget}
+                metadata={metadata}
+                forList
+                onValidateObject={onValidateObject}
+                clearFieldErrors={clearFieldErrors}
+                fieldsErrors={fieldsErrors}
+                ref={this.processControlRef}
+                controlRef={controlRef}
+                validationKey={key}
+                collapsed={collapsed}
+                data-testid={`object-control-${key}`}
+                hasError={hasError}
+                parentIds={[...parentIds, forID, key]}
+              />
+            )}
+          </ClassNames>
+        )}
       </SortableListItem>
     );
   };

--- a/packages/netlify-cms-widget-object/src/ObjectControl.js
+++ b/packages/netlify-cms-widget-object/src/ObjectControl.js
@@ -175,15 +175,17 @@ export default class ObjectControl extends React.Component {
                   t={t}
                 />
               )}
-              <div
-                className={cx({
-                  [css`
-                    ${styleStrings.collapsedObjectControl}
-                  `]: collapsed,
-                })}
-              >
-                {this.renderFields(multiFields, singleField)}
-              </div>
+              {!collapsed && (
+                <div
+                  className={cx({
+                    [css`
+                      ${styleStrings.collapsedObjectControl}
+                    `]: collapsed,
+                  })}
+                >
+                  {this.renderFields(multiFields, singleField)}
+                </div>
+              )}
             </div>
           )}
         </ClassNames>


### PR DESCRIPTION
fixes #6563 and #3415. 

**Summary**

Performance of list and object widgets degrade quickly given large sub-widget composition. See above issues with reproductions.

---

I can't exactly speculate on the reason performance is so slow with large collections containing list and object widgets.

I can at least position a smaller fix here, which is to reduce unnecessary rendering of visually hidden sub-components. If a component isn't visible, then it doesn't need take up time for React reconciliation, and therefore things like UI delays are greatly reduced.

A gotcha on this optimization is that if the object and list widgets are all open on a page, a customer will be right back to poor performance. For that reason this is an **incremental fix** to alleviate at least a part of the problem.

**Test plan**

The main way I'm testing this is by loading up the kitchen sink collection and testing responsiveness of fields/UI events. There is a massive improvement so long as some or all of the lists are collapsed.

Tests will be removed that assert against now-removed DOM nodes in collapsed state, replaced by tests checking a void render.

**Checklist**

Please add a `x` inside each checkbox:

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [x] Code is formatted via running `yarn format`.
- [ ] Tests are passing via running `yarn test`.
- [ ] The status checks are successful (continuous integration). Those can be seen below.

🐶 🐱 🐰 🦔 🐀 🐁 🐜
