### PR TITLE
fix(markdown): remove empty links when text is deleted

### DIFF
--- a/packages/decap-cms-widget-markdown/src/MarkdownControl/plugins/inlines/withInlines.js
+++ b/packages/decap-cms-widget-markdown/src/MarkdownControl/plugins/inlines/withInlines.js
@@ -1,13 +1,31 @@
+import { Element, Node, Transforms } from 'slate';
+
 import keyDown from './events/keyDown';
 
 function withInlines(editor) {
-  const { isInline, isVoid } = editor;
+  const { isInline, isVoid, normalizeNode } = editor;
 
   editor.isInline = element =>
     ['link', 'button', 'break', 'image'].includes(element.type) || isInline(element);
 
   editor.isVoid = element =>
     ['break', 'image', 'thematic-break'].includes(element.type) || isVoid(element);
+
+  // Remove empty links (fixes #7640: hidden link remains when deleting linked text)
+  editor.normalizeNode = entry => {
+    const [node, path] = entry;
+
+    if (Element.isElement(node) && node.type === 'link') {
+      // Check if link is empty (no text content)
+      const text = Node.string(node);
+      if (text === '') {
+        Transforms.removeNodes(editor, { at: path });
+        return;
+      }
+    }
+
+    normalizeNode(entry);
+  };
 
   if (editor.keyDownHandlers === undefined) {
     editor.keyDownHandlers = [];


### PR DESCRIPTION
## Summary

Fixes #7640 - Hidden link remains when deleting link in markdown widget

When a user deletes all text within a link in the visual markdown editor, the empty link markup was being left behind (visible when switching to raw markdown mode).

## Problem

Reproduction:
1. Open page with markdown widget
2. Insert a link inside
3. Delete the linked text in rich text mode
4. Switch to markdown mode - the empty hyperlink `[](url)` remains

## Solution

Added a Slate normalizer in `withInlines.js` that automatically removes link nodes when they become empty (have no text content).

The normalizer:
- Checks if a node is a link element
- Uses `Node.string()` to get text content
- Removes the node if text is empty
- Falls through to default normalizer otherwise

## Files Changed

- `packages/decap-cms-widget-markdown/src/MarkdownControl/plugins/inlines/withInlines.js`

## Test Plan

- [ ] Create a link in the visual markdown editor
- [ ] Delete all text within the link
- [ ] Verify the link wrapper is also removed
- [ ] Switch to raw mode and verify no empty `[]()` markup

---
Generated with [Claude Code](https://claude.ai/code)