### PR TITLE
fix: increase deploy preview polling and cancel on unmount

### DIFF
--- a/packages/decap-cms-core/src/actions/deploys.ts
+++ b/packages/decap-cms-core/src/actions/deploys.ts
@@ -55,16 +55,17 @@ export function loadDeployPreview(
   slug: string,
   entry: Entry,
   published: boolean,
-  opts?: { maxAttempts?: number; interval?: number },
+  opts?: { maxAttempts?: number; interval?: number; signal?: AbortSignal },
 ) {
   return async (dispatch: ThunkDispatch<State, undefined, AnyAction>, getState: () => State) => {
     const state = getState();
     const backend = currentBackend(state.config);
     const collectionName = collection.get('name');
 
-    // Exit if currently fetching
+    // Exit if currently fetching, unless the caller provides a signal
+    // (indicating it manages cancellation of the previous poll externally).
     const deployState = selectDeployPreview(state, collectionName, slug);
-    if (deployState && deployState.isFetching) {
+    if (deployState && deployState.isFetching && !opts?.signal) {
       return;
     }
 

--- a/packages/decap-cms-core/src/backend.ts
+++ b/packages/decap-cms-core/src/backend.ts
@@ -1046,7 +1046,11 @@ export class Backend {
     collection: Collection,
     slug: string,
     entry: EntryMap,
-    { maxAttempts = 1, interval = 5000 } = {},
+    {
+      maxAttempts = 1,
+      interval = 5000,
+      signal,
+    }: { maxAttempts?: number; interval?: number; signal?: AbortSignal } = {},
   ) {
     /**
      * If the registered backend does not provide a `getDeployPreview` method, or
@@ -1063,6 +1067,9 @@ export class Backend {
     let deployPreview,
       count = 0;
     while (!deployPreview && count < maxAttempts) {
+      if (signal?.aborted) {
+        return;
+      }
       count++;
       deployPreview = await this.implementation.getDeployPreview(collection.get('name'), slug);
       if (!deployPreview) {

--- a/packages/decap-cms-core/src/components/Editor/EditorToolbar.js
+++ b/packages/decap-cms-core/src/components/Editor/EditorToolbar.js
@@ -303,15 +303,30 @@ export class EditorToolbar extends React.Component {
 
     const { isNewEntry, loadDeployPreview } = this.props;
     if (!isNewEntry) {
-      loadDeployPreview({ maxAttempts: 3 });
+      // 24 attempts × 5s interval = ~2 min polling window.
+      // With editorial workflow, saving remounts the component (navigates to
+      // the unpublished entry view), so componentDidMount is the primary
+      // polling trigger — not componentDidUpdate.
+      this._pollController = new AbortController();
+      loadDeployPreview({ maxAttempts: 24, signal: this._pollController.signal });
     }
   }
 
   componentDidUpdate(prevProps) {
     const { isNewEntry, isPersisting, loadDeployPreview } = this.props;
     if (!isNewEntry && prevProps.isPersisting && !isPersisting) {
-      loadDeployPreview({ maxAttempts: 3 });
+      // Abort any in-flight poll before starting a new one.
+      this._pollController?.abort();
+      this._pollController = new AbortController();
+      // Fires on subsequent saves when the component survives (no remount).
+      // In editorial workflow the first save remounts, so this mainly
+      // covers the second-save-and-beyond case.
+      loadDeployPreview({ maxAttempts: 3, signal: this._pollController.signal });
     }
+  }
+
+  componentWillUnmount() {
+    this._pollController?.abort();
   }
 
   renderSimpleControls = () => {

--- a/packages/decap-cms-core/src/components/Editor/__tests__/EditorToolbar.spec.js
+++ b/packages/decap-cms-core/src/components/Editor/__tests__/EditorToolbar.spec.js
@@ -117,4 +117,50 @@ describe('EditorToolbar', () => {
       expect(asFragment()).toMatchSnapshot();
     });
   });
+
+  describe('deploy preview polling', () => {
+    it('should poll with maxAttempts: 24 and an AbortSignal on mount for existing entries', () => {
+      render(<EditorToolbar {...props} isNewEntry={false} />);
+      expect(props.loadDeployPreview).toHaveBeenCalledTimes(1);
+      const opts = props.loadDeployPreview.mock.calls[0][0];
+      expect(opts.maxAttempts).toBe(24);
+      expect(opts.signal).toBeInstanceOf(AbortSignal);
+    });
+
+    it('should not poll on mount for new entries', () => {
+      render(<EditorToolbar {...props} isNewEntry={true} />);
+      expect(props.loadDeployPreview).not.toHaveBeenCalled();
+    });
+
+    it('should poll with maxAttempts: 3 after a save completes', () => {
+      const { rerender } = render(<EditorToolbar {...props} isPersisting={true} />);
+      props.loadDeployPreview.mockClear();
+      rerender(<EditorToolbar {...props} isPersisting={false} />);
+      expect(props.loadDeployPreview).toHaveBeenCalledTimes(1);
+      const opts = props.loadDeployPreview.mock.calls[0][0];
+      expect(opts.maxAttempts).toBe(3);
+      expect(opts.signal).toBeInstanceOf(AbortSignal);
+    });
+
+    it('should abort polling on unmount', () => {
+      const { unmount } = render(<EditorToolbar {...props} isNewEntry={false} />);
+      const signal = props.loadDeployPreview.mock.calls[0][0].signal;
+      expect(signal.aborted).toBe(false);
+      unmount();
+      expect(signal.aborted).toBe(true);
+    });
+
+    it('should abort previous poll when a new save triggers a new poll', () => {
+      const { rerender } = render(<EditorToolbar {...props} isPersisting={false} />);
+      const firstSignal = props.loadDeployPreview.mock.calls[0][0].signal;
+
+      // Simulate save completing
+      rerender(<EditorToolbar {...props} isPersisting={true} />);
+      rerender(<EditorToolbar {...props} isPersisting={false} />);
+
+      expect(firstSignal.aborted).toBe(true);
+      const secondSignal = props.loadDeployPreview.mock.calls[1][0].signal;
+      expect(secondSignal.aborted).toBe(false);
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Increase the deploy preview polling window in `componentDidMount` from 3 attempts (15s) to 24 attempts (~2 min), and cancel in-flight polling when the component unmounts or a new save starts.

## Problem

With the **editorial workflow** enabled, saving an entry navigates to the unpublished entry view. This **remounts** the `EditorToolbar` component, meaning:

- `componentDidMount` is the primary polling trigger after save — not `componentDidUpdate`
- The `isPersisting` transition check in `componentDidUpdate` never fires on the first save, because the component wasn't mounted during the persist

Both paths previously used `maxAttempts: 3` (15 seconds at the default 5s interval), which is too short for virtually any CI pipeline to finish. Users always had to manually click "Check for Preview."

Additionally, there was no cancellation — navigating away left the polling loop running in the background for up to 2 minutes, wasting API calls and blocking new polls via the `isFetching` guard.

## Changes

| File | Change |
|---|---|
| `EditorToolbar.js` | `componentDidMount`: 3 → 24 attempts (~2 min). Creates `AbortController`, passes signal. |
| `EditorToolbar.js` | `componentDidUpdate`: Aborts previous poll before starting a new one (3 attempts). |
| `EditorToolbar.js` | New `componentWillUnmount`: Aborts any in-flight poll. |
| `backend.ts` | `getDeployPreview`: Accepts optional `signal` and exits the polling loop when aborted. |
| `deploys.ts` | Threads `signal` through to backend. Skips `isFetching` guard when caller provides a signal (caller manages cancellation). |
| `EditorToolbar.spec.js` | 5 new tests for polling behavior and cancellation. |

## Why ~2 min?

- Most CI pipelines complete a deploy preview within 1–2 minutes
- Polling exits early on success, so fast pipelines are unaffected
- The spinner from #7757 gives users feedback that polling is in progress
- If the pipeline takes longer, users can still manually click "Check for Preview"

## Context

This builds on two recently merged PRs:
- #7756 — Clear stale deploy preview state (prevents showing an outdated production URL)
- #7757 — Add loading feedback to the "Check for Preview" button (spinner + disabled state)

Together, the three changes fix the deploy preview experience end-to-end: stale URLs are cleared (#7756), users see that something is happening (#7757), and the polling window is long enough to actually succeed while being properly cleaned up on navigation (this PR).

## Known limitation

When saving a second time in editorial workflow, the component does not remount — `componentDidUpdate` fires instead. Since a successful commit status already exists from the first build, the previous deploy preview URL is returned almost immediately. This means the preview link won't reflect the second set of changes until the CI pipeline rebuilds from the new commit.

Fixing this would require commit-level awareness in the `getDeployPreview` backend API (comparing the saved commit SHA against the commit the deploy was built from), which is out of scope for this change.