### PR TITLE
Add linked image support for richtext widget

### DIFF
--- a/dev-test/config.yml
+++ b/dev-test/config.yml
@@ -1,34 +1,290 @@
-local_backend: true
-
 backend:
-  name: git-gateway
-  branch: main
-  squash_merges: true
+  name: test-repo
 
-logo_url: /media/brand/logo.svg
-media_folder: static/media/uploads
-public_folder: /media/uploads
+site_url: https://example.com
 
-slug:
-  encoding: ascii
-  clean_accents: true
+publish_mode: editorial_workflow
+media_folder: assets/uploads
 
-aliases:
-  - &VISIBLE_IN_CMS {name: visibleInCMS, widget: hidden, default: true, i18n: duplicate}
+collections: # A list of collections the CMS should be able to edit
+  - name: 'posts' # Used in routes, ie.: /admin/collections/:slug/edit
+    label: 'Posts' # Used in the UI
+    label_singular: 'Post' # Used in the UI, ie: "New Post"
+    description: >
+      The description is a great place for tone setting, high level information, and editing
+      guidelines that are specific to a collection.
+    folder: '_posts'
+    slug: '{{year}}-{{month}}-{{day}}-{{slug}}'
+    summary: '{{title}} -- {{year}}/{{month}}/{{day}}'
+    create: true # Allow users to create new documents in this collection
+    editor:
+      visualEditing: true
+    sortable_fields:
+      - title
+      - { field: date, default_sort: desc }
+      - draft
+    view_filters:
+      - label: Posts With Index
+        field: title
+        pattern: 'This is post #'
+      - label: Posts Without Index
+        field: title
+        pattern: front matter post
+      - label: Drafts
+        field: draft
+        pattern: true
+    view_groups:
+      - label: Year
+        field: date
+        pattern: \d{4}
+      - label: Drafts
+        field: draft
+    fields: # The fields each document in this collection have
+      - { label: 'Title', name: 'title', widget: 'string', tagname: 'h1' }
+      - { label: 'Draft', name: 'draft', widget: 'boolean', default: false }
+      - {
+          label: 'Publish Date',
+          name: 'date',
+          widget: 'datetime',
+          format: 'YYYY-MM-DD HH:mm',
+          default: '{{now}}',
+        }
+      - label: 'Cover Image'
+        name: 'image'
+        widget: 'image'
+        required: false
+        tagname: ''
 
-collections:
-  - name: other
-    label: Other
-    label_singular: page
-    format: yaml-frontmatter
-    folder: content
-    create: true
-    filter: {field: visibleInCMS, value: true}
+      - { label: 'Body', name: 'body', widget: 'richtext', hint: 'Main content goes here.' }
+      - { label: 'Body', name: 'bodyold', widget: 'markdown', hint: 'Main content goes here.' }
+      - { label: 'Body', name: 'bodyold2', widget: 'markdown', hint: 'Main content goes here 2.' }
+
+  - name: 'restaurants' # Used in routes, ie.: /admin/collections/:slug/edit
+    label: 'Restaurants' # Used in the UI
+    label_singular: 'Restaurant' # Used in the UI, ie: "New Post"
+    description: >
+      Restaurants is an entry type used for testing galleries, relations and other widgets.
+      The tests must be written in such way that adding new fields does not affect previous flows.
+    folder: '_restaurants'
+    slug: '{{year}}-{{month}}-{{day}}-{{slug}}'
+    summary: '{{title}} -- {{year}}/{{month}}/{{day}}'
+    create: true # Allow users to create new documents in this collection
+    editor:
+      visualEditing: true
+    fields: # The fields each document in this collection have
+      - { label: 'Title', name: 'title', widget: 'string', tagname: 'h1' }
+      - { label: 'Body', name: 'body', widget: 'markdown', hint: 'Main content goes here.' }
+      - { name: 'gallery', widget: 'image', choose_url: true, media_library: {config: {multiple: true, max_files: 999}}}
+      - { name: 'post', widget: relation, collection: posts, multiple: true, search_fields: [ "title" ], display_fields: [ "title" ], value_field: "{{slug}}", filters: [ {field: "draft", values: [false]} ] }
+      - name: authors
+        label: Authors
+        label_singular: 'Author'
+        widget: list
+        fields:
+          - { label: 'Name', name: 'name', widget: 'string', hint: 'First and Last' }
+          - { label: 'Description', name: 'description', widget: 'markdown' }
+
+  - name: 'faq' # Used in routes, ie.: /admin/collections/:slug/edit
+    label: 'FAQ' # Used in the UI
+    folder: '_faqs'
+    create: true # Allow users to create new documents in this collection
+    fields: # The fields each document in this collection have
+      - { label: 'Question', name: 'title', widget: 'string', tagname: 'h1' }
+      - { label: 'Answer', name: 'body', widget: 'markdown' }
+
+  - name: 'settings'
+    label: 'Settings'
+    delete: false # Prevent users from deleting documents in this collection
     editor:
       preview: false
-    fields: [
-      {name: title, label: Title, widget: string},
-      # {name: body, label: Body, widget: richtext},
-      {name: body, label: Body, widget: markdown},
-      *VISIBLE_IN_CMS,
-    ]
+    files:
+      - name: 'general'
+        label: 'Site Settings'
+        file: '_data/settings.json'
+        description: 'General Site Settings'
+        fields:
+          - { label: 'Global title', name: 'site_title', widget: 'string' }
+          - label: 'Post Settings'
+            name: posts
+            widget: 'object'
+            fields:
+              - {
+                  label: 'Number of posts on frontpage',
+                  name: front_limit,
+                  widget: number,
+                  min: 1,
+                  max: 10,
+                }
+              - { label: 'Default Author', name: author, widget: string }
+              - {
+                  label: 'Default Thumbnail',
+                  name: thumb,
+                  widget: image,
+                  class: 'thumb',
+                  required: false,
+                }
+
+      - name: 'authors'
+        label: 'Authors'
+        file: '_data/authors.yml'
+        description: 'Author descriptions'
+        fields:
+          - name: authors
+            label: Authors
+            label_singular: 'Author'
+            widget: list
+            fields:
+              - { label: 'Name', name: 'name', widget: 'string', hint: 'First and Last' }
+              - { label: 'Description', name: 'description', widget: 'markdown' }
+
+  - name: 'kitchenSink' # all the things in one entry, for documentation and quick testing
+    label: 'Kitchen Sink'
+    folder: '_sink'
+    create: true
+    fields:
+      - label: 'Related Post'
+        name: 'post'
+        widget: 'relationKitchenSinkPost'
+        collection: 'posts'
+        display_fields: ['title', 'datetime']
+        search_fields: ['title', 'body']
+        value_field: 'title'
+      - { label: 'Title', name: 'title', widget: 'string' }
+      - { label: 'Boolean', name: 'boolean', widget: 'boolean', default: true }
+      - { label: 'Map', name: 'map', widget: 'map' }
+      - { label: 'Text', name: 'text', widget: 'text', hint: 'Plain text, not markdown' }
+      - { label: 'Number', name: 'number', widget: 'number', hint: 'To infinity and beyond!' }
+      - { label: 'Markdown', name: 'markdown', widget: 'markdown' }
+      - { label: 'Datetime', name: 'datetime', widget: 'datetime' }
+      - { label: 'Image', name: 'image', widget: 'image' }
+      - { label: 'File', name: 'file', widget: 'file' }
+      - { label: 'Select', name: 'select', widget: 'select', options: ['a', 'b', 'c'] }
+      - {
+          label: 'Select multiple',
+          name: 'select_multiple',
+          widget: 'select',
+          options: ['a', 'b', 'c'],
+          multiple: true,
+        }
+      - { label: 'Hidden', name: 'hidden', widget: 'hidden', default: 'hidden' }
+      - { label: 'Color', name: 'color', widget: 'color' }
+      - label: 'Object'
+        name: 'object'
+        widget: 'object'
+        collapsed: true
+        fields:
+          - label: 'Related Post'
+            name: 'post'
+            widget: 'relationKitchenSinkPost'
+            collection: 'posts'
+            search_fields: ['title', 'body']
+            value_field: 'title'
+          - { label: 'String', name: 'string', widget: 'string' }
+          - { label: 'Boolean', name: 'boolean', widget: 'boolean', default: false }
+          - { label: 'Text', name: 'text', widget: 'text' }
+          - { label: 'Number', name: 'number', widget: 'number' }
+          - { label: 'Markdown', name: 'markdown', widget: 'markdown' }
+          - { label: 'Datetime', name: 'datetime', widget: 'datetime' }
+          - { label: 'Image', name: 'image', widget: 'image' }
+          - { label: 'File', name: 'file', widget: 'file' }
+          - { label: 'Select', name: 'select', widget: 'select', options: ['a', 'b', 'c'] }
+      - label: 'List'
+        name: 'list'
+        widget: 'list'
+        fields:
+          - { label: 'String', name: 'string', widget: 'string' }
+          - { label: 'Boolean', name: 'boolean', widget: 'boolean' }
+          - { label: 'Text', name: 'text', widget: 'text' }
+          - { label: 'Number', name: 'number', widget: 'number' }
+          - { label: 'Markdown', name: 'markdown', widget: 'markdown' }
+          - { label: 'Datetime', name: 'datetime', widget: 'datetime' }
+          - { label: 'Image', name: 'image', widget: 'image' }
+          - { label: 'File', name: 'file', widget: 'file' }
+          - { label: 'Select', name: 'select', widget: 'select', options: ['a', 'b', 'c'] }
+          - label: 'Object'
+            name: 'object'
+            widget: 'object'
+            fields:
+              - { label: 'String', name: 'string', widget: 'string' }
+              - { label: 'Boolean', name: 'boolean', widget: 'boolean' }
+              - { label: 'Text', name: 'text', widget: 'text' }
+              - { label: 'Number', name: 'number', widget: 'number' }
+              - { label: 'Markdown', name: 'markdown', widget: 'markdown' }
+              - { label: 'Datetime', name: 'datetime', widget: 'datetime' }
+              - { label: 'Image', name: 'image', widget: 'image' }
+              - { label: 'File', name: 'file', widget: 'file' }
+              - { label: 'Select', name: 'select', widget: 'select', options: ['a', 'b', 'c'] }
+              - label: 'List'
+                name: 'list'
+                widget: 'list'
+                fields:
+                  - label: 'Related Post'
+                    name: 'post'
+                    widget: 'relationKitchenSinkPost'
+                    collection: 'posts'
+                    search_fields: ['title', 'body']
+                    value_field: 'title'
+                  - { label: 'String', name: 'string', widget: 'string' }
+                  - { label: 'Boolean', name: 'boolean', widget: 'boolean' }
+                  - { label: 'Text', name: 'text', widget: 'text' }
+                  - { label: 'Number', name: 'number', widget: 'number' }
+                  - { label: 'Markdown', name: 'markdown', widget: 'markdown' }
+                  - { label: 'Datetime', name: 'datetime', widget: 'datetime' }
+                  - { label: 'Image', name: 'image', widget: 'image' }
+                  - { label: 'File', name: 'file', widget: 'file' }
+                  - { label: 'Select', name: 'select', widget: 'select', options: ['a', 'b', 'c'] }
+                  - { label: 'Hidden', name: 'hidden', widget: 'hidden', default: 'hidden' }
+                  - label: 'Object'
+                    name: 'object'
+                    widget: 'object'
+                    fields:
+                      - { label: 'String', name: 'string', widget: 'string' }
+                      - { label: 'Boolean', name: 'boolean', widget: 'boolean' }
+                      - { label: 'Text', name: 'text', widget: 'text' }
+                      - { label: 'Number', name: 'number', widget: 'number' }
+                      - { label: 'Markdown', name: 'markdown', widget: 'markdown' }
+                      - { label: 'Datetime', name: 'datetime', widget: 'datetime' }
+                      - { label: 'Image', name: 'image', widget: 'image' }
+                      - { label: 'File', name: 'file', widget: 'file' }
+                      - {
+                          label: 'Select',
+                          name: 'select',
+                          widget: 'select',
+                          options: ['a', 'b', 'c'],
+                        }
+      - label: 'Typed List'
+        name: 'typed_list'
+        widget: 'list'
+        types:
+          - label: 'Type 1 Object'
+            name: 'type_1_object'
+            widget: 'object'
+            fields:
+              - { label: 'String', name: 'string', widget: 'string' }
+              - { label: 'Boolean', name: 'boolean', widget: 'boolean' }
+              - { label: 'Text', name: 'text', widget: 'text' }
+          - label: 'Type 2 Object'
+            name: 'type_2_object'
+            widget: 'object'
+            fields:
+              - { label: 'Number', name: 'number', widget: 'number' }
+              - { label: 'Select', name: 'select', widget: 'select', options: ['a', 'b', 'c'] }
+              - { label: 'Datetime', name: 'datetime', widget: 'datetime' }
+              - { label: 'Markdown', name: 'markdown', widget: 'markdown' }
+          - label: 'Type 3 Object'
+            name: 'type_3_object'
+            widget: 'object'
+            fields:
+              - { label: 'Image', name: 'image', widget: 'image' }
+              - { label: 'File', name: 'file', widget: 'file' }
+  - name: pages # a nested collection
+    label: Pages
+    label_singular: 'Page'
+    folder: _pages
+    create: true
+    nested: { depth: 100, subfolders: false }
+    fields:
+      - label: Title
+        name: title
+        widget: string
+    meta: { path: { widget: string, label: 'Path', index_file: 'index' } }

--- a/dev-test/config.yml
+++ b/dev-test/config.yml
@@ -1,290 +1,34 @@
+local_backend: true
+
 backend:
-  name: test-repo
+  name: git-gateway
+  branch: main
+  squash_merges: true
 
-site_url: https://example.com
+logo_url: /media/brand/logo.svg
+media_folder: static/media/uploads
+public_folder: /media/uploads
 
-publish_mode: editorial_workflow
-media_folder: assets/uploads
+slug:
+  encoding: ascii
+  clean_accents: true
 
-collections: # A list of collections the CMS should be able to edit
-  - name: 'posts' # Used in routes, ie.: /admin/collections/:slug/edit
-    label: 'Posts' # Used in the UI
-    label_singular: 'Post' # Used in the UI, ie: "New Post"
-    description: >
-      The description is a great place for tone setting, high level information, and editing
-      guidelines that are specific to a collection.
-    folder: '_posts'
-    slug: '{{year}}-{{month}}-{{day}}-{{slug}}'
-    summary: '{{title}} -- {{year}}/{{month}}/{{day}}'
-    create: true # Allow users to create new documents in this collection
-    editor:
-      visualEditing: true
-    sortable_fields:
-      - title
-      - { field: date, default_sort: desc }
-      - draft
-    view_filters:
-      - label: Posts With Index
-        field: title
-        pattern: 'This is post #'
-      - label: Posts Without Index
-        field: title
-        pattern: front matter post
-      - label: Drafts
-        field: draft
-        pattern: true
-    view_groups:
-      - label: Year
-        field: date
-        pattern: \d{4}
-      - label: Drafts
-        field: draft
-    fields: # The fields each document in this collection have
-      - { label: 'Title', name: 'title', widget: 'string', tagname: 'h1' }
-      - { label: 'Draft', name: 'draft', widget: 'boolean', default: false }
-      - {
-          label: 'Publish Date',
-          name: 'date',
-          widget: 'datetime',
-          format: 'YYYY-MM-DD HH:mm',
-          default: '{{now}}',
-        }
-      - label: 'Cover Image'
-        name: 'image'
-        widget: 'image'
-        required: false
-        tagname: ''
+aliases:
+  - &VISIBLE_IN_CMS {name: visibleInCMS, widget: hidden, default: true, i18n: duplicate}
 
-      - { label: 'Body', name: 'body', widget: 'richtext', hint: 'Main content goes here.' }
-      - { label: 'Body', name: 'bodyold', widget: 'markdown', hint: 'Main content goes here.' }
-      - { label: 'Body', name: 'bodyold2', widget: 'markdown', hint: 'Main content goes here 2.' }
-
-  - name: 'restaurants' # Used in routes, ie.: /admin/collections/:slug/edit
-    label: 'Restaurants' # Used in the UI
-    label_singular: 'Restaurant' # Used in the UI, ie: "New Post"
-    description: >
-      Restaurants is an entry type used for testing galleries, relations and other widgets.
-      The tests must be written in such way that adding new fields does not affect previous flows.
-    folder: '_restaurants'
-    slug: '{{year}}-{{month}}-{{day}}-{{slug}}'
-    summary: '{{title}} -- {{year}}/{{month}}/{{day}}'
-    create: true # Allow users to create new documents in this collection
-    editor:
-      visualEditing: true
-    fields: # The fields each document in this collection have
-      - { label: 'Title', name: 'title', widget: 'string', tagname: 'h1' }
-      - { label: 'Body', name: 'body', widget: 'markdown', hint: 'Main content goes here.' }
-      - { name: 'gallery', widget: 'image', choose_url: true, media_library: {config: {multiple: true, max_files: 999}}}
-      - { name: 'post', widget: relation, collection: posts, multiple: true, search_fields: [ "title" ], display_fields: [ "title" ], value_field: "{{slug}}", filters: [ {field: "draft", values: [false]} ] }
-      - name: authors
-        label: Authors
-        label_singular: 'Author'
-        widget: list
-        fields:
-          - { label: 'Name', name: 'name', widget: 'string', hint: 'First and Last' }
-          - { label: 'Description', name: 'description', widget: 'markdown' }
-
-  - name: 'faq' # Used in routes, ie.: /admin/collections/:slug/edit
-    label: 'FAQ' # Used in the UI
-    folder: '_faqs'
-    create: true # Allow users to create new documents in this collection
-    fields: # The fields each document in this collection have
-      - { label: 'Question', name: 'title', widget: 'string', tagname: 'h1' }
-      - { label: 'Answer', name: 'body', widget: 'markdown' }
-
-  - name: 'settings'
-    label: 'Settings'
-    delete: false # Prevent users from deleting documents in this collection
+collections:
+  - name: other
+    label: Other
+    label_singular: page
+    format: yaml-frontmatter
+    folder: content
+    create: true
+    filter: {field: visibleInCMS, value: true}
     editor:
       preview: false
-    files:
-      - name: 'general'
-        label: 'Site Settings'
-        file: '_data/settings.json'
-        description: 'General Site Settings'
-        fields:
-          - { label: 'Global title', name: 'site_title', widget: 'string' }
-          - label: 'Post Settings'
-            name: posts
-            widget: 'object'
-            fields:
-              - {
-                  label: 'Number of posts on frontpage',
-                  name: front_limit,
-                  widget: number,
-                  min: 1,
-                  max: 10,
-                }
-              - { label: 'Default Author', name: author, widget: string }
-              - {
-                  label: 'Default Thumbnail',
-                  name: thumb,
-                  widget: image,
-                  class: 'thumb',
-                  required: false,
-                }
-
-      - name: 'authors'
-        label: 'Authors'
-        file: '_data/authors.yml'
-        description: 'Author descriptions'
-        fields:
-          - name: authors
-            label: Authors
-            label_singular: 'Author'
-            widget: list
-            fields:
-              - { label: 'Name', name: 'name', widget: 'string', hint: 'First and Last' }
-              - { label: 'Description', name: 'description', widget: 'markdown' }
-
-  - name: 'kitchenSink' # all the things in one entry, for documentation and quick testing
-    label: 'Kitchen Sink'
-    folder: '_sink'
-    create: true
-    fields:
-      - label: 'Related Post'
-        name: 'post'
-        widget: 'relationKitchenSinkPost'
-        collection: 'posts'
-        display_fields: ['title', 'datetime']
-        search_fields: ['title', 'body']
-        value_field: 'title'
-      - { label: 'Title', name: 'title', widget: 'string' }
-      - { label: 'Boolean', name: 'boolean', widget: 'boolean', default: true }
-      - { label: 'Map', name: 'map', widget: 'map' }
-      - { label: 'Text', name: 'text', widget: 'text', hint: 'Plain text, not markdown' }
-      - { label: 'Number', name: 'number', widget: 'number', hint: 'To infinity and beyond!' }
-      - { label: 'Markdown', name: 'markdown', widget: 'markdown' }
-      - { label: 'Datetime', name: 'datetime', widget: 'datetime' }
-      - { label: 'Image', name: 'image', widget: 'image' }
-      - { label: 'File', name: 'file', widget: 'file' }
-      - { label: 'Select', name: 'select', widget: 'select', options: ['a', 'b', 'c'] }
-      - {
-          label: 'Select multiple',
-          name: 'select_multiple',
-          widget: 'select',
-          options: ['a', 'b', 'c'],
-          multiple: true,
-        }
-      - { label: 'Hidden', name: 'hidden', widget: 'hidden', default: 'hidden' }
-      - { label: 'Color', name: 'color', widget: 'color' }
-      - label: 'Object'
-        name: 'object'
-        widget: 'object'
-        collapsed: true
-        fields:
-          - label: 'Related Post'
-            name: 'post'
-            widget: 'relationKitchenSinkPost'
-            collection: 'posts'
-            search_fields: ['title', 'body']
-            value_field: 'title'
-          - { label: 'String', name: 'string', widget: 'string' }
-          - { label: 'Boolean', name: 'boolean', widget: 'boolean', default: false }
-          - { label: 'Text', name: 'text', widget: 'text' }
-          - { label: 'Number', name: 'number', widget: 'number' }
-          - { label: 'Markdown', name: 'markdown', widget: 'markdown' }
-          - { label: 'Datetime', name: 'datetime', widget: 'datetime' }
-          - { label: 'Image', name: 'image', widget: 'image' }
-          - { label: 'File', name: 'file', widget: 'file' }
-          - { label: 'Select', name: 'select', widget: 'select', options: ['a', 'b', 'c'] }
-      - label: 'List'
-        name: 'list'
-        widget: 'list'
-        fields:
-          - { label: 'String', name: 'string', widget: 'string' }
-          - { label: 'Boolean', name: 'boolean', widget: 'boolean' }
-          - { label: 'Text', name: 'text', widget: 'text' }
-          - { label: 'Number', name: 'number', widget: 'number' }
-          - { label: 'Markdown', name: 'markdown', widget: 'markdown' }
-          - { label: 'Datetime', name: 'datetime', widget: 'datetime' }
-          - { label: 'Image', name: 'image', widget: 'image' }
-          - { label: 'File', name: 'file', widget: 'file' }
-          - { label: 'Select', name: 'select', widget: 'select', options: ['a', 'b', 'c'] }
-          - label: 'Object'
-            name: 'object'
-            widget: 'object'
-            fields:
-              - { label: 'String', name: 'string', widget: 'string' }
-              - { label: 'Boolean', name: 'boolean', widget: 'boolean' }
-              - { label: 'Text', name: 'text', widget: 'text' }
-              - { label: 'Number', name: 'number', widget: 'number' }
-              - { label: 'Markdown', name: 'markdown', widget: 'markdown' }
-              - { label: 'Datetime', name: 'datetime', widget: 'datetime' }
-              - { label: 'Image', name: 'image', widget: 'image' }
-              - { label: 'File', name: 'file', widget: 'file' }
-              - { label: 'Select', name: 'select', widget: 'select', options: ['a', 'b', 'c'] }
-              - label: 'List'
-                name: 'list'
-                widget: 'list'
-                fields:
-                  - label: 'Related Post'
-                    name: 'post'
-                    widget: 'relationKitchenSinkPost'
-                    collection: 'posts'
-                    search_fields: ['title', 'body']
-                    value_field: 'title'
-                  - { label: 'String', name: 'string', widget: 'string' }
-                  - { label: 'Boolean', name: 'boolean', widget: 'boolean' }
-                  - { label: 'Text', name: 'text', widget: 'text' }
-                  - { label: 'Number', name: 'number', widget: 'number' }
-                  - { label: 'Markdown', name: 'markdown', widget: 'markdown' }
-                  - { label: 'Datetime', name: 'datetime', widget: 'datetime' }
-                  - { label: 'Image', name: 'image', widget: 'image' }
-                  - { label: 'File', name: 'file', widget: 'file' }
-                  - { label: 'Select', name: 'select', widget: 'select', options: ['a', 'b', 'c'] }
-                  - { label: 'Hidden', name: 'hidden', widget: 'hidden', default: 'hidden' }
-                  - label: 'Object'
-                    name: 'object'
-                    widget: 'object'
-                    fields:
-                      - { label: 'String', name: 'string', widget: 'string' }
-                      - { label: 'Boolean', name: 'boolean', widget: 'boolean' }
-                      - { label: 'Text', name: 'text', widget: 'text' }
-                      - { label: 'Number', name: 'number', widget: 'number' }
-                      - { label: 'Markdown', name: 'markdown', widget: 'markdown' }
-                      - { label: 'Datetime', name: 'datetime', widget: 'datetime' }
-                      - { label: 'Image', name: 'image', widget: 'image' }
-                      - { label: 'File', name: 'file', widget: 'file' }
-                      - {
-                          label: 'Select',
-                          name: 'select',
-                          widget: 'select',
-                          options: ['a', 'b', 'c'],
-                        }
-      - label: 'Typed List'
-        name: 'typed_list'
-        widget: 'list'
-        types:
-          - label: 'Type 1 Object'
-            name: 'type_1_object'
-            widget: 'object'
-            fields:
-              - { label: 'String', name: 'string', widget: 'string' }
-              - { label: 'Boolean', name: 'boolean', widget: 'boolean' }
-              - { label: 'Text', name: 'text', widget: 'text' }
-          - label: 'Type 2 Object'
-            name: 'type_2_object'
-            widget: 'object'
-            fields:
-              - { label: 'Number', name: 'number', widget: 'number' }
-              - { label: 'Select', name: 'select', widget: 'select', options: ['a', 'b', 'c'] }
-              - { label: 'Datetime', name: 'datetime', widget: 'datetime' }
-              - { label: 'Markdown', name: 'markdown', widget: 'markdown' }
-          - label: 'Type 3 Object'
-            name: 'type_3_object'
-            widget: 'object'
-            fields:
-              - { label: 'Image', name: 'image', widget: 'image' }
-              - { label: 'File', name: 'file', widget: 'file' }
-  - name: pages # a nested collection
-    label: Pages
-    label_singular: 'Page'
-    folder: _pages
-    create: true
-    nested: { depth: 100, subfolders: false }
-    fields:
-      - label: Title
-        name: title
-        widget: string
-    meta: { path: { widget: string, label: 'Path', index_file: 'index' } }
+    fields: [
+      {name: title, label: Title, widget: string},
+      # {name: body, label: Body, widget: richtext},
+      {name: body, label: Body, widget: markdown},
+      *VISIBLE_IN_CMS,
+    ]

--- a/packages/decap-cms-editor-component-image/src/index.js
+++ b/packages/decap-cms-editor-component-image/src/index.js
@@ -17,7 +17,7 @@ const image = {
     const src = getAsset(image, imageField);
     return <img src={src || ''} alt={alt || ''} title={title || ''} />;
   },
-  pattern: /^!\[(.*)\]\((.*?)(\s"(.*)")?\)/,
+  pattern: /^!\[([^\]]*)\]\((.*?)(\s"([^"]*)")?\)/,
   fields: [
     {
       label: 'Image',

--- a/packages/decap-cms-widget-richtext/src/RichtextControl/VisualEditor.js
+++ b/packages/decap-cms-widget-richtext/src/RichtextControl/VisualEditor.js
@@ -25,7 +25,9 @@ import HeadingElement from './components/Element/HeadingElement';
 import ListElement from './components/Element/ListElement';
 import BlockquoteElement from './components/Element/BlockquoteElement';
 import LinkElement from './components/Element/LinkElement';
+import ImageElement from './components/Element/ImageElement';
 import ExtendedBlockquotePlugin from './plugins/ExtendedBlockquotePlugin';
+import ImagePlugin from './plugins/ImagePlugin';
 import ShortcodePlugin from './plugins/ShortcodePlugin';
 import { TablePlugin, TableRowPlugin, TableCellPlugin } from './plugins/TablePlugin';
 import defaultEmptyBlock from './defaultEmptyBlock';
@@ -59,6 +61,7 @@ export default function VisualEditor(props) {
     isShowModeToggle,
     onChange,
     getEditorComponents,
+    getAsset,
   } = props;
 
   let editorComponents = getEditorComponents();
@@ -106,6 +109,7 @@ export default function VisualEditor(props) {
         ['ol']: withProps(ListElement, { variant: 'ol' }),
         ['li']: withProps(ListElement, { variant: 'li' }),
         ['blockquote']: BlockquoteElement,
+        ['image']: withProps(ImageElement, { getAsset, field }),
       },
     },
     plugins: [
@@ -129,6 +133,7 @@ export default function VisualEditor(props) {
         shortcuts: { toggle: { keys: 'mod+shift+c' } },
       }),
       ListPlugin,
+      ImagePlugin,
       LinkPlugin.configure({
         node: { component: LinkElement },
         shortcuts: {

--- a/packages/decap-cms-widget-richtext/src/RichtextControl/__tests__/parser.spec.js
+++ b/packages/decap-cms-widget-richtext/src/RichtextControl/__tests__/parser.spec.js
@@ -534,6 +534,43 @@ Array [
 `);
   });
 
+  it('should compile linked images', () => {
+    const value = `
+[![Project logo](https://raw.githubusercontent.com/decaporg/decap-cms/main/img/decap.svg)](https://decapcms.org)
+`;
+    expect(parser(value)).toMatchInlineSnapshot(`
+Array [
+  Object {
+    "children": Array [
+      Object {
+        "children": Array [
+          Object {
+            "children": Array [
+              Object {
+                "text": "",
+              },
+            ],
+            "data": Object {
+              "alt": "Project logo",
+              "title": null,
+              "url": "https://raw.githubusercontent.com/decaporg/decap-cms/main/img/decap.svg",
+            },
+            "type": "image",
+          },
+        ],
+        "data": Object {
+          "title": null,
+          "url": "https://decapcms.org",
+        },
+        "type": "a",
+      },
+    ],
+    "type": "p",
+  },
+]
+`);
+  });
+
   it('should compile plugins', () => {
     const value = `
 ![test](test.png)

--- a/packages/decap-cms-widget-richtext/src/RichtextControl/components/Element/ImageElement.js
+++ b/packages/decap-cms-widget-richtext/src/RichtextControl/components/Element/ImageElement.js
@@ -1,0 +1,44 @@
+import React from 'react';
+import { PlateElement } from 'platejs/react';
+
+function isAbsoluteAssetUrl(url) {
+  return /^(?:[a-z]+:)?\/\//i.test(url) || url.startsWith('data:') || url.startsWith('blob:');
+}
+
+function resolveImageSource(url, getAsset, field) {
+  if (!url) {
+    return '';
+  }
+
+  if (!getAsset || isAbsoluteAssetUrl(url)) {
+    return url;
+  }
+
+  const asset = getAsset(url, field);
+  return asset && typeof asset.toString === 'function' ? asset.toString() : asset;
+}
+
+function ImageElement({ children, element, getAsset, field, ...props }) {
+  const { alt, title, url } = element?.data || {};
+  const src = resolveImageSource(url, getAsset, field);
+
+  return (
+    <PlateElement
+      as="span"
+      element={element}
+      contentEditable={false}
+      style={{ display: 'inline-block' }}
+      {...props}
+    >
+      <img
+        src={src || ''}
+        alt={alt || ''}
+        title={title || ''}
+        style={{ maxWidth: '100%', height: 'auto', verticalAlign: 'middle' }}
+      />
+      {children}
+    </PlateElement>
+  );
+}
+
+export default ImageElement;

--- a/packages/decap-cms-widget-richtext/src/RichtextControl/components/Element/LinkElement.js
+++ b/packages/decap-cms-widget-richtext/src/RichtextControl/components/Element/LinkElement.js
@@ -8,7 +8,12 @@ function LinkElement({ children, element, ...rest }) {
     <PlateElement
       as="a"
       element={element}
-      style={{ textDecoration: 'underline', fontSize: 'inherit', maxWidth: '100%', fontWeight: 'inherit' }}
+      style={{
+        textDecoration: 'underline',
+        fontSize: 'inherit',
+        maxWidth: '100%',
+        fontWeight: 'inherit',
+      }}
       {...linkProps}
       {...rest}
     >

--- a/packages/decap-cms-widget-richtext/src/RichtextControl/components/Element/LinkElement.js
+++ b/packages/decap-cms-widget-richtext/src/RichtextControl/components/Element/LinkElement.js
@@ -3,8 +3,7 @@ import { PlateElement, useElement } from 'platejs/react';
 import { useLink } from '@platejs/link/react';
 
 function LinkElement({ children, element, ...rest }) {
-  const el = useElement();
-  const { props: linkProps } = useLink({ element: el });
+  const { props: linkProps } = useLink({ element });  
   return (
     <PlateElement
       as="a"

--- a/packages/decap-cms-widget-richtext/src/RichtextControl/components/Element/LinkElement.js
+++ b/packages/decap-cms-widget-richtext/src/RichtextControl/components/Element/LinkElement.js
@@ -1,20 +1,20 @@
 import React from 'react';
-import styled from '@emotion/styled';
-import { PlateLeaf, useElement } from 'platejs/react';
+import { PlateElement, useElement } from 'platejs/react';
 import { useLink } from '@platejs/link/react';
 
-const StyledA = styled.a`
-  text-decoration: underline;
-  font-size: inherit;
-`;
-
-function LinkElement({ children, ...rest }) {
-  const element = useElement();
-  const { props } = useLink({ element });
+function LinkElement({ children, element, ...rest }) {
+  const el = useElement();
+  const { props: linkProps } = useLink({ element: el });
   return (
-    <PlateLeaf asChild {...props} {...rest}>
-      <StyledA>{children}</StyledA>
-    </PlateLeaf>
+    <PlateElement
+      as="a"
+      element={element}
+      style={{ textDecoration: 'underline', fontSize: 'inherit', maxWidth: '100%', fontWeight: 'inherit' }}
+      {...linkProps}
+      {...rest}
+    >
+      {children}
+    </PlateElement>
   );
 }
 

--- a/packages/decap-cms-widget-richtext/src/RichtextControl/components/Element/LinkElement.js
+++ b/packages/decap-cms-widget-richtext/src/RichtextControl/components/Element/LinkElement.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { PlateElement, useElement } from 'platejs/react';
+import { PlateElement } from 'platejs/react';
 import { useLink } from '@platejs/link/react';
 
 function LinkElement({ children, element, ...rest }) {

--- a/packages/decap-cms-widget-richtext/src/RichtextControl/components/Element/LinkElement.js
+++ b/packages/decap-cms-widget-richtext/src/RichtextControl/components/Element/LinkElement.js
@@ -3,7 +3,7 @@ import { PlateElement } from 'platejs/react';
 import { useLink } from '@platejs/link/react';
 
 function LinkElement({ children, element, ...rest }) {
-  const { props: linkProps } = useLink({ element });  
+  const { props: linkProps } = useLink({ element });
   return (
     <PlateElement
       as="a"

--- a/packages/decap-cms-widget-richtext/src/RichtextControl/plugins/ImagePlugin.js
+++ b/packages/decap-cms-widget-richtext/src/RichtextControl/plugins/ImagePlugin.js
@@ -1,0 +1,15 @@
+import { createSlatePlugin } from 'platejs';
+import { toPlatePlugin } from 'platejs/react';
+
+const plugin = createSlatePlugin({
+  key: 'image',
+  node: {
+    isElement: true,
+    isInline: true,
+    isVoid: true,
+  },
+});
+
+const ImagePlugin = toPlatePlugin(plugin);
+
+export default ImagePlugin;

--- a/packages/decap-cms-widget-richtext/src/serializers/remarkShortcodes.js
+++ b/packages/decap-cms-widget-richtext/src/serializers/remarkShortcodes.js
@@ -73,6 +73,13 @@ function createShortcodeTokenizer({ plugins }) {
 
       const shortcodeData = plugin.fromBlock(match);
 
+      // Only eat if the match starts at the beginning of the remaining text.
+      // If it's further in (e.g. found via matchFromLines inside a paragraph),
+      // fall through silently so remark's inline parsers can handle it.
+      if (value.slice(0, match[0].length) !== match[0]) {
+        return;
+      }
+
       try {
         return eat(match[0])({
           type: 'shortcode',


### PR DESCRIPTION
Linked images are possible in markdown, but not well-supported in Decap. We're lacking an editor component that would do this, bu the old markdown widget at least rendered these images it added in markdown mode. The new widget did not have that, so this PR adds it. It also improves the image editor component pattern.

To consider: should we also extend the image editor component to allow a link? Or maybe add another option for linked images. I'm open to suggestions