### PR TITLE
fix: set PENDING status on deploy preview request and failure

### DIFF
--- a/packages/decap-cms-core/src/reducers/__tests__/deploys.spec.ts
+++ b/packages/decap-cms-core/src/reducers/__tests__/deploys.spec.ts
@@ -1,0 +1,111 @@
+import deploys, { selectDeployPreview } from '../deploys';
+import {
+  DEPLOY_PREVIEW_REQUEST,
+  DEPLOY_PREVIEW_SUCCESS,
+  DEPLOY_PREVIEW_FAILURE,
+} from '../../actions/deploys';
+
+describe('deploys reducer', () => {
+  it('should return the default state', () => {
+    const result = deploys(undefined, { type: 'UNKNOWN' });
+    expect(result).toEqual({});
+  });
+
+  describe('DEPLOY_PREVIEW_REQUEST', () => {
+    it('should set isFetching to true and status to PENDING', () => {
+      const result = deploys(undefined, {
+        type: DEPLOY_PREVIEW_REQUEST,
+        payload: { collection: 'posts', slug: 'my-post' },
+      });
+      expect(result['posts.my-post']).toEqual({ isFetching: true, status: 'PENDING' });
+    });
+
+    it('should clear stale url and replace status with PENDING', () => {
+      const staleState = {
+        'posts.my-post': {
+          isFetching: false,
+          url: 'https://production.example.com/posts/my-post',
+          status: 'SUCCESS',
+        },
+      };
+      const result = deploys(staleState, {
+        type: DEPLOY_PREVIEW_REQUEST,
+        payload: { collection: 'posts', slug: 'my-post' },
+      });
+      expect(result['posts.my-post']).toEqual({ isFetching: true, status: 'PENDING' });
+      expect(result['posts.my-post'].url).toBeUndefined();
+    });
+  });
+
+  describe('DEPLOY_PREVIEW_SUCCESS', () => {
+    it('should store the deploy preview url and status', () => {
+      const initialState = {
+        'posts.my-post': { isFetching: true },
+      };
+      const result = deploys(initialState, {
+        type: DEPLOY_PREVIEW_SUCCESS,
+        payload: {
+          collection: 'posts',
+          slug: 'my-post',
+          url: 'https://preview.example.com/posts/my-post',
+          status: 'SUCCESS',
+        },
+      });
+      expect(result['posts.my-post']).toEqual({
+        isFetching: false,
+        url: 'https://preview.example.com/posts/my-post',
+        status: 'SUCCESS',
+      });
+    });
+  });
+
+  describe('DEPLOY_PREVIEW_FAILURE', () => {
+    it('should set isFetching to false and status to PENDING', () => {
+      const initialState = {
+        'posts.my-post': { isFetching: true, status: 'PENDING' },
+      };
+      const result = deploys(initialState, {
+        type: DEPLOY_PREVIEW_FAILURE,
+        payload: { collection: 'posts', slug: 'my-post' },
+      });
+      expect(result['posts.my-post'].isFetching).toBe(false);
+      expect(result['posts.my-post'].status).toBe('PENDING');
+    });
+
+    it('should clear url and replace status with PENDING to prevent stale data', () => {
+      const initialState = {
+        'posts.my-post': {
+          isFetching: true,
+          url: 'https://production.example.com/posts/my-post',
+          status: 'SUCCESS',
+        },
+      };
+      const result = deploys(initialState, {
+        type: DEPLOY_PREVIEW_FAILURE,
+        payload: { collection: 'posts', slug: 'my-post' },
+      });
+      expect(result['posts.my-post']).toEqual({
+        isFetching: false,
+        url: undefined,
+        status: 'PENDING',
+      });
+    });
+  });
+
+  describe('selectDeployPreview', () => {
+    it('should return the deploy preview for a given collection and slug', () => {
+      const state = {
+        'posts.my-post': {
+          isFetching: false,
+          url: 'https://preview.example.com/posts/my-post',
+          status: 'SUCCESS',
+        },
+      };
+      expect(selectDeployPreview(state, 'posts', 'my-post')).toBe(state['posts.my-post']);
+    });
+
+    it('should return undefined for unknown collection/slug', () => {
+      expect(selectDeployPreview({}, 'posts', 'unknown')).toBeUndefined();
+    });
+  });
+});

--- a/packages/decap-cms-core/src/reducers/deploys.ts
+++ b/packages/decap-cms-core/src/reducers/deploys.ts
@@ -23,8 +23,7 @@ const deploys = produce((state: Deploys, action: DeploysAction) => {
     case DEPLOY_PREVIEW_REQUEST: {
       const { collection, slug } = action.payload;
       const key = `${collection}.${slug}`;
-      state[key] = state[key] || {};
-      state[key].isFetching = true;
+      state[key] = { isFetching: true, status: 'PENDING' };
       break;
     }
 
@@ -39,7 +38,10 @@ const deploys = produce((state: Deploys, action: DeploysAction) => {
 
     case DEPLOY_PREVIEW_FAILURE: {
       const { collection, slug } = action.payload;
-      state[`${collection}.${slug}`].isFetching = false;
+      const key = `${collection}.${slug}`;
+      state[key].isFetching = false;
+      state[key].url = undefined;
+      state[key].status = 'PENDING';
       break;
     }
   }


### PR DESCRIPTION
## Summary

Sets `status: 'PENDING'` in the deploys reducer on both `DEPLOY_PREVIEW_REQUEST` and `DEPLOY_PREVIEW_FAILURE`, preventing stale production URLs from appearing and ensuring the "Check for Preview" button remains visible during polling. Adds unit tests for the deploys reducer (none existed before).

## Problem

When a user opens an existing published entry, `getDeploy` stores `{ status: "SUCCESS", url: "https://production-url/..." }` in Redux. If the user then saves (creating an editorial workflow branch), `getDeployPreview` polls for commit statuses. Two issues:

1. **Stale production URL:** If no commit status exists yet, the old `SUCCESS` state and production URL persisted, causing "View Preview" to link to the production URL instead of the deploy preview.
2. **Disappearing controls:** Clearing `status` to `undefined` caused the deploy preview controls to disappear entirely — `renderDeployPreviewControls` has a guard clause `if (!status) return` — leaving editors with no way to manually check for a preview.

## Fix

```diff
     case DEPLOY_PREVIEW_REQUEST: {
       const { collection, slug } = action.payload;
       const key = `${collection}.${slug}`;
-      state[key] = state[key] || {};
-      state[key].isFetching = true;
+      state[key] = { isFetching: true, status: 'PENDING' };
       break;
     }
     ...
     case DEPLOY_PREVIEW_FAILURE: {
       const { collection, slug } = action.payload;
-      state[`${collection}.${slug}`].isFetching = false;
+      const key = `${collection}.${slug}`;
+      state[key].isFetching = false;
+      state[key].url = undefined;
+      state[key].status = 'PENDING';
       break;
     }
```

- **`DEPLOY_PREVIEW_REQUEST`**: Resets the entry to `{ isFetching: true, status: 'PENDING' }`, clearing stale `url`/`status` while keeping the "Check for Preview" button visible.
- **`DEPLOY_PREVIEW_FAILURE`**: Clears `url` and sets `status: 'PENDING'` so the button stays visible and clickable for manual retries.

## Tests

Added `packages/decap-cms-core/src/reducers/__tests__/deploys.spec.ts`. Covers:
- All three action types (`REQUEST`, `SUCCESS`, `FAILURE`)
- `REQUEST` clears stale url and sets status to PENDING
- `FAILURE` clears url and sets status to PENDING
- `selectDeployPreview` selector

Fixes #7755