### PR TITLE
feat: add loading feedback to deploy preview button

### DIFF
--- a/packages/decap-cms-core/src/components/Editor/EditorToolbar.js
+++ b/packages/decap-cms-core/src/components/Editor/EditorToolbar.js
@@ -230,6 +230,24 @@ const RefreshPreviewButton = styled.button`
   span {
     margin-right: 6px;
   }
+
+  &:disabled {
+    cursor: default;
+    opacity: 0.6;
+  }
+
+  ${Icon} {
+    ${props => props.$spinning && `animation: spin 1s linear infinite;`}
+  }
+
+  @keyframes spin {
+    from {
+      transform: rotate(0deg);
+    }
+    to {
+      transform: rotate(360deg);
+    }
+  }
 `;
 
 const PreviewLink = RefreshPreviewButton.withComponent('a');
@@ -331,7 +349,11 @@ export class EditorToolbar extends React.Component {
             <Icon type="new-tab" size="xsmall" />
           </PreviewLink>
         ) : (
-          <RefreshPreviewButton onClick={loadDeployPreview}>
+          <RefreshPreviewButton
+            onClick={loadDeployPreview}
+            disabled={isFetching}
+            $spinning={isFetching}
+          >
             <span>{t('editor.editorToolbar.deployPreviewPendingButtonLabel')}</span>
             <Icon type="refresh" size="xsmall" />
           </RefreshPreviewButton>


### PR DESCRIPTION
## Summary

Adds visual loading feedback to the "Check for Preview" button while deploy preview polling is in progress.

## Changes

### Spinning refresh icon
When `isFetching` is true, the refresh icon on the "Check for Preview" button spins with a CSS animation, giving editors clear visual feedback that the system is actively checking for a preview.

### Disabled during polling
The button is disabled while polling is in progress, preventing duplicate requests from stacking up.

### Transient prop
Uses `$spinning` (Emotion transient prop) to avoid leaking non-standard attributes to the DOM.

## UX flow

1. Editor clicks "Check for Preview" or polling starts automatically
2. Refresh icon spins, button is disabled
3. When polling resolves, spinning stops and button either transitions to "View Preview" link or re-enables for manual retry