### PR TITLE
Feat: Added company image to header with link

### DIFF
--- a/packages/netlify-cms-core/src/components/App/Header.js
+++ b/packages/netlify-cms-core/src/components/App/Header.js
@@ -220,6 +220,7 @@ class Header extends React.Component {
               displayUrl={displayUrl}
               isTestRepo={isTestRepo}
               imageUrl={user?.avatar_url}
+              logoUrl ={"https://assets-us-01.kc-usercontent.com/4ec262a7-3d6c-008c-aa10-1e6ffc6c2e14/ac7c0614-e1d3-407e-83ce-cd9cb62c7e2a/netlify-logo.png"} // need help pulling url here
               onLogoutClick={onLogoutClick}
             />
           </AppHeaderActions>

--- a/packages/netlify-cms-core/src/components/UI/SettingsDropdown.js
+++ b/packages/netlify-cms-core/src/components/UI/SettingsDropdown.js
@@ -12,6 +12,9 @@ const styles = {
     width: 32px;
     border-radius: 32px;
   `,
+  CompanyImage: css`
+  width: 100px;
+`,
 };
 
 const AvatarDropdownButton = styled(DropdownButton)`
@@ -24,6 +27,10 @@ const AvatarDropdownButton = styled(DropdownButton)`
 
 const AvatarImage = styled.img`
   ${styles.avatarImage};
+`;
+
+const CompanyImage = styled.img`
+  ${styles.CompanyImage};
 `;
 
 const AvatarPlaceholderIcon = styled(Icon)`
@@ -59,7 +66,7 @@ Avatar.propTypes = {
   imageUrl: PropTypes.string,
 };
 
-function SettingsDropdown({ displayUrl, isTestRepo, imageUrl, onLogoutClick, t }) {
+function SettingsDropdown({ displayUrl, isTestRepo, imageUrl, onLogoutClick , logoUrl , t  }) {
   return (
     <React.Fragment>
       {isTestRepo && (
@@ -73,7 +80,7 @@ function SettingsDropdown({ displayUrl, isTestRepo, imageUrl, onLogoutClick, t }
       )}
       {displayUrl ? (
         <AppHeaderSiteLink href={displayUrl} target="_blank">
-          {stripProtocol(displayUrl)}
+          <CompanyImage src={logoUrl} />
         </AppHeaderSiteLink>
       ) : null}
       <Dropdown


### PR DESCRIPTION
fixes UI #5548

**Summary**

As mentioned in #5548, added the logo defined at logo_url to the header. Clicking the image links to the base site.

Important: Need help pulling in the logoUrl in the Header.js file. It is hardcoded to the netlify logo at the moment as a demo - but unsure of what approach to take to get that logo image from the redux config set in the yaml file.

I'm a code newbie and this is my first pr request ever so help is kindly appreciated :) but feel free to rip up my edits/code to help me learn.

**Test plan**

I see there are some issues with the current builds.

**Checklist**

Please add a `x` inside each checkbox:

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [x] Code is formatted via running `yarn format`.
- [ ] Tests are passing via running `yarn test`. 
- [ ] The status checks are successful (continuous integration). Those can be seen below.

![cute](https://www.rd.com/wp-content/uploads/2019/01/shutterstock_673465372.jpg?fit=700,467)

