### PR TITLE
fixes #7036 handle potential null labels in pull request filtering (Azure Backend)

### DIFF
--- a/packages/decap-cms-backend-azure/src/API.ts
+++ b/packages/decap-cms-backend-azure/src/API.ts
@@ -592,7 +592,8 @@ export default class API {
     });
 
     const filtered = pullRequests.filter(pr => {
-      return pr.labels.some(label => isCMSLabel(label.name, this.cmsLabelPrefix));
+      const labels = pr.labels ?? [];
+      return labels.some(label => isCMSLabel(label.name, this.cmsLabelPrefix));
     });
     return filtered;
   }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines here:
https://github.com/decaporg/decap-cms/blob/main/CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first two fields are mandatory:
-->

**Summary**
When at least one Azure DevOps Pull request has no labels, the Decap CMS throws a lot of errors as mentioned in #7036.

<!--
Explain the **motivation** for making this change.
What existing problem does the pull request solve?
-->


<!--
**Test plan**

Demonstrate the code is solid.
Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.
-->

**Checklist**

Please add a `x` inside each checkbox:

- [ x] I have read the [contribution guidelines](https://github.com/decaporg/decap-cms/blob/main/CONTRIBUTING.md).
