### PR TITLE
fix: Add initialValue prop to Slate editor

### DIFF
--- a/packages/decap-cms-widget-markdown/src/MarkdownControl/RawEditor.js
+++ b/packages/decap-cms-widget-markdown/src/MarkdownControl/RawEditor.js
@@ -57,7 +57,7 @@ function RawEditor(props) {
   }
 
   return (
-    <Slate editor={editor} value={value} onChange={handleChange}>
+    <Slate editor={editor} value={value} initialValue={value} onChange={handleChange}>
       <RawEditorContainer>
         <EditorControlBar>
           <Toolbar


### PR DESCRIPTION
The Slate upgrade https://github.com/decaporg/decap-cms/pull/7617 made the editor crash when changing to RawEditor which is now fixed by adding initialValue prop

<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines here:
https://github.com/decaporg/decap-cms/blob/main/CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first two fields are mandatory:
-->

**Summary**

<!--
Explain the **motivation** for making this change.
What existing problem does the pull request solve?
-->

**Test plan**

<!--
Demonstrate the code is solid.
Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.
-->

**Checklist**

Please add a `x` inside each checkbox:

- [ ] I have read the [contribution guidelines](https://github.com/decaporg/decap-cms/blob/main/CONTRIBUTING.md).

**A picture of a cute animal (not mandatory but encouraged)**
