### PR TITLE
fix: display image uploaded from device in preview pane

### DIFF
--- a/packages/decap-cms-widget-image/src/ImagePreview.js
+++ b/packages/decap-cms-widget-image/src/ImagePreview.js
@@ -11,13 +11,13 @@ const StyledImage = styled(({ src }) => <img src={src || ''} role="presentation"
 `;
 
 function StyledImageAsset({ getAsset, value, field }) {
- let src = '';
- if (value instanceof File) {
-  src = URL.createObjectURL(value);
- } else {
-  src = getAsset(value, field);
- }
- return <StyledImage src={src} />
+  let src = '';
+  if (value instanceof File) {
+    src = URL.createObjectURL(value);
+  } else {
+    src = getAsset(value, field);
+  }
+  return <StyledImage src={src} />;
 }
 
 function ImagePreviewContent(props) {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines here:
https://github.com/decaporg/decap-cms/blob/main/CONTRIBUTING.md

If this is a bug fix, make sure your description


on includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first two fields are mandatory:
-->

**Summary**
This PR fixes a bug where images uploaded from a local device do not appear in the CMS preview pane. The preview now properly renders images by checking if the value is a File object and using `URL.createObjectURL()` to display it.

Closes #7576
<!--
Explain the **motivation** for making this change.
What existing problem does the pull request solve?
-->
Images uploaded from a user’s device were not showing in the preview pane, causing confusion even though the upload succeeded. This change fixes that by detecting local file uploads and using URL.createObjectURL() to display them instantly in the preview.

**Test plan**
- Cloned the repo locally on macOS
- Ran the project using `npm install` then `npm start`
- Opened an editable entry in the CMS demo
- Uploaded an image from my device
- Verified the image appeared in the preview without needing to save or refresh

<!--
Demonstrate the code is solid.
Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.
-->

https://github.com/user-attachments/assets/9c2c31b7-a8a4-432f-ba6d-149a46b8e6ae

**Checklist**

Please add a `x` inside each checkbox:

- [ x] I have read the [contribution guidelines](https://github.com/decaporg/decap-cms/blob/main/CONTRIBUTING.md).

**Here's a picture of a cute little spider 🕷️**

![](https://t3.ftcdn.net/jpg/01/78/55/88/360_F_178558806_M10mMPTOeTFxzIGw27WzvURgnLYrpLz2.jpg)

