### PR TITLE
Fix/propagate errors for i18n entries

### DIFF
--- a/packages/decap-cms-core/src/lib/i18n.ts
+++ b/packages/decap-cms-core/src/lib/i18n.ts
@@ -317,14 +317,14 @@ export async function getI18nEntry(
     );
 
     const nonNullValues = entryValuesResults
-      .filter(e => e.status === 'fulfilled')
-      .map(e => e.value);
+      .map(e => (e.status === 'fulfilled' ? e.value : undefined))
+      .filter(e => e !== undefined);
 
     if (nonNullValues.length === 0) {
       // mergeValues will throw on an empty list, and show the error messages.
       const [error = new Error('No entry values found for any locale')] = entryValuesResults
-        .filter(e => e.status === 'rejected')
-        .map(e => e.reason);
+        .map(e => (e.status === 'rejected' ? e.reason : undefined))
+        .filter(e => e !== undefined);
 
       throw error;
     }

--- a/packages/decap-cms-core/src/lib/i18n.ts
+++ b/packages/decap-cms-core/src/lib/i18n.ts
@@ -308,18 +308,24 @@ export async function getI18nEntry(
   if (structure === I18N_STRUCTURE.SINGLE_FILE) {
     entryValue = mergeSingleFileValue(await getEntryValue(path), defaultLocale, locales);
   } else {
-    const entryValues = await Promise.all(
+    const entryValuesResults = await Promise.allSettled(
       locales.map(async locale => {
         const entryPath = getFilePath(structure, extension, path, slug, locale);
-        const value = await getEntryValue(entryPath).catch(() => null);
+        const value = await getEntryValue(entryPath);
         return { value, locale };
       }),
     );
 
-    const nonNullValues = entryValues.filter(e => e.value !== null) as {
-      value: EntryValue;
-      locale: string;
-    }[];
+    const nonNullValues = entryValuesResults.filter(e => e.status === 'fulfilled').map(e => e.value);
+
+    if (nonNullValues.length === 0) {
+      // mergeValues will throw on an empty list, and show the error messages.
+      const [
+        error = new Error('No entry values found for any locale'),
+      ] = entryValuesResults.filter(e => e.status === 'rejected').map(e => e.reason);
+
+      throw error;
+    }
 
     entryValue = mergeValues(collection, structure, defaultLocale, nonNullValues);
   }

--- a/packages/decap-cms-core/src/lib/i18n.ts
+++ b/packages/decap-cms-core/src/lib/i18n.ts
@@ -318,7 +318,7 @@ export async function getI18nEntry(
 
     const nonNullValues = entryValuesResults
       .map(e => (e.status === 'fulfilled' ? e.value : undefined))
-      .filter(e => e !== undefined);
+      .filter((e): e is { value: EntryValue; locale: string } => e !== undefined);
 
     if (nonNullValues.length === 0) {
       // mergeValues will throw on an empty list, and show the error messages.

--- a/packages/decap-cms-core/src/lib/i18n.ts
+++ b/packages/decap-cms-core/src/lib/i18n.ts
@@ -316,13 +316,15 @@ export async function getI18nEntry(
       }),
     );
 
-    const nonNullValues = entryValuesResults.filter(e => e.status === 'fulfilled').map(e => e.value);
+    const nonNullValues = entryValuesResults
+      .filter(e => e.status === 'fulfilled')
+      .map(e => e.value);
 
     if (nonNullValues.length === 0) {
       // mergeValues will throw on an empty list, and show the error messages.
-      const [
-        error = new Error('No entry values found for any locale'),
-      ] = entryValuesResults.filter(e => e.status === 'rejected').map(e => e.reason);
+      const [error = new Error('No entry values found for any locale')] = entryValuesResults
+        .filter(e => e.status === 'rejected')
+        .map(e => e.reason);
 
       throw error;
     }


### PR DESCRIPTION
**Summary**

On 18n enabled websites, when for some reason the backend fails to retrieve any entries, for example because their is no internet connection: [The default entry will be set to undefined since the values array is empty](https://github.com/decaporg/decap-cms/blob/a004f0d83fc086a48d17479aabced356a146e78c/packages/decap-cms-core/src/lib/i18n.ts#L249). This causes the following [line](https://github.com/decaporg/decap-cms/blob/a004f0d83fc086a48d17479aabced356a146e78c/packages/decap-cms-core/src/lib/i18n.ts#L263) to throw since it's accessing `defaultEntry.value` where defaultEntry is undefined. 

The following PR should fix this by not allowing an empty list to be passed to the mergeValues function in the first place and properly propagate errors.

**Test plan**

- Setup Decap CMS with i18n
- Modify decap-server to throw an error in the entry retrieval code

**Checklist**

Please add a `x` inside each checkbox:

- [x] I have read the [contribution guidelines](https://github.com/decaporg/decap-cms/blob/main/CONTRIBUTING.md).
