### PR TITLE
fix: define packageManager field

### DIFF
--- a/package.json
+++ b/package.json
@@ -169,5 +169,6 @@
   "resolutions": {
     "react-redux": "^7.2.0"
   },
-  "version": "0.0.0"
+  "version": "0.0.0",
+  "packageManager": "npm@10.8.1+sha1.1f1cb1305cd9246b9efe07d8629874df23157a2f"
 }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines here:
https://github.com/decaporg/decap-cms/blob/main/CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first two fields are mandatory:
-->

**Summary**

Basically, this adds the `packageManager` field to avoid dependencies being installed using `yarn` or `pnpm`. The way they hoist and symlink packages all have differences, and if you installed the project using something else than `npm` (in my case, pnpm) it would lead to an issue when trying to run `npm run build`.

This is to improve the developer experience especially for first-time contributors, since many expect every repository to work fine nowadays with pnpm, for example. In a follow-up PR, we can definitely change to pnpm as default since it has better monorepo support than npm.

**Test plan**

If you try to run `yarn install` or `pnpm install` it will be blocked through corepack, e.g.
<img width="1062" height="105" alt="image" src="https://github.com/user-attachments/assets/4049391a-15f0-4b67-86ca-8eb3df490fb1" />


**Checklist**

Please add a `x` inside each checkbox:

- [x] I have read the [contribution guidelines](https://github.com/decaporg/decap-cms/blob/main/CONTRIBUTING.md).

**A picture of a cute animal (not mandatory but encouraged)**
<img width="225" height="225" alt="image" src="https://github.com/user-attachments/assets/210291db-d561-4ca0-86f4-fb09dffa4e7e" />
