### PR TITLE
chore: improve cache restore message for clarity

### DIFF
--- a/scripts/cache.js
+++ b/scripts/cache.js
@@ -8,7 +8,7 @@ cache({
     {
       path: path.join(os.homedir(), '.cache', 'Cypress'),
       invalidateOn: __filename,
-      command: 'echo noop',
+      command: 'echo "No operation needed — cache intact"',
     },
   ],
   ignoreIfFolderExists: false,


### PR DESCRIPTION

Summary
Improved the cache restore log message in the build configuration.
Replaced echo noop with a more descriptive message:
echo "No operation needed — cache intact".
This makes CI/CD logs clearer, helping developers quickly understand that the cache step was executed successfully but no rebuild was needed.

Test plan

Ran the build process with the updated message.
Verified that the new log text appears in the build output without affecting cache functionality.
Confirmed no side effects on cache restore behavior.

- [x] I have read the [contribution guidelines](https://github.com/decaporg/decap-cms/blob/main/CONTRIBUTING.md).

;)
<img width="408" height="487" alt="Screenshot 2025-08-09 at 10 11 01 PM" src="https://github.com/user-attachments/assets/f44a381f-515e-4867-ae43-646300d5306d" />

