### PR TITLE
fix: issue #6616 - meta tag robots updated to noindex

### DIFF
--- a/website/src/components/layout.js
+++ b/website/src/components/layout.js
@@ -53,6 +53,7 @@ function Layout({ hasPageHero, children }) {
           >
             <Helmet defaultTitle={title} titleTemplate={`%s | ${title}`}>
               <meta name="description" content={description} />
+              <meta name="robots" content="noindex" />
               <link
                 rel="stylesheet"
                 href="https://fonts.googleapis.com/css?family=Roboto:400,100,100italic,300,300italic,400italic,500,700,900|Roboto+Mono:400,700"

--- a/website/src/html.js
+++ b/website/src/html.js
@@ -16,6 +16,7 @@ class HTML extends React.Component {
           <link rel="mask-icon" href="/img/favicon/safari-pinned-tab.svg" color="#96cf05" />
           <meta name="apple-mobile-web-app-title" content="NetlifyCMS" />
           <meta name="application-name" content="NetlifyCMS" />
+          <meta name="robots" content="noindex" />
           {this.props.headComponents}
           <link
             rel="stylesheet"


### PR DESCRIPTION
**Summary**
- Added a robots tag with noindex
- This should hopefully remove /admin from appearing in Google search results

This is my first contribution to Netlify CMS and will hopefully remove /admin from appearing in Google Searches

**Test plan**

Added to both the Layout component and Html js file. 

**Checklist**

Please add a `x` inside each checkbox:

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [x] Code is formatted via running `yarn format`.
- [x] Tests are passing via running `yarn test`.
- [x] The status checks are successful (continuous integration). Those can be seen below.

