### PR TITLE
Fix padding top in EditorContainer

### DIFF
--- a/packages/decap-cms-core/src/components/Editor/EditorInterface.js
+++ b/packages/decap-cms-core/src/components/Editor/EditorInterface.js
@@ -95,7 +95,7 @@ const EditorContainer = styled.div`
   top: 0;
   left: 0;
   overflow: hidden;
-  padding-top: 66px;
+  padding-top: calc(66px + 56px);
   background-color: ${colors.background};
 `;
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines here:
https://github.com/decaporg/decap-cms/blob/master/CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first two fields are mandatory:
-->

**Summary**

The new fixed navbar displayed when editing overlays on top of the form. It's a minor nuisance when not scrolling, but hides the fixed editor controls when scrolling.

<img width="1186" alt="Screenshot 2023-08-28 at 08 51 02" src="https://github.com/decaporg/decap-cms/assets/23533178/17874912-1c11-4cb8-bdec-df450628b8ee">

(Scrolled to the top)

<img width="733" alt="Screenshot 2023-08-28 at 08 58 06" src="https://github.com/decaporg/decap-cms/assets/23533178/1387dcbe-8d55-4549-a72c-0353a9aede44">

(Scrolled halfway down the page)

To access the editor's controls I need to scroll back up to the top. 

By adding some extra padding to account for the new fixed element we can fix the issue:

<img width="1197" alt="Screenshot 2023-08-28 at 08 51 18" src="https://github.com/decaporg/decap-cms/assets/23533178/049cf008-468a-4ab3-9b71-725354a8d5fd">

(Scrolled to the top)

<img width="614" alt="Screenshot 2023-08-28 at 09 00 16" src="https://github.com/decaporg/decap-cms/assets/23533178/c9f7bc9d-1a23-4c31-bbe5-47f0744236f7">

(Scrolled halfway down the page)

**Checklist**

Please add a `x` inside each checkbox:

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).

**A picture of a cute animal (not mandatory but encouraged)**
